### PR TITLE
Got it from https://packages.ubuntu.com/yakkety/amd64/libgtksourceview-3.0-dev

### DIFF
--- a/GtkSource-3.0.gir
+++ b/GtkSource-3.0.gir
@@ -1,0 +1,12530 @@
+<?xml version="1.0"?>
+<!-- This file was automatically generated from C sources - DO NOT EDIT!
+To affect the contents of this file, edit the original C definitions,
+and/or use gtk-doc annotations.  -->
+<repository version="1.2"
+            xmlns="http://www.gtk.org/introspection/core/1.0"
+            xmlns:c="http://www.gtk.org/introspection/c/1.0"
+            xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+  <include name="Gdk" version="3.0"/>
+  <include name="Gtk" version="3.0"/>
+  <package name="gtksourceview-3.0"/>
+  <c:include name="gtksourceview/gtksource.h"/>
+  <namespace name="GtkSource"
+             version="3.0"
+             shared-library="libgtksourceview-3.0.so.1"
+             c:identifier-prefixes="GtkSource"
+             c:symbol-prefixes="gtk_source">
+    <alias name="Tag_autoptr" c:type="GtkSourceTag_autoptr">
+      <type name="gpointer" c:type="gpointer"/>
+    </alias>
+    <enumeration name="BackgroundPatternType"
+                 version="3.16"
+                 glib:type-name="GtkSourceBackgroundPatternType"
+                 glib:get-type="gtk_source_background_pattern_type_get_type"
+                 c:type="GtkSourceBackgroundPatternType">
+      <member name="none"
+              value="0"
+              c:identifier="GTK_SOURCE_BACKGROUND_PATTERN_TYPE_NONE"
+              glib:nick="none">
+        <doc xml:space="preserve">no pattern</doc>
+      </member>
+      <member name="grid"
+              value="1"
+              c:identifier="GTK_SOURCE_BACKGROUND_PATTERN_TYPE_GRID"
+              glib:nick="grid">
+        <doc xml:space="preserve">grid pattern</doc>
+      </member>
+    </enumeration>
+    <enumeration name="BracketMatchType"
+                 glib:type-name="GtkSourceBracketMatchType"
+                 glib:get-type="gtk_source_bracket_match_type_get_type"
+                 c:type="GtkSourceBracketMatchType">
+      <member name="none"
+              value="0"
+              c:identifier="GTK_SOURCE_BRACKET_MATCH_NONE"
+              glib:nick="none">
+        <doc xml:space="preserve">there is no bracket to match.</doc>
+      </member>
+      <member name="out_of_range"
+              value="1"
+              c:identifier="GTK_SOURCE_BRACKET_MATCH_OUT_OF_RANGE"
+              glib:nick="out-of-range">
+        <doc xml:space="preserve">matching a bracket
+ failed because the maximum range was reached.</doc>
+      </member>
+      <member name="not_found"
+              value="2"
+              c:identifier="GTK_SOURCE_BRACKET_MATCH_NOT_FOUND"
+              glib:nick="not-found">
+        <doc xml:space="preserve">a matching bracket was not found.</doc>
+      </member>
+      <member name="found"
+              value="3"
+              c:identifier="GTK_SOURCE_BRACKET_MATCH_FOUND"
+              glib:nick="found">
+        <doc xml:space="preserve">a matching bracket was found.</doc>
+      </member>
+    </enumeration>
+    <class name="Buffer"
+           c:symbol-prefix="buffer"
+           c:type="GtkSourceBuffer"
+           parent="Gtk.TextBuffer"
+           glib:type-name="GtkSourceBuffer"
+           glib:get-type="gtk_source_buffer_get_type"
+           glib:type-struct="BufferClass">
+      <constructor name="new" c:identifier="gtk_source_buffer_new">
+        <doc xml:space="preserve">Creates a new source buffer.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new source buffer.</doc>
+          <type name="Buffer" c:type="GtkSourceBuffer*"/>
+        </return-value>
+        <parameters>
+          <parameter name="table"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a #GtkTextTagTable, or %NULL to create a new one.</doc>
+            <type name="Gtk.TextTagTable" c:type="GtkTextTagTable*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_with_language"
+                   c:identifier="gtk_source_buffer_new_with_language">
+        <doc xml:space="preserve">Creates a new source buffer using the highlighting patterns in
+@language.  This is equivalent to creating a new source buffer with
+a new tag table and then calling gtk_source_buffer_set_language().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new source buffer which will highlight text
+according to the highlighting patterns in @language.</doc>
+          <type name="Buffer" c:type="GtkSourceBuffer*"/>
+        </return-value>
+        <parameters>
+          <parameter name="language" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguage.</doc>
+            <type name="Language" c:type="GtkSourceLanguage*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <virtual-method name="bracket_matched">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="state" transfer-ownership="none">
+            <type name="BracketMatchType" c:type="GtkSourceBracketMatchType"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="redo" invoker="redo">
+        <doc xml:space="preserve">Redoes the last undo operation.  Use gtk_source_buffer_can_redo()
+to check whether a call to this function will have any effect.
+
+This function emits the #GtkSourceBuffer::redo signal.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="undo" invoker="undo">
+        <doc xml:space="preserve">Undoes the last user action which modified the buffer.  Use
+gtk_source_buffer_can_undo() to check whether a call to this
+function will have any effect.
+
+This function emits the #GtkSourceBuffer::undo signal.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <method name="backward_iter_to_source_mark"
+              c:identifier="gtk_source_buffer_backward_iter_to_source_mark"
+              version="2.2">
+        <doc xml:space="preserve">Moves @iter to the position of the previous #GtkSourceMark of the given
+category. Returns %TRUE if @iter was moved. If @category is NULL, the
+previous source mark can be of any category.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether @iter was moved.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">an iterator.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="category"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">category to search for, or %NULL</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="begin_not_undoable_action"
+              c:identifier="gtk_source_buffer_begin_not_undoable_action">
+        <doc xml:space="preserve">Marks the beginning of a not undoable action on the buffer,
+disabling the undo manager.  Typically you would call this function
+before initially setting the contents of the buffer (e.g. when
+loading a file in a text editor).
+
+You may nest gtk_source_buffer_begin_not_undoable_action() /
+gtk_source_buffer_end_not_undoable_action() blocks.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="can_redo" c:identifier="gtk_source_buffer_can_redo">
+        <doc xml:space="preserve">Determines whether a source buffer can redo the last action
+(i.e. if the last operation was an undo).</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if a redo is possible.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="can_undo" c:identifier="gtk_source_buffer_can_undo">
+        <doc xml:space="preserve">Determines whether a source buffer can undo the last action.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if it's possible to undo the last action.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="change_case"
+              c:identifier="gtk_source_buffer_change_case"
+              version="3.12">
+        <doc xml:space="preserve">Changes the case of the text between the specified iterators.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="case_type" transfer-ownership="none">
+            <doc xml:space="preserve">how to change the case.</doc>
+            <type name="ChangeCaseType" c:type="GtkSourceChangeCaseType"/>
+          </parameter>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="create_source_mark"
+              c:identifier="gtk_source_buffer_create_source_mark"
+              version="2.2">
+        <doc xml:space="preserve">Creates a source mark in the @buffer of category @category.  A source mark is
+a #GtkTextMark but organised into categories. Depending on the category
+a pixbuf can be specified that will be displayed along the line of the mark.
+
+Like a #GtkTextMark, a #GtkSourceMark can be anonymous if the
+passed @name is %NULL.  Also, the buffer owns the marks so you
+shouldn't unreference it.
+
+Marks always have left gravity and are moved to the beginning of
+the line when the user deletes the line they were in.
+
+Typical uses for a source mark are bookmarks, breakpoints, current
+executing instruction indication in a source file, etc..</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a new #GtkSourceMark, owned by the buffer.</doc>
+          <type name="Mark" c:type="GtkSourceMark*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">the name of the mark, or %NULL.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="category" transfer-ownership="none">
+            <doc xml:space="preserve">a string defining the mark category.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="where" transfer-ownership="none">
+            <doc xml:space="preserve">location to place the mark.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="create_source_tag"
+              c:identifier="gtk_source_buffer_create_source_tag"
+              version="3.20"
+              introspectable="0">
+        <doc xml:space="preserve">In short, this is the same function as gtk_text_buffer_create_tag(), but
+instead of creating a #GtkTextTag, this function creates a #GtkSourceTag.
+
+This function creates a #GtkSourceTag and adds it to the tag table for
+@buffer.  Equivalent to calling gtk_text_tag_new() and then adding the tag to
+the buffer’s tag table. The returned tag is owned by the buffer’s tag table,
+so the ref count will be equal to one.
+
+If @tag_name is %NULL, the tag is anonymous.
+
+If @tag_name is non-%NULL, a tag called @tag_name must not already
+exist in the tag table for this buffer.
+
+The @first_property_name argument and subsequent arguments are a list
+of properties to set on the tag, as with g_object_set().</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a new #GtkSourceTag.</doc>
+          <type name="Gtk.TextTag" c:type="GtkTextTag*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="tag_name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">name of the new tag, or %NULL</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="first_property_name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">name of first property to set, or %NULL</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve">%NULL-terminated list of property names and values</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="end_not_undoable_action"
+              c:identifier="gtk_source_buffer_end_not_undoable_action">
+        <doc xml:space="preserve">Marks the end of a not undoable action on the buffer.  When the
+last not undoable block is closed through the call to this
+function, the list of undo actions is cleared and the undo manager
+is re-enabled.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="ensure_highlight"
+              c:identifier="gtk_source_buffer_ensure_highlight">
+        <doc xml:space="preserve">Forces buffer to analyze and highlight the given area synchronously.
+
+&lt;note&gt;
+  &lt;para&gt;
+    This is a potentially slow operation and should be used only
+    when you need to make sure that some text not currently
+    visible is highlighted, for instance before printing.
+  &lt;/para&gt;
+&lt;/note&gt;</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">start of the area to highlight.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">end of the area to highlight.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="forward_iter_to_source_mark"
+              c:identifier="gtk_source_buffer_forward_iter_to_source_mark"
+              version="2.2">
+        <doc xml:space="preserve">Moves @iter to the position of the next #GtkSourceMark of the given
+@category. Returns %TRUE if @iter was moved. If @category is NULL, the
+next source mark can be of any category.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether @iter was moved.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">an iterator.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="category"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">category to search for, or %NULL</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_context_classes_at_iter"
+              c:identifier="gtk_source_buffer_get_context_classes_at_iter"
+              version="2.10">
+        <doc xml:space="preserve">Get all defined context classes at @iter.
+
+See the #GtkSourceBuffer description for the list of default context classes.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new %NULL
+terminated array of context class names.
+Use g_strfreev() to free the array if it is no longer needed.</doc>
+          <array c:type="gchar**">
+            <type name="utf8"/>
+          </array>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_highlight_matching_brackets"
+              c:identifier="gtk_source_buffer_get_highlight_matching_brackets">
+        <doc xml:space="preserve">Determines whether bracket match highlighting is activated for the
+source buffer.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the source buffer will highlight matching
+brackets.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_highlight_syntax"
+              c:identifier="gtk_source_buffer_get_highlight_syntax">
+        <doc xml:space="preserve">Determines whether syntax highlighting is activated in the source
+buffer.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if syntax highlighting is enabled, %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_implicit_trailing_newline"
+              c:identifier="gtk_source_buffer_get_implicit_trailing_newline"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the @buffer has an implicit trailing newline.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_language"
+              c:identifier="gtk_source_buffer_get_language">
+        <doc xml:space="preserve">Returns the #GtkSourceLanguage associated with the buffer,
+see gtk_source_buffer_set_language().  The returned object should not be
+unreferenced by the user.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the #GtkSourceLanguage associated
+with the buffer, or %NULL.</doc>
+          <type name="Language" c:type="GtkSourceLanguage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_max_undo_levels"
+              c:identifier="gtk_source_buffer_get_max_undo_levels">
+        <doc xml:space="preserve">Determines the number of undo levels the buffer will track for buffer edits.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the maximum number of possible undo levels or -1 if no limit is set.</doc>
+          <type name="gint" c:type="gint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_source_marks_at_iter"
+              c:identifier="gtk_source_buffer_get_source_marks_at_iter"
+              version="2.2">
+        <doc xml:space="preserve">Returns the list of marks of the given category at @iter. If @category
+is %NULL it returns all marks at @iter.</doc>
+        <return-value transfer-ownership="container">
+          <doc xml:space="preserve">
+a newly allocated #GSList.</doc>
+          <type name="GLib.SList" c:type="GSList*">
+            <type name="Mark"/>
+          </type>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">an iterator.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="category"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">category to search for, or %NULL</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_source_marks_at_line"
+              c:identifier="gtk_source_buffer_get_source_marks_at_line"
+              version="2.2">
+        <doc xml:space="preserve">Returns the list of marks of the given category at @line.
+If @category is %NULL, all marks at @line are returned.</doc>
+        <return-value transfer-ownership="container">
+          <doc xml:space="preserve">
+a newly allocated #GSList.</doc>
+          <type name="GLib.SList" c:type="GSList*">
+            <type name="Mark"/>
+          </type>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="line" transfer-ownership="none">
+            <doc xml:space="preserve">a line number.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="category"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">category to search for, or %NULL</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_style_scheme"
+              c:identifier="gtk_source_buffer_get_style_scheme">
+        <doc xml:space="preserve">Returns the #GtkSourceStyleScheme associated with the buffer,
+see gtk_source_buffer_set_style_scheme().
+The returned object should not be unreferenced by the user.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the #GtkSourceStyleScheme
+associated with the buffer, or %NULL.</doc>
+          <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_undo_manager"
+              c:identifier="gtk_source_buffer_get_undo_manager">
+        <doc xml:space="preserve">Returns the #GtkSourceUndoManager associated with the buffer,
+see gtk_source_buffer_set_undo_manager().  The returned object should not be
+unreferenced by the user.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the #GtkSourceUndoManager associated
+with the buffer, or %NULL.</doc>
+          <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="iter_backward_to_context_class_toggle"
+              c:identifier="gtk_source_buffer_iter_backward_to_context_class_toggle"
+              version="2.10">
+        <doc xml:space="preserve">Moves backward to the next toggle (on or off) of the context class. If no
+matching context class toggles are found, returns %FALSE, otherwise %TRUE.
+Does not return toggles located at @iter, only toggles after @iter. Sets
+@iter to the location of the toggle, or to the end of the buffer if no
+toggle is found.
+
+See the #GtkSourceBuffer description for the list of default context classes.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether we found a context class toggle before @iter</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="context_class" transfer-ownership="none">
+            <doc xml:space="preserve">the context class.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="iter_forward_to_context_class_toggle"
+              c:identifier="gtk_source_buffer_iter_forward_to_context_class_toggle"
+              version="2.10">
+        <doc xml:space="preserve">Moves forward to the next toggle (on or off) of the context class. If no
+matching context class toggles are found, returns %FALSE, otherwise %TRUE.
+Does not return toggles located at @iter, only toggles after @iter. Sets
+@iter to the location of the toggle, or to the end of the buffer if no
+toggle is found.
+
+See the #GtkSourceBuffer description for the list of default context classes.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether we found a context class toggle after @iter</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="context_class" transfer-ownership="none">
+            <doc xml:space="preserve">the context class.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="iter_has_context_class"
+              c:identifier="gtk_source_buffer_iter_has_context_class"
+              version="2.10">
+        <doc xml:space="preserve">Check if the class @context_class is set on @iter.
+
+See the #GtkSourceBuffer description for the list of default context classes.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether @iter has the context class.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+          <parameter name="context_class" transfer-ownership="none">
+            <doc xml:space="preserve">class to search for.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="join_lines"
+              c:identifier="gtk_source_buffer_join_lines"
+              version="3.16">
+        <doc xml:space="preserve">Joins the lines of text between the specified iterators.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="redo" c:identifier="gtk_source_buffer_redo">
+        <doc xml:space="preserve">Redoes the last undo operation.  Use gtk_source_buffer_can_redo()
+to check whether a call to this function will have any effect.
+
+This function emits the #GtkSourceBuffer::redo signal.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="remove_source_marks"
+              c:identifier="gtk_source_buffer_remove_source_marks"
+              version="2.2">
+        <doc xml:space="preserve">Remove all marks of @category between @start and @end from the buffer.
+If @category is NULL, all marks in the range will be removed.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+          <parameter name="category"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">category to search for, or %NULL.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_highlight_matching_brackets"
+              c:identifier="gtk_source_buffer_set_highlight_matching_brackets">
+        <doc xml:space="preserve">Controls the bracket match highlighting function in the buffer.  If
+activated, when you position your cursor over a bracket character
+(a parenthesis, a square bracket, etc.) the matching opening or
+closing bracket character will be highlighted.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="highlight" transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE if you want matching brackets highlighted.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_highlight_syntax"
+              c:identifier="gtk_source_buffer_set_highlight_syntax">
+        <doc xml:space="preserve">Controls whether syntax is highlighted in the buffer. If @highlight
+is %TRUE, the text will be highlighted according to the syntax
+patterns specified in the language set with
+gtk_source_buffer_set_language(). If @highlight is %FALSE, syntax highlighting
+is disabled and all the GtkTextTag objects that have been added by the
+syntax highlighting engine are removed from the buffer.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="highlight" transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE to enable syntax highlighting, %FALSE to disable it.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_implicit_trailing_newline"
+              c:identifier="gtk_source_buffer_set_implicit_trailing_newline"
+              version="3.14">
+        <doc xml:space="preserve">Sets whether the @buffer has an implicit trailing newline.
+
+If an explicit trailing newline is present in a #GtkTextBuffer, #GtkTextView
+shows it as an empty line. This is generally not what the user expects.
+
+If @implicit_trailing_newline is %TRUE (the default value):
+ - when a #GtkSourceFileLoader loads the content of a file into the @buffer,
+   the trailing newline (if present in the file) is not inserted into the
+   @buffer.
+ - when a #GtkSourceFileSaver saves the content of the @buffer into a file, a
+   trailing newline is added to the file.
+
+On the other hand, if @implicit_trailing_newline is %FALSE, the file's
+content is not modified when loaded into the @buffer, and the @buffer's
+content is not modified when saved into a file.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="implicit_trailing_newline"
+                     transfer-ownership="none">
+            <doc xml:space="preserve">the new value.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_language"
+              c:identifier="gtk_source_buffer_set_language">
+        <doc xml:space="preserve">Associate a #GtkSourceLanguage with the buffer. If @language is
+not-%NULL and syntax highlighting is enabled (see gtk_source_buffer_set_highlight_syntax()),
+the syntax patterns defined in @language will be used to highlight the text
+contained in the buffer. If @language is %NULL, the text contained in the
+buffer is not highlighted.
+
+The buffer holds a reference to @language.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="language"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a #GtkSourceLanguage to set, or %NULL.</doc>
+            <type name="Language" c:type="GtkSourceLanguage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_max_undo_levels"
+              c:identifier="gtk_source_buffer_set_max_undo_levels">
+        <doc xml:space="preserve">Sets the number of undo levels for user actions the buffer will
+track.  If the number of user actions exceeds the limit set by this
+function, older actions will be discarded.
+
+If @max_undo_levels is -1, the undo/redo is unlimited.
+
+If @max_undo_levels is 0, the undo/redo is disabled.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="max_undo_levels" transfer-ownership="none">
+            <doc xml:space="preserve">the desired maximum number of undo levels.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_style_scheme"
+              c:identifier="gtk_source_buffer_set_style_scheme">
+        <doc xml:space="preserve">Sets style scheme used by the buffer. If @scheme is %NULL no
+style scheme is used.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="scheme"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a #GtkSourceStyleScheme or %NULL.</doc>
+            <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_undo_manager"
+              c:identifier="gtk_source_buffer_set_undo_manager">
+        <doc xml:space="preserve">Set the buffer undo manager. If @manager is %NULL the default undo manager
+will be set.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="manager"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">A #GtkSourceUndoManager or %NULL.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="sort_lines"
+              c:identifier="gtk_source_buffer_sort_lines"
+              version="3.18">
+        <doc xml:space="preserve">Sort the lines of text between the specified iterators.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="flags" transfer-ownership="none">
+            <doc xml:space="preserve">#GtkSourceSortFlags specifying how the sort should behave</doc>
+            <type name="SortFlags" c:type="GtkSourceSortFlags"/>
+          </parameter>
+          <parameter name="column" transfer-ownership="none">
+            <doc xml:space="preserve">sort considering the text starting at the given column</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="undo" c:identifier="gtk_source_buffer_undo">
+        <doc xml:space="preserve">Undoes the last user action which modified the buffer.  Use
+gtk_source_buffer_can_undo() to check whether a call to this
+function will have any effect.
+
+This function emits the #GtkSourceBuffer::undo signal.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <property name="can-redo" transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="can-undo" transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="highlight-matching-brackets"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Whether to highlight matching brackets in the buffer.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="highlight-syntax" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">Whether to highlight syntax in the buffer.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="implicit-trailing-newline"
+                version="3.14"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Whether the buffer has an implicit trailing newline. See
+gtk_source_buffer_set_implicit_trailing_newline().</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="language" writable="1" transfer-ownership="none">
+        <type name="Language"/>
+      </property>
+      <property name="max-undo-levels" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">Number of undo levels for the buffer. -1 means no limit. This property
+will only affect the default undo manager.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="style-scheme" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">Style scheme. It contains styles for syntax highlighting, optionally
+foreground, background, cursor color, current line color, and matching
+brackets style.</doc>
+        <type name="StyleScheme"/>
+      </property>
+      <property name="undo-manager"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <type name="UndoManager"/>
+      </property>
+      <field name="parent_instance">
+        <type name="Gtk.TextBuffer" c:type="GtkTextBuffer"/>
+      </field>
+      <field name="priv">
+        <type name="BufferPrivate" c:type="GtkSourceBufferPrivate*"/>
+      </field>
+      <glib:signal name="bracket-matched" when="last" version="2.12">
+        <doc xml:space="preserve">@iter is set to a valid iterator pointing to the matching bracket
+if @state is %GTK_SOURCE_BRACKET_MATCH_FOUND. Otherwise @iter is
+meaningless.
+
+The signal is emitted only when the @state changes, typically when
+the cursor moves.
+
+A use-case for this signal is to show messages in a #GtkStatusbar.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">if found, the location of the matching bracket.</doc>
+            <type name="Gtk.TextIter"/>
+          </parameter>
+          <parameter name="state" transfer-ownership="none">
+            <doc xml:space="preserve">state of bracket matching.</doc>
+            <type name="BracketMatchType"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="highlight-updated" when="last">
+        <doc xml:space="preserve">The ::highlight-updated signal is emitted when the syntax
+highlighting is updated in a certain region of the @buffer. This
+signal is useful to be notified when a context class region is
+updated (e.g. the no-spell-check context class).</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">the start of the updated region</doc>
+            <type name="Gtk.TextIter"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">the end of the updated region</doc>
+            <type name="Gtk.TextIter"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="redo" when="last">
+        <doc xml:space="preserve">The ::redo signal is emitted to redo the last undo operation.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+      <glib:signal name="source-mark-updated" when="last">
+        <doc xml:space="preserve">The ::source-mark-updated signal is emitted each time
+a mark is added to, moved or removed from the @buffer.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="mark" transfer-ownership="none">
+            <doc xml:space="preserve">the #GtkSourceMark</doc>
+            <type name="Gtk.TextMark"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="undo" when="last">
+        <doc xml:space="preserve">The ::undo signal is emitted to undo the last user action which
+modified the buffer.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+    </class>
+    <record name="BufferClass"
+            c:type="GtkSourceBufferClass"
+            glib:is-gtype-struct-for="Buffer">
+      <field name="parent_class">
+        <type name="Gtk.TextBufferClass" c:type="GtkTextBufferClass"/>
+      </field>
+      <field name="undo">
+        <callback name="undo">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="buffer" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+              <type name="Buffer" c:type="GtkSourceBuffer*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="redo">
+        <callback name="redo">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="buffer" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+              <type name="Buffer" c:type="GtkSourceBuffer*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="bracket_matched">
+        <callback name="bracket_matched">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="buffer" transfer-ownership="none">
+              <type name="Buffer" c:type="GtkSourceBuffer*"/>
+            </parameter>
+            <parameter name="iter" transfer-ownership="none">
+              <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+            </parameter>
+            <parameter name="state" transfer-ownership="none">
+              <type name="BracketMatchType"
+                    c:type="GtkSourceBracketMatchType"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved1" introspectable="0">
+        <callback name="_gtk_source_reserved1">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved2" introspectable="0">
+        <callback name="_gtk_source_reserved2">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved3" introspectable="0">
+        <callback name="_gtk_source_reserved3">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <record name="BufferPrivate" c:type="GtkSourceBufferPrivate" disguised="1">
+    </record>
+    <enumeration name="ChangeCaseType"
+                 version="3.12"
+                 glib:type-name="GtkSourceChangeCaseType"
+                 glib:get-type="gtk_source_change_case_type_get_type"
+                 c:type="GtkSourceChangeCaseType">
+      <member name="lower"
+              value="0"
+              c:identifier="GTK_SOURCE_CHANGE_CASE_LOWER"
+              glib:nick="lower">
+        <doc xml:space="preserve">change case to lowercase.</doc>
+      </member>
+      <member name="upper"
+              value="1"
+              c:identifier="GTK_SOURCE_CHANGE_CASE_UPPER"
+              glib:nick="upper">
+        <doc xml:space="preserve">change case to uppercase.</doc>
+      </member>
+      <member name="toggle"
+              value="2"
+              c:identifier="GTK_SOURCE_CHANGE_CASE_TOGGLE"
+              glib:nick="toggle">
+        <doc xml:space="preserve">toggle case of each character.</doc>
+      </member>
+      <member name="title"
+              value="3"
+              c:identifier="GTK_SOURCE_CHANGE_CASE_TITLE"
+              glib:nick="title">
+        <doc xml:space="preserve">capitalize each word.</doc>
+      </member>
+    </enumeration>
+    <class name="Completion"
+           c:symbol-prefix="completion"
+           c:type="GtkSourceCompletion"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceCompletion"
+           glib:get-type="gtk_source_completion_get_type"
+           glib:type-struct="CompletionClass">
+      <implements name="Gtk.Buildable"/>
+      <virtual-method name="activate_proposal">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="hide" invoker="hide">
+        <doc xml:space="preserve">Hides the completion if it is active (visible).</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletion.</doc>
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="move_cursor">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+          <parameter name="step" transfer-ownership="none">
+            <type name="Gtk.ScrollStep" c:type="GtkScrollStep"/>
+          </parameter>
+          <parameter name="num" transfer-ownership="none">
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="move_page">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+          <parameter name="step" transfer-ownership="none">
+            <type name="Gtk.ScrollStep" c:type="GtkScrollStep"/>
+          </parameter>
+          <parameter name="num" transfer-ownership="none">
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="populate_context">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+          <parameter name="context" transfer-ownership="none">
+            <type name="CompletionContext"
+                  c:type="GtkSourceCompletionContext*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="proposal_activated">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+          <parameter name="provider" transfer-ownership="none">
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </parameter>
+          <parameter name="proposal" transfer-ownership="none">
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="show">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <method name="add_provider"
+              c:identifier="gtk_source_completion_add_provider"
+              throws="1">
+        <doc xml:space="preserve">Add a new #GtkSourceCompletionProvider to the completion object. This will
+add a reference @provider, so make sure to unref your own copy when you
+no longer need it.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if @provider was successfully added, otherwise if @error
+         is provided, it will be set with the error and %FALSE is returned.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletion.</doc>
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+          <parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="block_interactive"
+              c:identifier="gtk_source_completion_block_interactive">
+        <doc xml:space="preserve">Block interactive completion. This can be used to disable interactive
+completion when inserting or deleting text from the buffer associated with
+the completion. Use gtk_source_completion_unblock_interactive() to enable
+interactive completion again.
+
+This function may be called multiple times. It will continue to block
+interactive completion until gtk_source_completion_unblock_interactive()
+has been called the same number of times.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletion.</doc>
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="create_context"
+              c:identifier="gtk_source_completion_create_context">
+        <doc xml:space="preserve">Create a new #GtkSourceCompletionContext for @completion. The position where
+the completion occurs can be specified by @position. If @position is %NULL,
+the current cursor position will be used.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a new #GtkSourceCompletionContext.
+The reference being returned is a 'floating' reference,
+so if you invoke gtk_source_completion_show() with this context
+you don't need to unref it.</doc>
+          <type name="CompletionContext" c:type="GtkSourceCompletionContext*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletion.</doc>
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+          <parameter name="position"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a #GtkTextIter, or %NULL.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_info_window"
+              c:identifier="gtk_source_completion_get_info_window">
+        <doc xml:space="preserve">The info widget is the window where the completion displays optional extra
+information of the proposal.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">The #GtkSourceCompletionInfo window
+                          associated with @completion.</doc>
+          <type name="CompletionInfo" c:type="GtkSourceCompletionInfo*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletion.</doc>
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_providers"
+              c:identifier="gtk_source_completion_get_providers">
+        <doc xml:space="preserve">Get list of providers registered on @completion. The returned list is owned
+by the completion and should not be freed.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">
+list of #GtkSourceCompletionProvider.</doc>
+          <type name="GLib.List" c:type="GList*">
+            <type name="CompletionProvider"/>
+          </type>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletion.</doc>
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_view" c:identifier="gtk_source_completion_get_view">
+        <doc xml:space="preserve">The #GtkSourceView associated with @completion, or %NULL if the view has been
+destroyed.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">
+The #GtkSourceView associated with @completion, or %NULL.</doc>
+          <type name="View" c:type="GtkSourceView*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletion.</doc>
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="hide" c:identifier="gtk_source_completion_hide">
+        <doc xml:space="preserve">Hides the completion if it is active (visible).</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletion.</doc>
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="move_window"
+              c:identifier="gtk_source_completion_move_window"
+              deprecated="1"
+              deprecated-version="3.8">
+        <doc xml:space="preserve">Move the completion window to a specific iter.</doc>
+        <doc-deprecated xml:space="preserve">Use gtk_source_completion_provider_get_start_iter() instead.</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletion.</doc>
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="remove_provider"
+              c:identifier="gtk_source_completion_remove_provider"
+              throws="1">
+        <doc xml:space="preserve">Remove @provider from the completion.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if @provider was successfully removed, otherwise if @error
+         is provided, it will be set with the error and %FALSE is returned.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletion.</doc>
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+          <parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="show" c:identifier="gtk_source_completion_show">
+        <doc xml:space="preserve">Starts a new completion with the specified #GtkSourceCompletionContext and
+a list of potential candidate providers for completion.
+
+It can be convenient for showing a completion on-the-fly, without the need to
+add or remove providers to the #GtkSourceCompletion.
+
+Another solution is to add providers with
+gtk_source_completion_add_provider(), and implement
+gtk_source_completion_provider_match() for each provider.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if it was possible to the show completion window.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletion.</doc>
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+          <parameter name="providers"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">
+a list of #GtkSourceCompletionProvider, or %NULL.</doc>
+            <type name="GLib.List" c:type="GList*">
+              <type name="CompletionProvider"/>
+            </type>
+          </parameter>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">The #GtkSourceCompletionContext
+with which to start the completion.</doc>
+            <type name="CompletionContext"
+                  c:type="GtkSourceCompletionContext*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="unblock_interactive"
+              c:identifier="gtk_source_completion_unblock_interactive">
+        <doc xml:space="preserve">Unblock interactive completion. This can be used after using
+gtk_source_completion_block_interactive() to enable interactive completion
+again.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="completion" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletion.</doc>
+            <type name="Completion" c:type="GtkSourceCompletion*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <property name="accelerators"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Number of keyboard accelerators to show for the first proposals. For
+example, to activate the first proposal, the user can press
+&lt;keycombo&gt;&lt;keycap&gt;Alt&lt;/keycap&gt;&lt;keycap&gt;1&lt;/keycap&gt;&lt;/keycombo&gt;.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="auto-complete-delay"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Determines the popup delay (in milliseconds) at which the completion
+will be shown for interactive completion.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="proposal-page-size"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The scroll page size of the proposals in the completion window. In
+other words, when &lt;keycap&gt;PageDown&lt;/keycap&gt; or
+&lt;keycap&gt;PageUp&lt;/keycap&gt; is pressed, the selected
+proposal becomes the one which is located one page size backward or
+forward.
+
+See also the #GtkSourceCompletion::move-cursor signal.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="provider-page-size"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The scroll page size of the provider pages in the completion window.
+
+See the #GtkSourceCompletion::move-page signal.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="remember-info-visibility"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Determines whether the visibility of the info window should be
+saved when the completion is hidden, and restored when the completion
+is shown again.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="select-on-show"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Determines whether the first proposal should be selected when the
+completion is first shown.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="show-headers"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Determines whether provider headers should be shown in the proposal
+list. It can be useful to disable when there is only one provider.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="show-icons"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Determines whether provider and proposal icons should be shown in
+the completion popup.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="view"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The #GtkSourceView bound to the completion object.</doc>
+        <type name="View"/>
+      </property>
+      <field name="parent_instance">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv">
+        <type name="CompletionPrivate" c:type="GtkSourceCompletionPrivate*"/>
+      </field>
+      <glib:signal name="activate-proposal" when="last" action="1">
+        <doc xml:space="preserve">The #GtkSourceCompletion::activate-proposal signal is a
+keybinding signal which gets emitted when the user initiates
+a proposal activation.
+
+Applications should not connect to it, but may emit it with
+g_signal_emit_by_name() if they need to control the proposal
+activation programmatically.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+      <glib:signal name="hide" when="last" action="1">
+        <doc xml:space="preserve">Emitted when the completion window is hidden. The default handler
+will actually hide the window.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+      <glib:signal name="move-cursor" when="last" action="1">
+        <doc xml:space="preserve">The #GtkSourceCompletion::move-cursor signal is a keybinding
+signal which gets emitted when the user initiates a cursor
+movement.
+
+The &lt;keycap&gt;Up&lt;/keycap&gt;, &lt;keycap&gt;Down&lt;/keycap&gt;,
+&lt;keycap&gt;PageUp&lt;/keycap&gt;, &lt;keycap&gt;PageDown&lt;/keycap&gt;,
+&lt;keycap&gt;Home&lt;/keycap&gt; and &lt;keycap&gt;End&lt;/keycap&gt; keys are bound to the
+normal behavior expected by those keys.
+
+When @step is equal to %GTK_SCROLL_PAGES, the page size is defined by
+the #GtkSourceCompletion:proposal-page-size property. It is used for
+the &lt;keycap&gt;PageDown&lt;/keycap&gt; and &lt;keycap&gt;PageUp&lt;/keycap&gt; keys.
+
+Applications should not connect to it, but may emit it with
+g_signal_emit_by_name() if they need to control the cursor
+programmatically.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="step" transfer-ownership="none">
+            <doc xml:space="preserve">The #GtkScrollStep by which to move the cursor</doc>
+            <type name="Gtk.ScrollStep"/>
+          </parameter>
+          <parameter name="num" transfer-ownership="none">
+            <doc xml:space="preserve">The amount of steps to move the cursor</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="move-page" when="last" action="1">
+        <doc xml:space="preserve">The #GtkSourceCompletion::move-page signal is a keybinding
+signal which gets emitted when the user initiates a page
+movement (i.e. switches between provider pages).
+
+&lt;keycombo&gt;&lt;keycap&gt;Control&lt;/keycap&gt;&lt;keycap&gt;Left&lt;/keycap&gt;&lt;/keycombo&gt;
+is for going to the previous provider.
+&lt;keycombo&gt;&lt;keycap&gt;Control&lt;/keycap&gt;&lt;keycap&gt;Right&lt;/keycap&gt;&lt;/keycombo&gt;
+is for going to the next provider.
+&lt;keycombo&gt;&lt;keycap&gt;Control&lt;/keycap&gt;&lt;keycap&gt;Home&lt;/keycap&gt;&lt;/keycombo&gt;
+is for displaying all the providers.
+&lt;keycombo&gt;&lt;keycap&gt;Control&lt;/keycap&gt;&lt;keycap&gt;End&lt;/keycap&gt;&lt;/keycombo&gt;
+is for going to the last provider.
+
+When @step is equal to #GTK_SCROLL_PAGES, the page size is defined by
+the #GtkSourceCompletion:provider-page-size property.
+
+Applications should not connect to it, but may emit it with
+g_signal_emit_by_name() if they need to control the page selection
+programmatically.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="step" transfer-ownership="none">
+            <doc xml:space="preserve">The #GtkScrollStep by which to move the page</doc>
+            <type name="Gtk.ScrollStep"/>
+          </parameter>
+          <parameter name="num" transfer-ownership="none">
+            <doc xml:space="preserve">The amount of steps to move the page</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="populate-context" when="last" action="1">
+        <doc xml:space="preserve">Emitted just before starting to populate the completion with providers.
+You can use this signal to add additional attributes in the context.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">The #GtkSourceCompletionContext for the current completion</doc>
+            <type name="CompletionContext"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="show" when="last" action="1">
+        <doc xml:space="preserve">Emitted when the completion window is shown. The default handler
+will actually show the window.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+    </class>
+    <bitfield name="CompletionActivation"
+              glib:type-name="GtkSourceCompletionActivation"
+              glib:get-type="gtk_source_completion_activation_get_type"
+              c:type="GtkSourceCompletionActivation">
+      <member name="none"
+              value="0"
+              c:identifier="GTK_SOURCE_COMPLETION_ACTIVATION_NONE"
+              glib:nick="none">
+        <doc xml:space="preserve">None.</doc>
+      </member>
+      <member name="interactive"
+              value="1"
+              c:identifier="GTK_SOURCE_COMPLETION_ACTIVATION_INTERACTIVE"
+              glib:nick="interactive">
+        <doc xml:space="preserve">Interactive activation. By
+default, it occurs on each insertion in the #GtkTextBuffer. This can be
+blocked temporarily with gtk_source_completion_block_interactive().</doc>
+      </member>
+      <member name="user_requested"
+              value="2"
+              c:identifier="GTK_SOURCE_COMPLETION_ACTIVATION_USER_REQUESTED"
+              glib:nick="user-requested">
+        <doc xml:space="preserve">User requested activation.
+By default, it occurs when the user presses
+&lt;keycombo&gt;&lt;keycap&gt;Control&lt;/keycap&gt;&lt;keycap&gt;space&lt;/keycap&gt;&lt;/keycombo&gt;.</doc>
+      </member>
+    </bitfield>
+    <record name="CompletionClass"
+            c:type="GtkSourceCompletionClass"
+            glib:is-gtype-struct-for="Completion">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="proposal_activated">
+        <callback name="proposal_activated">
+          <return-value transfer-ownership="none">
+            <type name="gboolean" c:type="gboolean"/>
+          </return-value>
+          <parameters>
+            <parameter name="completion" transfer-ownership="none">
+              <type name="Completion" c:type="GtkSourceCompletion*"/>
+            </parameter>
+            <parameter name="provider" transfer-ownership="none">
+              <type name="CompletionProvider"
+                    c:type="GtkSourceCompletionProvider*"/>
+            </parameter>
+            <parameter name="proposal" transfer-ownership="none">
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="show">
+        <callback name="show">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="completion" transfer-ownership="none">
+              <type name="Completion" c:type="GtkSourceCompletion*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="hide">
+        <callback name="hide">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="completion" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletion.</doc>
+              <type name="Completion" c:type="GtkSourceCompletion*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="populate_context">
+        <callback name="populate_context">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="completion" transfer-ownership="none">
+              <type name="Completion" c:type="GtkSourceCompletion*"/>
+            </parameter>
+            <parameter name="context" transfer-ownership="none">
+              <type name="CompletionContext"
+                    c:type="GtkSourceCompletionContext*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="move_cursor">
+        <callback name="move_cursor">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="completion" transfer-ownership="none">
+              <type name="Completion" c:type="GtkSourceCompletion*"/>
+            </parameter>
+            <parameter name="step" transfer-ownership="none">
+              <type name="Gtk.ScrollStep" c:type="GtkScrollStep"/>
+            </parameter>
+            <parameter name="num" transfer-ownership="none">
+              <type name="gint" c:type="gint"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="move_page">
+        <callback name="move_page">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="completion" transfer-ownership="none">
+              <type name="Completion" c:type="GtkSourceCompletion*"/>
+            </parameter>
+            <parameter name="step" transfer-ownership="none">
+              <type name="Gtk.ScrollStep" c:type="GtkScrollStep"/>
+            </parameter>
+            <parameter name="num" transfer-ownership="none">
+              <type name="gint" c:type="gint"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="activate_proposal">
+        <callback name="activate_proposal">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="completion" transfer-ownership="none">
+              <type name="Completion" c:type="GtkSourceCompletion*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+    </record>
+    <class name="CompletionContext"
+           c:symbol-prefix="completion_context"
+           c:type="GtkSourceCompletionContext"
+           parent="GObject.InitiallyUnowned"
+           glib:type-name="GtkSourceCompletionContext"
+           glib:get-type="gtk_source_completion_context_get_type"
+           glib:type-struct="CompletionContextClass">
+      <virtual-method name="cancelled">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <type name="CompletionContext"
+                  c:type="GtkSourceCompletionContext*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <method name="add_proposals"
+              c:identifier="gtk_source_completion_context_add_proposals">
+        <doc xml:space="preserve">Providers can use this function to add proposals to the completion. They
+can do so asynchronously by means of the @finished argument. Providers must
+ensure that they always call this function with @finished set to %TRUE
+once each population (even if no proposals need to be added).
+Population occurs when the gtk_source_completion_provider_populate()
+function is called.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionContext.</doc>
+            <type name="CompletionContext"
+                  c:type="GtkSourceCompletionContext*"/>
+          </instance-parameter>
+          <parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </parameter>
+          <parameter name="proposals"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">The list of proposals to add.</doc>
+            <type name="GLib.List" c:type="GList*">
+              <type name="CompletionProposal"/>
+            </type>
+          </parameter>
+          <parameter name="finished" transfer-ownership="none">
+            <doc xml:space="preserve">Whether the provider is finished adding proposals.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_activation"
+              c:identifier="gtk_source_completion_context_get_activation">
+        <doc xml:space="preserve">Get the context activation.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">The context activation.</doc>
+          <type name="CompletionActivation"
+                c:type="GtkSourceCompletionActivation"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionContext.</doc>
+            <type name="CompletionContext"
+                  c:type="GtkSourceCompletionContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_iter"
+              c:identifier="gtk_source_completion_context_get_iter">
+        <doc xml:space="preserve">Get the iter at which the completion was invoked. Providers can use this
+to determine how and if to match proposals.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if @iter is correctly set, %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionContext.</doc>
+            <type name="CompletionContext"
+                  c:type="GtkSourceCompletionContext*"/>
+          </instance-parameter>
+          <parameter name="iter"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="activation"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The completion activation</doc>
+        <type name="CompletionActivation"/>
+      </property>
+      <property name="completion"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The #GtkSourceCompletion associated with the context.</doc>
+        <type name="Completion"/>
+      </property>
+      <property name="iter" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">The #GtkTextIter at which the completion is invoked.</doc>
+        <type name="Gtk.TextIter"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.InitiallyUnowned" c:type="GInitiallyUnowned"/>
+      </field>
+      <field name="priv">
+        <type name="CompletionContextPrivate"
+              c:type="GtkSourceCompletionContextPrivate*"/>
+      </field>
+      <glib:signal name="cancelled" when="last" action="1">
+        <doc xml:space="preserve">Emitted when the current population of proposals has been cancelled.
+Providers adding proposals asynchronously should connect to this signal
+to know when to cancel running proposal queries.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+    </class>
+    <record name="CompletionContextClass"
+            c:type="GtkSourceCompletionContextClass"
+            glib:is-gtype-struct-for="CompletionContext">
+      <field name="parent_class">
+        <type name="GObject.InitiallyUnownedClass"
+              c:type="GInitiallyUnownedClass"/>
+      </field>
+      <field name="cancelled">
+        <callback name="cancelled">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="context" transfer-ownership="none">
+              <type name="CompletionContext"
+                    c:type="GtkSourceCompletionContext*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved1" introspectable="0">
+        <callback name="_gtk_source_reserved1">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved2" introspectable="0">
+        <callback name="_gtk_source_reserved2">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved3" introspectable="0">
+        <callback name="_gtk_source_reserved3">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <record name="CompletionContextPrivate"
+            c:type="GtkSourceCompletionContextPrivate"
+            disguised="1">
+    </record>
+    <enumeration name="CompletionError"
+                 glib:type-name="GtkSourceCompletionError"
+                 glib:get-type="gtk_source_completion_error_get_type"
+                 c:type="GtkSourceCompletionError"
+                 glib:error-domain="gtk-source-completion-error-quark">
+      <doc xml:space="preserve">An error code used with %GTK_SOURCE_COMPLETION_ERROR in a #GError returned
+from a completion-related function.</doc>
+      <member name="already_bound"
+              value="0"
+              c:identifier="GTK_SOURCE_COMPLETION_ERROR_ALREADY_BOUND"
+              glib:nick="already-bound">
+        <doc xml:space="preserve">The #GtkSourceCompletionProvider
+is already bound to the #GtkSourceCompletion object.</doc>
+      </member>
+      <member name="not_bound"
+              value="1"
+              c:identifier="GTK_SOURCE_COMPLETION_ERROR_NOT_BOUND"
+              glib:nick="not-bound">
+        <doc xml:space="preserve">The #GtkSourceCompletionProvider is
+not bound to the #GtkSourceCompletion object.</doc>
+      </member>
+      <function name="quark" c:identifier="gtk_source_completion_error_quark">
+        <return-value transfer-ownership="none">
+          <type name="GLib.Quark" c:type="GQuark"/>
+        </return-value>
+      </function>
+    </enumeration>
+    <class name="CompletionInfo"
+           c:symbol-prefix="completion_info"
+           c:type="GtkSourceCompletionInfo"
+           parent="Gtk.Window"
+           glib:type-name="GtkSourceCompletionInfo"
+           glib:get-type="gtk_source_completion_info_get_type"
+           glib:type-struct="CompletionInfoClass">
+      <implements name="Atk.ImplementorIface"/>
+      <implements name="Gtk.Buildable"/>
+      <constructor name="new" c:identifier="gtk_source_completion_info_new">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a new GtkSourceCompletionInfo.</doc>
+          <type name="CompletionInfo" c:type="GtkSourceCompletionInfo*"/>
+        </return-value>
+      </constructor>
+      <virtual-method name="before_show">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="info" transfer-ownership="none">
+            <type name="CompletionInfo" c:type="GtkSourceCompletionInfo*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <method name="get_widget"
+              c:identifier="gtk_source_completion_info_get_widget"
+              deprecated="1"
+              deprecated-version="3.8">
+        <doc xml:space="preserve">Get the current content widget.</doc>
+        <doc-deprecated xml:space="preserve">Use gtk_bin_get_child() instead.</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">The current content widget.</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="info" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionInfo.</doc>
+            <type name="CompletionInfo" c:type="GtkSourceCompletionInfo*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="move_to_iter"
+              c:identifier="gtk_source_completion_info_move_to_iter">
+        <doc xml:space="preserve">Moves the #GtkSourceCompletionInfo to @iter. If @iter is %NULL @info is
+moved to the cursor position. Moving will respect the #GdkGravity setting
+of the info window and will ensure the line at @iter is not occluded by
+the window.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="info" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionInfo.</doc>
+            <type name="CompletionInfo" c:type="GtkSourceCompletionInfo*"/>
+          </instance-parameter>
+          <parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextView on which the info window should be positioned.</doc>
+            <type name="Gtk.TextView" c:type="GtkTextView*"/>
+          </parameter>
+          <parameter name="iter"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_widget"
+              c:identifier="gtk_source_completion_info_set_widget"
+              deprecated="1"
+              deprecated-version="3.8">
+        <doc xml:space="preserve">Sets the content widget of the info window. See that the previous widget will
+lose a reference and it can be destroyed, so if you do not want this to
+happen you must use g_object_ref() before calling this method.</doc>
+        <doc-deprecated xml:space="preserve">Use gtk_container_add() instead. If there is already a child
+widget, remove it with gtk_container_remove().</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="info" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionInfo.</doc>
+            <type name="CompletionInfo" c:type="GtkSourceCompletionInfo*"/>
+          </instance-parameter>
+          <parameter name="widget"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a #GtkWidget.</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <field name="parent">
+        <type name="Gtk.Window" c:type="GtkWindow"/>
+      </field>
+      <field name="priv">
+        <type name="CompletionInfoPrivate"
+              c:type="GtkSourceCompletionInfoPrivate*"/>
+      </field>
+      <glib:signal name="before-show"
+                   when="last"
+                   action="1"
+                   deprecated="1"
+                   deprecated-version="3.10">
+        <doc xml:space="preserve">This signal is emitted before any "show" management. You can connect
+to this signal if you want to change some properties or position
+before the real "show".</doc>
+        <doc-deprecated xml:space="preserve">This signal should not be used.</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+    </class>
+    <record name="CompletionInfoClass"
+            c:type="GtkSourceCompletionInfoClass"
+            glib:is-gtype-struct-for="CompletionInfo">
+      <field name="parent_class">
+        <type name="Gtk.WindowClass" c:type="GtkWindowClass"/>
+      </field>
+      <field name="before_show">
+        <callback name="before_show">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="info" transfer-ownership="none">
+              <type name="CompletionInfo" c:type="GtkSourceCompletionInfo*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+    </record>
+    <record name="CompletionInfoPrivate"
+            c:type="GtkSourceCompletionInfoPrivate"
+            disguised="1">
+    </record>
+    <class name="CompletionItem"
+           c:symbol-prefix="completion_item"
+           c:type="GtkSourceCompletionItem"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceCompletionItem"
+           glib:get-type="gtk_source_completion_item_get_type"
+           glib:type-struct="CompletionItemClass">
+      <implements name="CompletionProposal"/>
+      <constructor name="new" c:identifier="gtk_source_completion_item_new">
+        <doc xml:space="preserve">Create a new #GtkSourceCompletionItem with label @label, icon @icon and
+extra information @info. Both @icon and @info can be %NULL in which case
+there will be no icon shown and no extra information available.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #GtkSourceCompletionItem.</doc>
+          <type name="CompletionItem" c:type="GtkSourceCompletionItem*"/>
+        </return-value>
+        <parameters>
+          <parameter name="label" transfer-ownership="none">
+            <doc xml:space="preserve">The item label.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="text" transfer-ownership="none">
+            <doc xml:space="preserve">The item text.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="icon"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">The item icon.</doc>
+            <type name="GdkPixbuf.Pixbuf" c:type="GdkPixbuf*"/>
+          </parameter>
+          <parameter name="info"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">The item extra information.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_from_stock"
+                   c:identifier="gtk_source_completion_item_new_from_stock"
+                   deprecated="1"
+                   deprecated-version="3.10">
+        <doc xml:space="preserve">Creates a new #GtkSourceCompletionItem from a stock item. If @label is %NULL,
+the stock label will be used.</doc>
+        <doc-deprecated xml:space="preserve">Use gtk_source_completion_item_new() instead.</doc-deprecated>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #GtkSourceCompletionItem.</doc>
+          <type name="CompletionItem" c:type="GtkSourceCompletionItem*"/>
+        </return-value>
+        <parameters>
+          <parameter name="label"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">The item label.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="text" transfer-ownership="none">
+            <doc xml:space="preserve">The item text.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="stock" transfer-ownership="none">
+            <doc xml:space="preserve">The stock icon.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="info"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">The item extra information.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_with_markup"
+                   c:identifier="gtk_source_completion_item_new_with_markup">
+        <doc xml:space="preserve">Create a new #GtkSourceCompletionItem with markup label @markup, icon
+@icon and extra information @info. Both @icon and @info can be %NULL in
+which case there will be no icon shown and no extra information available.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #GtkSourceCompletionItem.</doc>
+          <type name="CompletionItem" c:type="GtkSourceCompletionItem*"/>
+        </return-value>
+        <parameters>
+          <parameter name="markup" transfer-ownership="none">
+            <doc xml:space="preserve">The item markup label.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="text" transfer-ownership="none">
+            <doc xml:space="preserve">The item text.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="icon"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">The item icon.</doc>
+            <type name="GdkPixbuf.Pixbuf" c:type="GdkPixbuf*"/>
+          </parameter>
+          <parameter name="info"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">The item extra information.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <property name="gicon"
+                version="3.18"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The #GIcon for the icon to be shown for this proposal.</doc>
+        <type name="Gio.Icon"/>
+      </property>
+      <property name="icon" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">The #GdkPixbuf for the icon to be shown for this proposal.</doc>
+        <type name="GdkPixbuf.Pixbuf"/>
+      </property>
+      <property name="icon-name"
+                version="3.18"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The icon name for the icon to be shown for this proposal.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="info" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">Optional extra information to be shown for this proposal.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="label" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">Label to be shown for this proposal.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="markup" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">Label with markup to be shown for this proposal.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="text" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">Proposal text.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv">
+        <type name="CompletionItemPrivate"
+              c:type="GtkSourceCompletionItemPrivate*"/>
+      </field>
+    </class>
+    <record name="CompletionItemClass"
+            c:type="GtkSourceCompletionItemClass"
+            glib:is-gtype-struct-for="CompletionItem">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+    </record>
+    <record name="CompletionItemPrivate"
+            c:type="GtkSourceCompletionItemPrivate"
+            disguised="1">
+    </record>
+    <record name="CompletionPrivate"
+            c:type="GtkSourceCompletionPrivate"
+            disguised="1">
+    </record>
+    <interface name="CompletionProposal"
+               c:symbol-prefix="completion_proposal"
+               c:type="GtkSourceCompletionProposal"
+               glib:type-name="GtkSourceCompletionProposal"
+               glib:get-type="gtk_source_completion_proposal_get_type"
+               glib:type-struct="CompletionProposalIface">
+      <virtual-method name="changed" invoker="changed">
+        <doc xml:space="preserve">Emits the "changed" signal on @proposal. This should be called by
+implementations whenever the name, icon or info of the proposal has
+changed.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="equal" invoker="equal">
+        <doc xml:space="preserve">Get whether two proposal objects are the same.  This is used to (together
+with gtk_source_completion_proposal_hash()) to match proposals in the
+completion model. By default, it uses direct equality (g_direct_equal()).</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if @proposal and @object are the same proposal</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+          <parameter name="other" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_gicon" invoker="get_gicon" version="3.18">
+        <doc xml:space="preserve">Gets the #GIcon for the icon of @proposal.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">A #GIcon with the icon of @proposal.</doc>
+          <type name="Gio.Icon" c:type="GIcon*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_icon" invoker="get_icon">
+        <doc xml:space="preserve">Gets the #GdkPixbuf for the icon of @proposal.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">A #GdkPixbuf with the icon of @proposal.</doc>
+          <type name="GdkPixbuf.Pixbuf" c:type="GdkPixbuf*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_icon_name"
+                      invoker="get_icon_name"
+                      version="3.18">
+        <doc xml:space="preserve">Gets the icon name of @proposal.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">The icon name of @proposal.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_info" invoker="get_info">
+        <doc xml:space="preserve">Gets extra information associated to the proposal. This information will be
+used to present the user with extra, detailed information about the
+selected proposal. The returned string must be freed with g_free().</doc>
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">a newly-allocated string containing
+extra information of @proposal or %NULL if no extra information is associated
+to @proposal.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_label" invoker="get_label">
+        <doc xml:space="preserve">Gets the label of @proposal. The label is shown in the list of proposals as
+plain text. If you need any markup (such as bold or italic text), you have
+to implement gtk_source_completion_proposal_get_markup(). The returned string
+must be freed with g_free().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new string containing the label of @proposal.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_markup" invoker="get_markup">
+        <doc xml:space="preserve">Gets the label of @proposal with markup. The label is shown in the list of
+proposals and may contain markup. This will be used instead of
+gtk_source_completion_proposal_get_label() if implemented. The returned string
+must be freed with g_free().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new string containing the label of @proposal with markup.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_text" invoker="get_text">
+        <doc xml:space="preserve">Gets the text of @proposal. The text that is inserted into
+the text buffer when the proposal is activated by the default activation.
+You are free to implement a custom activation handler in the provider and
+not implement this function. For more information, see
+gtk_source_completion_provider_activate_proposal(). The returned string must
+be freed with g_free().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new string containing the text of @proposal.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="hash" invoker="hash">
+        <doc xml:space="preserve">Get the hash value of @proposal. This is used to (together with
+gtk_source_completion_proposal_equal()) to match proposals in the completion
+model. By default, it uses a direct hash (g_direct_hash()).</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">The hash value of @proposal.</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <method name="changed"
+              c:identifier="gtk_source_completion_proposal_changed">
+        <doc xml:space="preserve">Emits the "changed" signal on @proposal. This should be called by
+implementations whenever the name, icon or info of the proposal has
+changed.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="equal" c:identifier="gtk_source_completion_proposal_equal">
+        <doc xml:space="preserve">Get whether two proposal objects are the same.  This is used to (together
+with gtk_source_completion_proposal_hash()) to match proposals in the
+completion model. By default, it uses direct equality (g_direct_equal()).</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if @proposal and @object are the same proposal</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+          <parameter name="other" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_gicon"
+              c:identifier="gtk_source_completion_proposal_get_gicon"
+              version="3.18">
+        <doc xml:space="preserve">Gets the #GIcon for the icon of @proposal.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">A #GIcon with the icon of @proposal.</doc>
+          <type name="Gio.Icon" c:type="GIcon*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_icon"
+              c:identifier="gtk_source_completion_proposal_get_icon">
+        <doc xml:space="preserve">Gets the #GdkPixbuf for the icon of @proposal.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">A #GdkPixbuf with the icon of @proposal.</doc>
+          <type name="GdkPixbuf.Pixbuf" c:type="GdkPixbuf*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_icon_name"
+              c:identifier="gtk_source_completion_proposal_get_icon_name"
+              version="3.18">
+        <doc xml:space="preserve">Gets the icon name of @proposal.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">The icon name of @proposal.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_info"
+              c:identifier="gtk_source_completion_proposal_get_info">
+        <doc xml:space="preserve">Gets extra information associated to the proposal. This information will be
+used to present the user with extra, detailed information about the
+selected proposal. The returned string must be freed with g_free().</doc>
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">a newly-allocated string containing
+extra information of @proposal or %NULL if no extra information is associated
+to @proposal.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_label"
+              c:identifier="gtk_source_completion_proposal_get_label">
+        <doc xml:space="preserve">Gets the label of @proposal. The label is shown in the list of proposals as
+plain text. If you need any markup (such as bold or italic text), you have
+to implement gtk_source_completion_proposal_get_markup(). The returned string
+must be freed with g_free().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new string containing the label of @proposal.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_markup"
+              c:identifier="gtk_source_completion_proposal_get_markup">
+        <doc xml:space="preserve">Gets the label of @proposal with markup. The label is shown in the list of
+proposals and may contain markup. This will be used instead of
+gtk_source_completion_proposal_get_label() if implemented. The returned string
+must be freed with g_free().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new string containing the label of @proposal with markup.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_text"
+              c:identifier="gtk_source_completion_proposal_get_text">
+        <doc xml:space="preserve">Gets the text of @proposal. The text that is inserted into
+the text buffer when the proposal is activated by the default activation.
+You are free to implement a custom activation handler in the provider and
+not implement this function. For more information, see
+gtk_source_completion_provider_activate_proposal(). The returned string must
+be freed with g_free().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new string containing the text of @proposal.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="hash" c:identifier="gtk_source_completion_proposal_hash">
+        <doc xml:space="preserve">Get the hash value of @proposal. This is used to (together with
+gtk_source_completion_proposal_equal()) to match proposals in the completion
+model. By default, it uses a direct hash (g_direct_hash()).</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">The hash value of @proposal.</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <glib:signal name="changed" when="last" action="1">
+        <doc xml:space="preserve">Emitted when the proposal has changed. The completion popup
+will react to this by updating the shown information.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+    </interface>
+    <record name="CompletionProposalIface"
+            c:type="GtkSourceCompletionProposalIface"
+            glib:is-gtype-struct-for="CompletionProposal">
+      <doc xml:space="preserve">The virtual function table for #GtkSourceCompletionProposal.</doc>
+      <field name="parent">
+        <doc xml:space="preserve">The parent interface.</doc>
+        <type name="GObject.TypeInterface" c:type="GTypeInterface"/>
+      </field>
+      <field name="get_label">
+        <callback name="get_label">
+          <return-value transfer-ownership="full">
+            <doc xml:space="preserve">a new string containing the label of @proposal.</doc>
+            <type name="utf8" c:type="gchar*"/>
+          </return-value>
+          <parameters>
+            <parameter name="proposal" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_markup">
+        <callback name="get_markup">
+          <return-value transfer-ownership="full">
+            <doc xml:space="preserve">a new string containing the label of @proposal with markup.</doc>
+            <type name="utf8" c:type="gchar*"/>
+          </return-value>
+          <parameters>
+            <parameter name="proposal" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_text">
+        <callback name="get_text">
+          <return-value transfer-ownership="full">
+            <doc xml:space="preserve">a new string containing the text of @proposal.</doc>
+            <type name="utf8" c:type="gchar*"/>
+          </return-value>
+          <parameters>
+            <parameter name="proposal" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_icon">
+        <callback name="get_icon">
+          <return-value transfer-ownership="none" nullable="1">
+            <doc xml:space="preserve">A #GdkPixbuf with the icon of @proposal.</doc>
+            <type name="GdkPixbuf.Pixbuf" c:type="GdkPixbuf*"/>
+          </return-value>
+          <parameters>
+            <parameter name="proposal" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_icon_name">
+        <callback name="get_icon_name">
+          <return-value transfer-ownership="none" nullable="1">
+            <doc xml:space="preserve">The icon name of @proposal.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </return-value>
+          <parameters>
+            <parameter name="proposal" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_gicon">
+        <callback name="get_gicon">
+          <return-value transfer-ownership="none" nullable="1">
+            <doc xml:space="preserve">A #GIcon with the icon of @proposal.</doc>
+            <type name="Gio.Icon" c:type="GIcon*"/>
+          </return-value>
+          <parameters>
+            <parameter name="proposal" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_info">
+        <callback name="get_info">
+          <return-value transfer-ownership="full" nullable="1">
+            <doc xml:space="preserve">a newly-allocated string containing
+extra information of @proposal or %NULL if no extra information is associated
+to @proposal.</doc>
+            <type name="utf8" c:type="gchar*"/>
+          </return-value>
+          <parameters>
+            <parameter name="proposal" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="hash">
+        <callback name="hash">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">The hash value of @proposal.</doc>
+            <type name="guint" c:type="guint"/>
+          </return-value>
+          <parameters>
+            <parameter name="proposal" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="equal">
+        <callback name="equal">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE if @proposal and @object are the same proposal</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </return-value>
+          <parameters>
+            <parameter name="proposal" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+            <parameter name="other" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="changed">
+        <callback name="changed">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="proposal" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+    </record>
+    <interface name="CompletionProvider"
+               c:symbol-prefix="completion_provider"
+               c:type="GtkSourceCompletionProvider"
+               glib:type-name="GtkSourceCompletionProvider"
+               glib:get-type="gtk_source_completion_provider_get_type"
+               glib:type-struct="CompletionProviderIface">
+      <virtual-method name="activate_proposal" invoker="activate_proposal">
+        <doc xml:space="preserve">Activate @proposal at @iter. When this functions returns %FALSE, the default
+activation of @proposal will take place which replaces the word at @iter
+with the text of @proposal (see gtk_source_completion_proposal_get_text()).
+
+Here is how the default activation selects the boundaries of the word to
+replace. The end of the word is @iter. For the start of the word, it depends
+on whether a start iter is defined for @proposal (see
+gtk_source_completion_provider_get_start_iter()). If a start iter is defined,
+the start of the word is the start iter. Else, the word (as long as possible)
+will contain only alphanumerical and the "_" characters.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE to indicate that the proposal activation has been handled,
+         %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+          <parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_activation" invoker="get_activation">
+        <doc xml:space="preserve">Get with what kind of activation the provider should be activated.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a combination of #GtkSourceCompletionActivation.</doc>
+          <type name="CompletionActivation"
+                c:type="GtkSourceCompletionActivation"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_gicon" invoker="get_gicon" version="3.18">
+        <doc xml:space="preserve">Gets the #GIcon for the icon of @provider.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">The icon to be used for the provider,
+         or %NULL if the provider does not have a special icon.</doc>
+          <type name="Gio.Icon" c:type="GIcon*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">The #GtkSourceCompletionProvider</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_icon" invoker="get_icon">
+        <doc xml:space="preserve">Get the #GdkPixbuf for the icon of the @provider.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">The icon to be used for the provider,
+         or %NULL if the provider does not have a special icon.</doc>
+          <type name="GdkPixbuf.Pixbuf" c:type="GdkPixbuf*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">The #GtkSourceCompletionProvider</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_icon_name"
+                      invoker="get_icon_name"
+                      version="3.18">
+        <doc xml:space="preserve">Gets the icon name of @provider.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">The icon name to be used for the provider,
+         or %NULL if the provider does not have a special icon.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">The #GtkSourceCompletionProvider</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_info_widget" invoker="get_info_widget">
+        <doc xml:space="preserve">Get a customized info widget to show extra information of a proposal.
+This allows for customized widgets on a proposal basis, although in general
+providers will have the same custom widget for all their proposals and
+@proposal can be ignored. The implementation of this function is optional.
+
+If this function is not implemented, the default widget is a #GtkLabel. The
+return value of gtk_source_completion_proposal_get_info() is used as the
+content of the #GtkLabel.
+
+&lt;note&gt;
+  &lt;para&gt;
+    If implemented, gtk_source_completion_provider_update_info()
+    &lt;emphasis&gt;must&lt;/emphasis&gt; also be implemented.
+  &lt;/para&gt;
+&lt;/note&gt;</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">a custom #GtkWidget to show extra
+information about @proposal, or %NULL if the provider does not have a special
+info widget.</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+          <parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a currently selected #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_interactive_delay"
+                      invoker="get_interactive_delay">
+        <doc xml:space="preserve">Get the delay in milliseconds before starting interactive completion for
+this provider. A value of -1 indicates to use the default value as set
+by the #GtkSourceCompletion:auto-complete-delay property.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the interactive delay in milliseconds.</doc>
+          <type name="gint" c:type="gint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_name" invoker="get_name">
+        <doc xml:space="preserve">Get the name of the provider. This should be a translatable name for
+display to the user. For example: _("Document word completion provider"). The
+returned string must be freed with g_free().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new string containing the name of the provider.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_priority" invoker="get_priority">
+        <doc xml:space="preserve">Get the provider priority. The priority determines the order in which
+proposals appear in the completion popup. Higher priorities are sorted
+before lower priorities. The default priority is 0.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the provider priority.</doc>
+          <type name="gint" c:type="gint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_start_iter" invoker="get_start_iter">
+        <doc xml:space="preserve">Get the #GtkTextIter at which the completion for @proposal starts. When
+implemented, this information is used to position the completion window
+accordingly when a proposal is selected in the completion window. The
+@proposal text inside the completion window is aligned on @iter.
+
+If this function is not implemented, the word boundary is taken to position
+the completion window. See gtk_source_completion_provider_activate_proposal()
+for an explanation on the word boundaries.
+
+When the @proposal is activated, the default handler uses @iter as the start
+of the word to replace. See
+gtk_source_completion_provider_activate_proposal() for more information.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if @iter was set for @proposal, %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionContext.</doc>
+            <type name="CompletionContext"
+                  c:type="GtkSourceCompletionContext*"/>
+          </parameter>
+          <parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </parameter>
+          <parameter name="iter"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="match" invoker="match">
+        <doc xml:space="preserve">Get whether the provider match the context of completion detailed in
+@context.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if @provider matches the completion context, %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionContext.</doc>
+            <type name="CompletionContext"
+                  c:type="GtkSourceCompletionContext*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="populate" invoker="populate">
+        <doc xml:space="preserve">Populate @context with proposals from @provider added with the
+gtk_source_completion_context_add_proposals() function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionContext.</doc>
+            <type name="CompletionContext"
+                  c:type="GtkSourceCompletionContext*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="update_info" invoker="update_info">
+        <doc xml:space="preserve">Update extra information shown in @info for @proposal.
+
+&lt;note&gt;
+  &lt;para&gt;
+    This function &lt;emphasis&gt;must&lt;/emphasis&gt; be implemented when
+    gtk_source_completion_provider_get_info_widget() is implemented.
+  &lt;/para&gt;
+&lt;/note&gt;</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+          <parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </parameter>
+          <parameter name="info" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionInfo.</doc>
+            <type name="CompletionInfo" c:type="GtkSourceCompletionInfo*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <method name="activate_proposal"
+              c:identifier="gtk_source_completion_provider_activate_proposal">
+        <doc xml:space="preserve">Activate @proposal at @iter. When this functions returns %FALSE, the default
+activation of @proposal will take place which replaces the word at @iter
+with the text of @proposal (see gtk_source_completion_proposal_get_text()).
+
+Here is how the default activation selects the boundaries of the word to
+replace. The end of the word is @iter. For the start of the word, it depends
+on whether a start iter is defined for @proposal (see
+gtk_source_completion_provider_get_start_iter()). If a start iter is defined,
+the start of the word is the start iter. Else, the word (as long as possible)
+will contain only alphanumerical and the "_" characters.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE to indicate that the proposal activation has been handled,
+         %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+          <parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_activation"
+              c:identifier="gtk_source_completion_provider_get_activation">
+        <doc xml:space="preserve">Get with what kind of activation the provider should be activated.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a combination of #GtkSourceCompletionActivation.</doc>
+          <type name="CompletionActivation"
+                c:type="GtkSourceCompletionActivation"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_gicon"
+              c:identifier="gtk_source_completion_provider_get_gicon"
+              version="3.18">
+        <doc xml:space="preserve">Gets the #GIcon for the icon of @provider.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">The icon to be used for the provider,
+         or %NULL if the provider does not have a special icon.</doc>
+          <type name="Gio.Icon" c:type="GIcon*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">The #GtkSourceCompletionProvider</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_icon"
+              c:identifier="gtk_source_completion_provider_get_icon">
+        <doc xml:space="preserve">Get the #GdkPixbuf for the icon of the @provider.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">The icon to be used for the provider,
+         or %NULL if the provider does not have a special icon.</doc>
+          <type name="GdkPixbuf.Pixbuf" c:type="GdkPixbuf*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">The #GtkSourceCompletionProvider</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_icon_name"
+              c:identifier="gtk_source_completion_provider_get_icon_name"
+              version="3.18">
+        <doc xml:space="preserve">Gets the icon name of @provider.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">The icon name to be used for the provider,
+         or %NULL if the provider does not have a special icon.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">The #GtkSourceCompletionProvider</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_info_widget"
+              c:identifier="gtk_source_completion_provider_get_info_widget">
+        <doc xml:space="preserve">Get a customized info widget to show extra information of a proposal.
+This allows for customized widgets on a proposal basis, although in general
+providers will have the same custom widget for all their proposals and
+@proposal can be ignored. The implementation of this function is optional.
+
+If this function is not implemented, the default widget is a #GtkLabel. The
+return value of gtk_source_completion_proposal_get_info() is used as the
+content of the #GtkLabel.
+
+&lt;note&gt;
+  &lt;para&gt;
+    If implemented, gtk_source_completion_provider_update_info()
+    &lt;emphasis&gt;must&lt;/emphasis&gt; also be implemented.
+  &lt;/para&gt;
+&lt;/note&gt;</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">a custom #GtkWidget to show extra
+information about @proposal, or %NULL if the provider does not have a special
+info widget.</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+          <parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a currently selected #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_interactive_delay"
+              c:identifier="gtk_source_completion_provider_get_interactive_delay">
+        <doc xml:space="preserve">Get the delay in milliseconds before starting interactive completion for
+this provider. A value of -1 indicates to use the default value as set
+by the #GtkSourceCompletion:auto-complete-delay property.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the interactive delay in milliseconds.</doc>
+          <type name="gint" c:type="gint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_name"
+              c:identifier="gtk_source_completion_provider_get_name">
+        <doc xml:space="preserve">Get the name of the provider. This should be a translatable name for
+display to the user. For example: _("Document word completion provider"). The
+returned string must be freed with g_free().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new string containing the name of the provider.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_priority"
+              c:identifier="gtk_source_completion_provider_get_priority">
+        <doc xml:space="preserve">Get the provider priority. The priority determines the order in which
+proposals appear in the completion popup. Higher priorities are sorted
+before lower priorities. The default priority is 0.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the provider priority.</doc>
+          <type name="gint" c:type="gint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_start_iter"
+              c:identifier="gtk_source_completion_provider_get_start_iter">
+        <doc xml:space="preserve">Get the #GtkTextIter at which the completion for @proposal starts. When
+implemented, this information is used to position the completion window
+accordingly when a proposal is selected in the completion window. The
+@proposal text inside the completion window is aligned on @iter.
+
+If this function is not implemented, the word boundary is taken to position
+the completion window. See gtk_source_completion_provider_activate_proposal()
+for an explanation on the word boundaries.
+
+When the @proposal is activated, the default handler uses @iter as the start
+of the word to replace. See
+gtk_source_completion_provider_activate_proposal() for more information.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if @iter was set for @proposal, %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionContext.</doc>
+            <type name="CompletionContext"
+                  c:type="GtkSourceCompletionContext*"/>
+          </parameter>
+          <parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </parameter>
+          <parameter name="iter"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="match" c:identifier="gtk_source_completion_provider_match">
+        <doc xml:space="preserve">Get whether the provider match the context of completion detailed in
+@context.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if @provider matches the completion context, %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionContext.</doc>
+            <type name="CompletionContext"
+                  c:type="GtkSourceCompletionContext*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="populate"
+              c:identifier="gtk_source_completion_provider_populate">
+        <doc xml:space="preserve">Populate @context with proposals from @provider added with the
+gtk_source_completion_context_add_proposals() function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionContext.</doc>
+            <type name="CompletionContext"
+                  c:type="GtkSourceCompletionContext*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="update_info"
+              c:identifier="gtk_source_completion_provider_update_info">
+        <doc xml:space="preserve">Update extra information shown in @info for @proposal.
+
+&lt;note&gt;
+  &lt;para&gt;
+    This function &lt;emphasis&gt;must&lt;/emphasis&gt; be implemented when
+    gtk_source_completion_provider_get_info_widget() is implemented.
+  &lt;/para&gt;
+&lt;/note&gt;</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="provider" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+            <type name="CompletionProvider"
+                  c:type="GtkSourceCompletionProvider*"/>
+          </instance-parameter>
+          <parameter name="proposal" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+            <type name="CompletionProposal"
+                  c:type="GtkSourceCompletionProposal*"/>
+          </parameter>
+          <parameter name="info" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionInfo.</doc>
+            <type name="CompletionInfo" c:type="GtkSourceCompletionInfo*"/>
+          </parameter>
+        </parameters>
+      </method>
+    </interface>
+    <record name="CompletionProviderIface"
+            c:type="GtkSourceCompletionProviderIface"
+            glib:is-gtype-struct-for="CompletionProvider">
+      <doc xml:space="preserve">The virtual function table for #GtkSourceCompletionProvider.</doc>
+      <field name="g_iface">
+        <doc xml:space="preserve">The parent interface.</doc>
+        <type name="GObject.TypeInterface" c:type="GTypeInterface"/>
+      </field>
+      <field name="get_name">
+        <callback name="get_name">
+          <return-value transfer-ownership="full">
+            <doc xml:space="preserve">a new string containing the name of the provider.</doc>
+            <type name="utf8" c:type="gchar*"/>
+          </return-value>
+          <parameters>
+            <parameter name="provider" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+              <type name="CompletionProvider"
+                    c:type="GtkSourceCompletionProvider*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_icon">
+        <callback name="get_icon">
+          <return-value transfer-ownership="none" nullable="1">
+            <doc xml:space="preserve">The icon to be used for the provider,
+         or %NULL if the provider does not have a special icon.</doc>
+            <type name="GdkPixbuf.Pixbuf" c:type="GdkPixbuf*"/>
+          </return-value>
+          <parameters>
+            <parameter name="provider" transfer-ownership="none">
+              <doc xml:space="preserve">The #GtkSourceCompletionProvider</doc>
+              <type name="CompletionProvider"
+                    c:type="GtkSourceCompletionProvider*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_icon_name">
+        <callback name="get_icon_name">
+          <return-value transfer-ownership="none" nullable="1">
+            <doc xml:space="preserve">The icon name to be used for the provider,
+         or %NULL if the provider does not have a special icon.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </return-value>
+          <parameters>
+            <parameter name="provider" transfer-ownership="none">
+              <doc xml:space="preserve">The #GtkSourceCompletionProvider</doc>
+              <type name="CompletionProvider"
+                    c:type="GtkSourceCompletionProvider*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_gicon">
+        <callback name="get_gicon">
+          <return-value transfer-ownership="none" nullable="1">
+            <doc xml:space="preserve">The icon to be used for the provider,
+         or %NULL if the provider does not have a special icon.</doc>
+            <type name="Gio.Icon" c:type="GIcon*"/>
+          </return-value>
+          <parameters>
+            <parameter name="provider" transfer-ownership="none">
+              <doc xml:space="preserve">The #GtkSourceCompletionProvider</doc>
+              <type name="CompletionProvider"
+                    c:type="GtkSourceCompletionProvider*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="populate">
+        <callback name="populate">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="provider" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+              <type name="CompletionProvider"
+                    c:type="GtkSourceCompletionProvider*"/>
+            </parameter>
+            <parameter name="context" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionContext.</doc>
+              <type name="CompletionContext"
+                    c:type="GtkSourceCompletionContext*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="match">
+        <callback name="match">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE if @provider matches the completion context, %FALSE otherwise.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </return-value>
+          <parameters>
+            <parameter name="provider" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+              <type name="CompletionProvider"
+                    c:type="GtkSourceCompletionProvider*"/>
+            </parameter>
+            <parameter name="context" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionContext.</doc>
+              <type name="CompletionContext"
+                    c:type="GtkSourceCompletionContext*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_activation">
+        <callback name="get_activation">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">a combination of #GtkSourceCompletionActivation.</doc>
+            <type name="CompletionActivation"
+                  c:type="GtkSourceCompletionActivation"/>
+          </return-value>
+          <parameters>
+            <parameter name="provider" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+              <type name="CompletionProvider"
+                    c:type="GtkSourceCompletionProvider*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_info_widget">
+        <callback name="get_info_widget">
+          <return-value transfer-ownership="none" nullable="1">
+            <doc xml:space="preserve">a custom #GtkWidget to show extra
+information about @proposal, or %NULL if the provider does not have a special
+info widget.</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </return-value>
+          <parameters>
+            <parameter name="provider" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+              <type name="CompletionProvider"
+                    c:type="GtkSourceCompletionProvider*"/>
+            </parameter>
+            <parameter name="proposal" transfer-ownership="none">
+              <doc xml:space="preserve">a currently selected #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="update_info">
+        <callback name="update_info">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="provider" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+              <type name="CompletionProvider"
+                    c:type="GtkSourceCompletionProvider*"/>
+            </parameter>
+            <parameter name="proposal" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+            <parameter name="info" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionInfo.</doc>
+              <type name="CompletionInfo" c:type="GtkSourceCompletionInfo*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_start_iter">
+        <callback name="get_start_iter">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE if @iter was set for @proposal, %FALSE otherwise.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </return-value>
+          <parameters>
+            <parameter name="provider" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+              <type name="CompletionProvider"
+                    c:type="GtkSourceCompletionProvider*"/>
+            </parameter>
+            <parameter name="context" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionContext.</doc>
+              <type name="CompletionContext"
+                    c:type="GtkSourceCompletionContext*"/>
+            </parameter>
+            <parameter name="proposal" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+            <parameter name="iter"
+                       direction="out"
+                       caller-allocates="1"
+                       transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkTextIter.</doc>
+              <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="activate_proposal">
+        <callback name="activate_proposal">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE to indicate that the proposal activation has been handled,
+         %FALSE otherwise.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </return-value>
+          <parameters>
+            <parameter name="provider" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+              <type name="CompletionProvider"
+                    c:type="GtkSourceCompletionProvider*"/>
+            </parameter>
+            <parameter name="proposal" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProposal.</doc>
+              <type name="CompletionProposal"
+                    c:type="GtkSourceCompletionProposal*"/>
+            </parameter>
+            <parameter name="iter" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkTextIter.</doc>
+              <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_interactive_delay">
+        <callback name="get_interactive_delay">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">the interactive delay in milliseconds.</doc>
+            <type name="gint" c:type="gint"/>
+          </return-value>
+          <parameters>
+            <parameter name="provider" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+              <type name="CompletionProvider"
+                    c:type="GtkSourceCompletionProvider*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_priority">
+        <callback name="get_priority">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">the provider priority.</doc>
+            <type name="gint" c:type="gint"/>
+          </return-value>
+          <parameters>
+            <parameter name="provider" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceCompletionProvider.</doc>
+              <type name="CompletionProvider"
+                    c:type="GtkSourceCompletionProvider*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+    </record>
+    <class name="CompletionWords"
+           c:symbol-prefix="completion_words"
+           c:type="GtkSourceCompletionWords"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceCompletionWords"
+           glib:get-type="gtk_source_completion_words_get_type"
+           glib:type-struct="CompletionWordsClass">
+      <implements name="CompletionProvider"/>
+      <constructor name="new" c:identifier="gtk_source_completion_words_new">
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #GtkSourceCompletionWords provider</doc>
+          <type name="CompletionWords" c:type="GtkSourceCompletionWords*"/>
+        </return-value>
+        <parameters>
+          <parameter name="name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">The name for the provider</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="icon"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">A specific icon for the provider</doc>
+            <type name="GdkPixbuf.Pixbuf" c:type="GdkPixbuf*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="register"
+              c:identifier="gtk_source_completion_words_register">
+        <doc xml:space="preserve">Registers @buffer in the @words provider.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="words" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionWords</doc>
+            <type name="CompletionWords" c:type="GtkSourceCompletionWords*"/>
+          </instance-parameter>
+          <parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextBuffer</doc>
+            <type name="Gtk.TextBuffer" c:type="GtkTextBuffer*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="unregister"
+              c:identifier="gtk_source_completion_words_unregister">
+        <doc xml:space="preserve">Unregisters @buffer from the @words provider.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="words" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceCompletionWords</doc>
+            <type name="CompletionWords" c:type="GtkSourceCompletionWords*"/>
+          </instance-parameter>
+          <parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextBuffer</doc>
+            <type name="Gtk.TextBuffer" c:type="GtkTextBuffer*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="activation"
+                version="3.10"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The type of activation.</doc>
+        <type name="CompletionActivation"/>
+      </property>
+      <property name="icon"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <type name="GdkPixbuf.Pixbuf"/>
+      </property>
+      <property name="interactive-delay"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="minimum-word-size"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="name"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="priority"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="proposals-batch-size"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="scan-batch-size"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <type name="guint" c:type="guint"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv">
+        <type name="CompletionWordsPrivate"
+              c:type="GtkSourceCompletionWordsPrivate*"/>
+      </field>
+    </class>
+    <record name="CompletionWordsClass"
+            c:type="GtkSourceCompletionWordsClass"
+            glib:is-gtype-struct-for="CompletionWords">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+    </record>
+    <record name="CompletionWordsPrivate"
+            c:type="GtkSourceCompletionWordsPrivate"
+            disguised="1">
+    </record>
+    <enumeration name="CompressionType"
+                 version="3.14"
+                 glib:type-name="GtkSourceCompressionType"
+                 glib:get-type="gtk_source_compression_type_get_type"
+                 c:type="GtkSourceCompressionType">
+      <member name="none"
+              value="0"
+              c:identifier="GTK_SOURCE_COMPRESSION_TYPE_NONE"
+              glib:nick="none">
+        <doc xml:space="preserve">plain text.</doc>
+      </member>
+      <member name="gzip"
+              value="1"
+              c:identifier="GTK_SOURCE_COMPRESSION_TYPE_GZIP"
+              glib:nick="gzip">
+        <doc xml:space="preserve">gzip compression.</doc>
+      </member>
+    </enumeration>
+    <bitfield name="DrawSpacesFlags"
+              glib:type-name="GtkSourceDrawSpacesFlags"
+              glib:get-type="gtk_source_draw_spaces_flags_get_type"
+              c:type="GtkSourceDrawSpacesFlags">
+      <doc xml:space="preserve">GtkSourceDrawSpacesFlags determine what kind of spaces whould be drawn. If none
+of GTK_SOURCE_DRAW_SPACES_LEADING, GTK_SOURCE_DRAW_SPACES_TEXT or
+GTK_SOURCE_DRAW_SPACES_TRAILING is specified, whitespaces at any position in
+the line will be drawn (i.e. it has the same effect as specifying all of them).</doc>
+      <member name="space"
+              value="1"
+              c:identifier="GTK_SOURCE_DRAW_SPACES_SPACE"
+              glib:nick="space">
+        <doc xml:space="preserve">whether the space character should be drawn.</doc>
+      </member>
+      <member name="tab"
+              value="2"
+              c:identifier="GTK_SOURCE_DRAW_SPACES_TAB"
+              glib:nick="tab">
+        <doc xml:space="preserve">whether the tab character should be drawn.</doc>
+      </member>
+      <member name="newline"
+              value="4"
+              c:identifier="GTK_SOURCE_DRAW_SPACES_NEWLINE"
+              glib:nick="newline">
+        <doc xml:space="preserve">whether the line breaks should be drawn.</doc>
+      </member>
+      <member name="nbsp"
+              value="8"
+              c:identifier="GTK_SOURCE_DRAW_SPACES_NBSP"
+              glib:nick="nbsp">
+        <doc xml:space="preserve">whether the non-breaking whitespaces should be drawn.</doc>
+      </member>
+      <member name="leading"
+              value="16"
+              c:identifier="GTK_SOURCE_DRAW_SPACES_LEADING"
+              glib:nick="leading">
+        <doc xml:space="preserve">whether leading whitespaces should be drawn.</doc>
+      </member>
+      <member name="text"
+              value="32"
+              c:identifier="GTK_SOURCE_DRAW_SPACES_TEXT"
+              glib:nick="text">
+        <doc xml:space="preserve">whether whitespaces inside text should be drawn.</doc>
+      </member>
+      <member name="trailing"
+              value="64"
+              c:identifier="GTK_SOURCE_DRAW_SPACES_TRAILING"
+              glib:nick="trailing">
+        <doc xml:space="preserve">whether trailing whitespaces should be drawn.</doc>
+      </member>
+      <member name="all"
+              value="127"
+              c:identifier="GTK_SOURCE_DRAW_SPACES_ALL"
+              glib:nick="all">
+        <doc xml:space="preserve">wheter all kind of spaces should be drawn.</doc>
+      </member>
+    </bitfield>
+    <record name="Encoding"
+            c:type="GtkSourceEncoding"
+            glib:type-name="GtkSourceEncoding"
+            glib:get-type="gtk_source_encoding_get_type"
+            c:symbol-prefix="encoding">
+      <method name="copy"
+              c:identifier="gtk_source_encoding_copy"
+              version="3.14">
+        <doc xml:space="preserve">Used by language bindings.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a copy of @enc.</doc>
+          <type name="Encoding" c:type="GtkSourceEncoding*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="enc" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceEncoding.</doc>
+            <type name="Encoding" c:type="const GtkSourceEncoding*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="free"
+              c:identifier="gtk_source_encoding_free"
+              version="3.14">
+        <doc xml:space="preserve">Used by language bindings.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="enc" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceEncoding.</doc>
+            <type name="Encoding" c:type="GtkSourceEncoding*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_charset"
+              c:identifier="gtk_source_encoding_get_charset"
+              version="3.14">
+        <doc xml:space="preserve">Gets the character set of the #GtkSourceEncoding, such as "UTF-8" or
+"ISO-8859-1".</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the character set of the #GtkSourceEncoding.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="enc" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceEncoding.</doc>
+            <type name="Encoding" c:type="const GtkSourceEncoding*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_name"
+              c:identifier="gtk_source_encoding_get_name"
+              version="3.14">
+        <doc xml:space="preserve">Gets the name of the #GtkSourceEncoding such as "Unicode" or "Western".</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the name of the #GtkSourceEncoding.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="enc" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceEncoding.</doc>
+            <type name="Encoding" c:type="const GtkSourceEncoding*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="to_string"
+              c:identifier="gtk_source_encoding_to_string"
+              version="3.14">
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a string representation. Free with g_free() when no longer needed.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="enc" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceEncoding.</doc>
+            <type name="Encoding" c:type="const GtkSourceEncoding*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <function name="get_all"
+                c:identifier="gtk_source_encoding_get_all"
+                version="3.14">
+        <doc xml:space="preserve">Gets all encodings.</doc>
+        <return-value transfer-ownership="container">
+          <doc xml:space="preserve">a list of
+all #GtkSourceEncoding's. Free with g_slist_free().</doc>
+          <type name="GLib.SList" c:type="GSList*">
+            <type name="Encoding"/>
+          </type>
+        </return-value>
+      </function>
+      <function name="get_current"
+                c:identifier="gtk_source_encoding_get_current"
+                version="3.14">
+        <doc xml:space="preserve">Gets the #GtkSourceEncoding for the current locale. See also g_get_charset().</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the current locale encoding.</doc>
+          <type name="Encoding" c:type="const GtkSourceEncoding*"/>
+        </return-value>
+      </function>
+      <function name="get_default_candidates"
+                c:identifier="gtk_source_encoding_get_default_candidates"
+                version="3.18">
+        <doc xml:space="preserve">Gets the list of default candidate encodings to try when loading a file. See
+gtk_source_file_loader_set_candidate_encodings().
+
+This function returns a different list depending on the current locale (i.e.
+language, country and default encoding). The UTF-8 encoding and the current
+locale encoding are guaranteed to be present in the returned list.</doc>
+        <return-value transfer-ownership="container">
+          <doc xml:space="preserve">the list of
+default candidate encodings. Free with g_slist_free().</doc>
+          <type name="GLib.SList" c:type="GSList*">
+            <type name="Encoding"/>
+          </type>
+        </return-value>
+      </function>
+      <function name="get_from_charset"
+                c:identifier="gtk_source_encoding_get_from_charset"
+                version="3.14">
+        <doc xml:space="preserve">Gets a #GtkSourceEncoding from a character set such as "UTF-8" or
+"ISO-8859-1".</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the corresponding #GtkSourceEncoding, or %NULL
+if not found.</doc>
+          <type name="Encoding" c:type="const GtkSourceEncoding*"/>
+        </return-value>
+        <parameters>
+          <parameter name="charset" transfer-ownership="none">
+            <doc xml:space="preserve">a character set.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="get_utf8"
+                c:identifier="gtk_source_encoding_get_utf8"
+                version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the UTF-8 encoding.</doc>
+          <type name="Encoding" c:type="const GtkSourceEncoding*"/>
+        </return-value>
+      </function>
+    </record>
+    <class name="File"
+           c:symbol-prefix="file"
+           c:type="GtkSourceFile"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceFile"
+           glib:get-type="gtk_source_file_get_type"
+           glib:type-struct="FileClass">
+      <constructor name="new"
+                   c:identifier="gtk_source_file_new"
+                   version="3.14">
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #GtkSourceFile object.</doc>
+          <type name="File" c:type="GtkSourceFile*"/>
+        </return-value>
+      </constructor>
+      <method name="check_file_on_disk"
+              c:identifier="gtk_source_file_check_file_on_disk"
+              version="3.18">
+        <doc xml:space="preserve">Checks synchronously the file on disk, to know whether the file is externally
+modified, or has been deleted, and whether the file is read-only.
+
+#GtkSourceFile doesn't create a #GFileMonitor to track those properties, so
+this function needs to be called instead. Creating lots of #GFileMonitor's
+would take lots of resources.
+
+Since this function is synchronous, it is advised to call it only on local
+files. See gtk_source_file_is_local().</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_compression_type"
+              c:identifier="gtk_source_file_get_compression_type"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the compression type.</doc>
+          <type name="CompressionType" c:type="GtkSourceCompressionType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_encoding"
+              c:identifier="gtk_source_file_get_encoding"
+              version="3.14">
+        <doc xml:space="preserve">The encoding is initially %NULL. After a successful file loading or saving
+operation, the encoding is non-%NULL.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the character encoding.</doc>
+          <type name="Encoding" c:type="const GtkSourceEncoding*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_location"
+              c:identifier="gtk_source_file_get_location"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #GFile.</doc>
+          <type name="Gio.File" c:type="GFile*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_newline_type"
+              c:identifier="gtk_source_file_get_newline_type"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the newline type.</doc>
+          <type name="NewlineType" c:type="GtkSourceNewlineType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_deleted"
+              c:identifier="gtk_source_file_is_deleted"
+              version="3.18">
+        <doc xml:space="preserve">Returns whether the file has been deleted. If the
+#GtkSourceFile:location is %NULL, returns %FALSE.
+
+To have an up-to-date value, you must first call
+gtk_source_file_check_file_on_disk().</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the file has been deleted.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_externally_modified"
+              c:identifier="gtk_source_file_is_externally_modified"
+              version="3.18">
+        <doc xml:space="preserve">Returns whether the file is externally modified. If the
+#GtkSourceFile:location is %NULL, returns %FALSE.
+
+To have an up-to-date value, you must first call
+gtk_source_file_check_file_on_disk().</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the file is externally modified.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_local"
+              c:identifier="gtk_source_file_is_local"
+              version="3.18">
+        <doc xml:space="preserve">Returns whether the file is local. If the #GtkSourceFile:location is %NULL,
+returns %FALSE.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the file is local.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_readonly"
+              c:identifier="gtk_source_file_is_readonly"
+              version="3.18">
+        <doc xml:space="preserve">Returns whether the file is read-only. If the
+#GtkSourceFile:location is %NULL, returns %FALSE.
+
+To have an up-to-date value, you must first call
+gtk_source_file_check_file_on_disk().</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the file is read-only.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_location"
+              c:identifier="gtk_source_file_set_location"
+              version="3.14">
+        <doc xml:space="preserve">Sets the location.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </instance-parameter>
+          <parameter name="location"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">the new #GFile, or %NULL.</doc>
+            <type name="Gio.File" c:type="GFile*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_mount_operation_factory"
+              c:identifier="gtk_source_file_set_mount_operation_factory"
+              version="3.14"
+              introspectable="0">
+        <doc xml:space="preserve">Sets a #GtkSourceMountOperationFactory function that will be called when a
+#GMountOperation must be created. This is useful for creating a
+#GtkMountOperation with the parent #GtkWindow.
+
+If a mount operation factory isn't set, g_mount_operation_new() will be
+called.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </instance-parameter>
+          <parameter name="callback"
+                     transfer-ownership="none"
+                     scope="notified"
+                     closure="1"
+                     destroy="2">
+            <doc xml:space="preserve">a #GtkSourceMountOperationFactory to call when a
+  #GMountOperation is needed.</doc>
+            <type name="MountOperationFactory"
+                  c:type="GtkSourceMountOperationFactory"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none">
+            <doc xml:space="preserve">the data to pass to the @callback function.</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="notify"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1"
+                     scope="async">
+            <doc xml:space="preserve">function to call on @user_data when the @callback is no
+  longer needed, or %NULL.</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="compression-type"
+                version="3.14"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The compression type.</doc>
+        <type name="CompressionType"/>
+      </property>
+      <property name="encoding" version="3.14" transfer-ownership="none">
+        <doc xml:space="preserve">The character encoding, initially %NULL. After a successful file
+loading or saving operation, the encoding is non-%NULL.</doc>
+        <type name="Encoding"/>
+      </property>
+      <property name="location"
+                version="3.14"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The location.</doc>
+        <type name="Gio.File"/>
+      </property>
+      <property name="newline-type" version="3.14" transfer-ownership="none">
+        <doc xml:space="preserve">The line ending type.</doc>
+        <type name="NewlineType"/>
+      </property>
+      <property name="read-only" version="3.18" transfer-ownership="none">
+        <doc xml:space="preserve">Whether the file is read-only or not. The value of this property is
+not updated automatically (there is no file monitors).</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv">
+        <type name="FilePrivate" c:type="GtkSourceFilePrivate*"/>
+      </field>
+    </class>
+    <record name="FileClass"
+            c:type="GtkSourceFileClass"
+            glib:is-gtype-struct-for="File">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="padding">
+        <array zero-terminated="0" c:type="gpointer" fixed-size="10">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <class name="FileLoader"
+           c:symbol-prefix="file_loader"
+           c:type="GtkSourceFileLoader"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceFileLoader"
+           glib:get-type="gtk_source_file_loader_get_type"
+           glib:type-struct="FileLoaderClass">
+      <constructor name="new"
+                   c:identifier="gtk_source_file_loader_new"
+                   version="3.14">
+        <doc xml:space="preserve">Creates a new #GtkSourceFileLoader object. The contents is read from the
+#GtkSourceFile's location. If not already done, call
+gtk_source_file_set_location() before calling this constructor. The previous
+location is anyway not needed, because as soon as the file loading begins,
+the @buffer is emptied.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #GtkSourceFileLoader object.</doc>
+          <type name="FileLoader" c:type="GtkSourceFileLoader*"/>
+        </return-value>
+        <parameters>
+          <parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">the #GtkSourceBuffer to load the contents into.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </parameter>
+          <parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">the #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_from_stream"
+                   c:identifier="gtk_source_file_loader_new_from_stream"
+                   version="3.14">
+        <doc xml:space="preserve">Creates a new #GtkSourceFileLoader object. The contents is read from @stream.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #GtkSourceFileLoader object.</doc>
+          <type name="FileLoader" c:type="GtkSourceFileLoader*"/>
+        </return-value>
+        <parameters>
+          <parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">the #GtkSourceBuffer to load the contents into.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </parameter>
+          <parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">the #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </parameter>
+          <parameter name="stream" transfer-ownership="none">
+            <doc xml:space="preserve">the #GInputStream to load, e.g. stdin.</doc>
+            <type name="Gio.InputStream" c:type="GInputStream*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="get_buffer"
+              c:identifier="gtk_source_file_loader_get_buffer"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #GtkSourceBuffer to load the contents into.</doc>
+          <type name="Buffer" c:type="GtkSourceBuffer*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="loader" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileLoader.</doc>
+            <type name="FileLoader" c:type="GtkSourceFileLoader*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_compression_type"
+              c:identifier="gtk_source_file_loader_get_compression_type"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the detected compression type.</doc>
+          <type name="CompressionType" c:type="GtkSourceCompressionType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="loader" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileLoader.</doc>
+            <type name="FileLoader" c:type="GtkSourceFileLoader*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_encoding"
+              c:identifier="gtk_source_file_loader_get_encoding"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the detected file encoding.</doc>
+          <type name="Encoding" c:type="const GtkSourceEncoding*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="loader" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileLoader.</doc>
+            <type name="FileLoader" c:type="GtkSourceFileLoader*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_file"
+              c:identifier="gtk_source_file_loader_get_file"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #GtkSourceFile.</doc>
+          <type name="File" c:type="GtkSourceFile*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="loader" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileLoader.</doc>
+            <type name="FileLoader" c:type="GtkSourceFileLoader*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_input_stream"
+              c:identifier="gtk_source_file_loader_get_input_stream"
+              version="3.14">
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the #GInputStream to load, or %NULL
+if a #GFile is used.</doc>
+          <type name="Gio.InputStream" c:type="GInputStream*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="loader" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileLoader.</doc>
+            <type name="FileLoader" c:type="GtkSourceFileLoader*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_location"
+              c:identifier="gtk_source_file_loader_get_location"
+              version="3.14">
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the #GFile to load, or %NULL
+if an input stream is used.</doc>
+          <type name="Gio.File" c:type="GFile*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="loader" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileLoader.</doc>
+            <type name="FileLoader" c:type="GtkSourceFileLoader*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_newline_type"
+              c:identifier="gtk_source_file_loader_get_newline_type"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the detected newline type.</doc>
+          <type name="NewlineType" c:type="GtkSourceNewlineType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="loader" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileLoader.</doc>
+            <type name="FileLoader" c:type="GtkSourceFileLoader*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="load_async"
+              c:identifier="gtk_source_file_loader_load_async"
+              version="3.14">
+        <doc xml:space="preserve">Loads asynchronously the file or input stream contents into the
+#GtkSourceBuffer. See the #GAsyncResult documentation to know how to use this
+function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="loader" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileLoader.</doc>
+            <type name="FileLoader" c:type="GtkSourceFileLoader*"/>
+          </instance-parameter>
+          <parameter name="io_priority" transfer-ownership="none">
+            <doc xml:space="preserve">the I/O priority of the request. E.g. %G_PRIORITY_LOW,
+  %G_PRIORITY_DEFAULT or %G_PRIORITY_HIGH.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="cancellable"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">optional #GCancellable object, %NULL to ignore.</doc>
+            <type name="Gio.Cancellable" c:type="GCancellable*"/>
+          </parameter>
+          <parameter name="progress_callback"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1"
+                     scope="notified"
+                     closure="3"
+                     destroy="4">
+            <doc xml:space="preserve">function to call back with
+  progress information, or %NULL if progress information is not needed.</doc>
+            <type name="Gio.FileProgressCallback"
+                  c:type="GFileProgressCallback"/>
+          </parameter>
+          <parameter name="progress_callback_data" transfer-ownership="none">
+            <doc xml:space="preserve">user data to pass to @progress_callback.</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="progress_callback_notify"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1"
+                     scope="async">
+            <doc xml:space="preserve">function to call on
+  @progress_callback_data when the @progress_callback is no longer needed, or
+  %NULL.</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="callback"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1"
+                     scope="async"
+                     closure="6">
+            <doc xml:space="preserve">a #GAsyncReadyCallback to call when the request is
+  satisfied.</doc>
+            <type name="Gio.AsyncReadyCallback" c:type="GAsyncReadyCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none">
+            <doc xml:space="preserve">user data to pass to @callback.</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="load_finish"
+              c:identifier="gtk_source_file_loader_load_finish"
+              version="3.14"
+              throws="1">
+        <doc xml:space="preserve">Finishes a file loading started with gtk_source_file_loader_load_async().
+
+If the contents has been loaded, the following #GtkSourceFile properties will
+be updated: the location, the encoding, the newline type and the compression
+type.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the contents has been loaded successfully.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="loader" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileLoader.</doc>
+            <type name="FileLoader" c:type="GtkSourceFileLoader*"/>
+          </instance-parameter>
+          <parameter name="result" transfer-ownership="none">
+            <doc xml:space="preserve">a #GAsyncResult.</doc>
+            <type name="Gio.AsyncResult" c:type="GAsyncResult*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_candidate_encodings"
+              c:identifier="gtk_source_file_loader_set_candidate_encodings"
+              version="3.14">
+        <doc xml:space="preserve">Sets the candidate encodings for the file loading. The encodings are tried in
+the same order as the list.
+
+For convenience, @candidate_encodings can contain duplicates. Only the first
+occurrence of a duplicated encoding is kept in the list.
+
+By default the candidate encodings are (in that order in the list):
+1. If set, the #GtkSourceFile's encoding as returned by
+gtk_source_file_get_encoding().
+2. The default candidates as returned by
+gtk_source_encoding_get_default_candidates().</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="loader" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileLoader.</doc>
+            <type name="FileLoader" c:type="GtkSourceFileLoader*"/>
+          </instance-parameter>
+          <parameter name="candidate_encodings" transfer-ownership="none">
+            <doc xml:space="preserve">a list of
+  #GtkSourceEncoding&lt;!-- --&gt;s.</doc>
+            <type name="GLib.SList" c:type="GSList*">
+              <type name="Encoding"/>
+            </type>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="buffer"
+                version="3.14"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The #GtkSourceBuffer to load the contents into. The
+#GtkSourceFileLoader object has a weak reference to the buffer.</doc>
+        <type name="Buffer"/>
+      </property>
+      <property name="file"
+                version="3.14"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The #GtkSourceFile. The #GtkSourceFileLoader object has a weak
+reference to the file.</doc>
+        <type name="File"/>
+      </property>
+      <property name="input-stream"
+                version="3.14"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The #GInputStream to load. Useful for reading stdin. If this property
+is set, the #GtkSourceFileLoader:location property is ignored.</doc>
+        <type name="Gio.InputStream"/>
+      </property>
+      <property name="location"
+                version="3.14"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The #GFile to load. If the #GtkSourceFileLoader:input-stream is
+%NULL, by default the location is taken from the #GtkSourceFile at
+construction time.</doc>
+        <type name="Gio.File"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv">
+        <type name="FileLoaderPrivate" c:type="GtkSourceFileLoaderPrivate*"/>
+      </field>
+    </class>
+    <record name="FileLoaderClass"
+            c:type="GtkSourceFileLoaderClass"
+            glib:is-gtype-struct-for="FileLoader">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="padding">
+        <array zero-terminated="0" c:type="gpointer" fixed-size="10">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <enumeration name="FileLoaderError"
+                 glib:type-name="GtkSourceFileLoaderError"
+                 glib:get-type="gtk_source_file_loader_error_get_type"
+                 c:type="GtkSourceFileLoaderError"
+                 glib:error-domain="gtk-source-file-loader-error">
+      <doc xml:space="preserve">An error code used with the %GTK_SOURCE_FILE_LOADER_ERROR domain.</doc>
+      <member name="too_big"
+              value="0"
+              c:identifier="GTK_SOURCE_FILE_LOADER_ERROR_TOO_BIG"
+              glib:nick="too-big">
+        <doc xml:space="preserve">The file is too big.</doc>
+      </member>
+      <member name="encoding_auto_detection_failed"
+              value="1"
+              c:identifier="GTK_SOURCE_FILE_LOADER_ERROR_ENCODING_AUTO_DETECTION_FAILED"
+              glib:nick="encoding-auto-detection-failed">
+        <doc xml:space="preserve">It is not
+possible to detect the encoding automatically.</doc>
+      </member>
+      <member name="conversion_fallback"
+              value="2"
+              c:identifier="GTK_SOURCE_FILE_LOADER_ERROR_CONVERSION_FALLBACK"
+              glib:nick="conversion-fallback">
+        <doc xml:space="preserve">There was an encoding
+conversion error and it was needed to use a fallback character.</doc>
+      </member>
+      <function name="quark" c:identifier="gtk_source_file_loader_error_quark">
+        <return-value transfer-ownership="none">
+          <type name="GLib.Quark" c:type="GQuark"/>
+        </return-value>
+      </function>
+    </enumeration>
+    <record name="FileLoaderPrivate"
+            c:type="GtkSourceFileLoaderPrivate"
+            disguised="1">
+    </record>
+    <record name="FilePrivate" c:type="GtkSourceFilePrivate" disguised="1">
+    </record>
+    <class name="FileSaver"
+           c:symbol-prefix="file_saver"
+           c:type="GtkSourceFileSaver"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceFileSaver"
+           glib:get-type="gtk_source_file_saver_get_type"
+           glib:type-struct="FileSaverClass">
+      <constructor name="new"
+                   c:identifier="gtk_source_file_saver_new"
+                   version="3.14">
+        <doc xml:space="preserve">Creates a new #GtkSourceFileSaver object. The @buffer will be saved to the
+#GtkSourceFile's location.
+
+This constructor is suitable for a simple "save" operation, when the @file
+already contains a non-%NULL #GtkSourceFile:location.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #GtkSourceFileSaver object.</doc>
+          <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+        </return-value>
+        <parameters>
+          <parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">the #GtkSourceBuffer to save.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </parameter>
+          <parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">the #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_with_target"
+                   c:identifier="gtk_source_file_saver_new_with_target"
+                   version="3.14">
+        <doc xml:space="preserve">Creates a new #GtkSourceFileSaver object with a target location. When the
+file saving is finished successfully, @target_location is set to the @file's
+#GtkSourceFile:location property. If an error occurs, the previous valid
+location is still available in #GtkSourceFile.
+
+This constructor is suitable for a "save as" operation, or for saving a new
+buffer for the first time.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #GtkSourceFileSaver object.</doc>
+          <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+        </return-value>
+        <parameters>
+          <parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">the #GtkSourceBuffer to save.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </parameter>
+          <parameter name="file" transfer-ownership="none">
+            <doc xml:space="preserve">the #GtkSourceFile.</doc>
+            <type name="File" c:type="GtkSourceFile*"/>
+          </parameter>
+          <parameter name="target_location" transfer-ownership="none">
+            <doc xml:space="preserve">the #GFile where to save the buffer to.</doc>
+            <type name="Gio.File" c:type="GFile*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="get_buffer"
+              c:identifier="gtk_source_file_saver_get_buffer"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #GtkSourceBuffer to save.</doc>
+          <type name="Buffer" c:type="GtkSourceBuffer*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="saver" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileSaver.</doc>
+            <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_compression_type"
+              c:identifier="gtk_source_file_saver_get_compression_type"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the compression type.</doc>
+          <type name="CompressionType" c:type="GtkSourceCompressionType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="saver" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileSaver.</doc>
+            <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_encoding"
+              c:identifier="gtk_source_file_saver_get_encoding"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the encoding.</doc>
+          <type name="Encoding" c:type="const GtkSourceEncoding*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="saver" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileSaver.</doc>
+            <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_file"
+              c:identifier="gtk_source_file_saver_get_file"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #GtkSourceFile.</doc>
+          <type name="File" c:type="GtkSourceFile*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="saver" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileSaver.</doc>
+            <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_flags"
+              c:identifier="gtk_source_file_saver_get_flags"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the flags.</doc>
+          <type name="FileSaverFlags" c:type="GtkSourceFileSaverFlags"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="saver" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileSaver.</doc>
+            <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_location"
+              c:identifier="gtk_source_file_saver_get_location"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #GFile where to save the buffer to.</doc>
+          <type name="Gio.File" c:type="GFile*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="saver" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileSaver.</doc>
+            <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_newline_type"
+              c:identifier="gtk_source_file_saver_get_newline_type"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the newline type.</doc>
+          <type name="NewlineType" c:type="GtkSourceNewlineType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="saver" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileSaver.</doc>
+            <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="save_async"
+              c:identifier="gtk_source_file_saver_save_async"
+              version="3.14">
+        <doc xml:space="preserve">Saves asynchronously the buffer into the file. See the #GAsyncResult
+documentation to know how to use this function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="saver" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileSaver.</doc>
+            <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+          </instance-parameter>
+          <parameter name="io_priority" transfer-ownership="none">
+            <doc xml:space="preserve">the I/O priority of the request. E.g. %G_PRIORITY_LOW,
+  %G_PRIORITY_DEFAULT or %G_PRIORITY_HIGH.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="cancellable"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">optional #GCancellable object, %NULL to ignore.</doc>
+            <type name="Gio.Cancellable" c:type="GCancellable*"/>
+          </parameter>
+          <parameter name="progress_callback"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1"
+                     scope="notified"
+                     closure="3"
+                     destroy="4">
+            <doc xml:space="preserve">function to call back with
+  progress information, or %NULL if progress information is not needed.</doc>
+            <type name="Gio.FileProgressCallback"
+                  c:type="GFileProgressCallback"/>
+          </parameter>
+          <parameter name="progress_callback_data" transfer-ownership="none">
+            <doc xml:space="preserve">user data to pass to @progress_callback.</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="progress_callback_notify"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1"
+                     scope="async">
+            <doc xml:space="preserve">function to call on
+  @progress_callback_data when the @progress_callback is no longer needed, or
+  %NULL.</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="callback"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1"
+                     scope="async"
+                     closure="6">
+            <doc xml:space="preserve">a #GAsyncReadyCallback to call when the request is
+  satisfied.</doc>
+            <type name="Gio.AsyncReadyCallback" c:type="GAsyncReadyCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none">
+            <doc xml:space="preserve">user data to pass to @callback.</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="save_finish"
+              c:identifier="gtk_source_file_saver_save_finish"
+              version="3.14"
+              throws="1">
+        <doc xml:space="preserve">Finishes a file saving started with gtk_source_file_saver_save_async().
+
+If the file has been saved successfully, the following #GtkSourceFile
+properties will be updated: the location, the encoding, the newline type and
+the compression type.
+
+Since the 3.20 version, gtk_text_buffer_set_modified() is called with %FALSE
+if the file has been saved successfully.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the file was saved successfully.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="saver" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileSaver.</doc>
+            <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+          </instance-parameter>
+          <parameter name="result" transfer-ownership="none">
+            <doc xml:space="preserve">a #GAsyncResult.</doc>
+            <type name="Gio.AsyncResult" c:type="GAsyncResult*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_compression_type"
+              c:identifier="gtk_source_file_saver_set_compression_type"
+              version="3.14">
+        <doc xml:space="preserve">Sets the compression type. By default the compression type is taken from the
+#GtkSourceFile.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="saver" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileSaver.</doc>
+            <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+          </instance-parameter>
+          <parameter name="compression_type" transfer-ownership="none">
+            <doc xml:space="preserve">the new compression type.</doc>
+            <type name="CompressionType" c:type="GtkSourceCompressionType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_encoding"
+              c:identifier="gtk_source_file_saver_set_encoding"
+              version="3.14">
+        <doc xml:space="preserve">Sets the encoding. If @encoding is %NULL, the UTF-8 encoding will be set.
+By default the encoding is taken from the #GtkSourceFile.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="saver" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileSaver.</doc>
+            <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+          </instance-parameter>
+          <parameter name="encoding"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">the new encoding, or %NULL for UTF-8.</doc>
+            <type name="Encoding" c:type="const GtkSourceEncoding*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_flags"
+              c:identifier="gtk_source_file_saver_set_flags"
+              version="3.14">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="saver" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileSaver.</doc>
+            <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+          </instance-parameter>
+          <parameter name="flags" transfer-ownership="none">
+            <doc xml:space="preserve">the new flags.</doc>
+            <type name="FileSaverFlags" c:type="GtkSourceFileSaverFlags"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_newline_type"
+              c:identifier="gtk_source_file_saver_set_newline_type"
+              version="3.14">
+        <doc xml:space="preserve">Sets the newline type. By default the newline type is taken from the
+#GtkSourceFile.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="saver" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceFileSaver.</doc>
+            <type name="FileSaver" c:type="GtkSourceFileSaver*"/>
+          </instance-parameter>
+          <parameter name="newline_type" transfer-ownership="none">
+            <doc xml:space="preserve">the new newline type.</doc>
+            <type name="NewlineType" c:type="GtkSourceNewlineType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="buffer"
+                version="3.14"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The #GtkSourceBuffer to save. The #GtkSourceFileSaver object has a
+weak reference to the buffer.</doc>
+        <type name="Buffer"/>
+      </property>
+      <property name="compression-type"
+                version="3.14"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The compression type.</doc>
+        <type name="CompressionType"/>
+      </property>
+      <property name="encoding"
+                version="3.14"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The file's encoding.</doc>
+        <type name="Encoding"/>
+      </property>
+      <property name="file"
+                version="3.14"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The #GtkSourceFile. The #GtkSourceFileSaver object has a weak
+reference to the file.</doc>
+        <type name="File"/>
+      </property>
+      <property name="flags"
+                version="3.14"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">File saving flags.</doc>
+        <type name="FileSaverFlags"/>
+      </property>
+      <property name="location"
+                version="3.14"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The #GFile where to save the buffer. By default the location is taken
+from the #GtkSourceFile at construction time.</doc>
+        <type name="Gio.File"/>
+      </property>
+      <property name="newline-type"
+                version="3.14"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The newline type.</doc>
+        <type name="NewlineType"/>
+      </property>
+      <field name="object">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv">
+        <type name="FileSaverPrivate" c:type="GtkSourceFileSaverPrivate*"/>
+      </field>
+    </class>
+    <record name="FileSaverClass"
+            c:type="GtkSourceFileSaverClass"
+            glib:is-gtype-struct-for="FileSaver">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="padding">
+        <array zero-terminated="0" c:type="gpointer" fixed-size="10">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <enumeration name="FileSaverError"
+                 version="3.14"
+                 glib:type-name="GtkSourceFileSaverError"
+                 glib:get-type="gtk_source_file_saver_error_get_type"
+                 c:type="GtkSourceFileSaverError"
+                 glib:error-domain="gtk-source-file-saver-error">
+      <doc xml:space="preserve">An error code used with the %GTK_SOURCE_FILE_SAVER_ERROR domain.</doc>
+      <member name="invalid_chars"
+              value="0"
+              c:identifier="GTK_SOURCE_FILE_SAVER_ERROR_INVALID_CHARS"
+              glib:nick="invalid-chars">
+        <doc xml:space="preserve">The buffer contains invalid
+  characters.</doc>
+      </member>
+      <member name="externally_modified"
+              value="1"
+              c:identifier="GTK_SOURCE_FILE_SAVER_ERROR_EXTERNALLY_MODIFIED"
+              glib:nick="externally-modified">
+        <doc xml:space="preserve">The file is externally
+  modified.</doc>
+      </member>
+      <function name="quark" c:identifier="gtk_source_file_saver_error_quark">
+        <return-value transfer-ownership="none">
+          <type name="GLib.Quark" c:type="GQuark"/>
+        </return-value>
+      </function>
+    </enumeration>
+    <bitfield name="FileSaverFlags"
+              version="3.14"
+              glib:type-name="GtkSourceFileSaverFlags"
+              glib:get-type="gtk_source_file_saver_flags_get_type"
+              c:type="GtkSourceFileSaverFlags">
+      <doc xml:space="preserve">Flags to define the behavior of a #GtkSourceFileSaver.</doc>
+      <member name="none"
+              value="0"
+              c:identifier="GTK_SOURCE_FILE_SAVER_FLAGS_NONE"
+              glib:nick="none">
+        <doc xml:space="preserve">No flags.</doc>
+      </member>
+      <member name="ignore_invalid_chars"
+              value="1"
+              c:identifier="GTK_SOURCE_FILE_SAVER_FLAGS_IGNORE_INVALID_CHARS"
+              glib:nick="ignore-invalid-chars">
+        <doc xml:space="preserve">Ignore invalid characters.</doc>
+      </member>
+      <member name="ignore_modification_time"
+              value="2"
+              c:identifier="GTK_SOURCE_FILE_SAVER_FLAGS_IGNORE_MODIFICATION_TIME"
+              glib:nick="ignore-modification-time">
+        <doc xml:space="preserve">Save file despite external modifications.</doc>
+      </member>
+      <member name="create_backup"
+              value="4"
+              c:identifier="GTK_SOURCE_FILE_SAVER_FLAGS_CREATE_BACKUP"
+              glib:nick="create-backup">
+        <doc xml:space="preserve">Create a backup before saving the file.</doc>
+      </member>
+    </bitfield>
+    <record name="FileSaverPrivate"
+            c:type="GtkSourceFileSaverPrivate"
+            disguised="1">
+    </record>
+    <class name="Gutter"
+           c:symbol-prefix="gutter"
+           c:type="GtkSourceGutter"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceGutter"
+           glib:get-type="gtk_source_gutter_get_type"
+           glib:type-struct="GutterClass">
+      <method name="get_padding"
+              c:identifier="gtk_source_gutter_get_padding"
+              deprecated="1"
+              deprecated-version="3.12">
+        <doc-deprecated xml:space="preserve">Use gtk_source_gutter_renderer_get_padding() instead.</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="gutter" transfer-ownership="none">
+            <type name="Gutter" c:type="GtkSourceGutter*"/>
+          </instance-parameter>
+          <parameter name="xpad" transfer-ownership="none">
+            <type name="gint" c:type="gint*"/>
+          </parameter>
+          <parameter name="ypad" transfer-ownership="none">
+            <type name="gint" c:type="gint*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_renderer_at_pos"
+              c:identifier="gtk_source_gutter_get_renderer_at_pos">
+        <doc xml:space="preserve">Finds the #GtkSourceGutterRenderer at (x, y).</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the renderer at (x, y) or %NULL.</doc>
+          <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="gutter" transfer-ownership="none">
+            <doc xml:space="preserve">A #GtkSourceGutter.</doc>
+            <type name="Gutter" c:type="GtkSourceGutter*"/>
+          </instance-parameter>
+          <parameter name="x" transfer-ownership="none">
+            <doc xml:space="preserve">The x position to get identified.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="y" transfer-ownership="none">
+            <doc xml:space="preserve">The y position to get identified.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_window"
+              c:identifier="gtk_source_gutter_get_window"
+              version="2.8"
+              deprecated="1"
+              deprecated-version="3.12">
+        <doc xml:space="preserve">Get the #GdkWindow of the gutter. The window will only be available when the
+gutter has at least one, non-zero width, cell renderer packed.</doc>
+        <doc-deprecated xml:space="preserve">Use gtk_text_view_get_window() instead.</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #GdkWindow of the gutter, or %NULL
+if the gutter has no window.</doc>
+          <type name="Gdk.Window" c:type="GdkWindow*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="gutter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutter.</doc>
+            <type name="Gutter" c:type="GtkSourceGutter*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="insert"
+              c:identifier="gtk_source_gutter_insert"
+              version="3.0">
+        <doc xml:space="preserve">Insert @renderer into the gutter. If @renderer is yet unowned then gutter
+claims its ownership. Otherwise just increases renderer's reference count.
+@renderer cannot be already inserted to another gutter.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if operation succeeded. Otherwise %FALSE.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="gutter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutter.</doc>
+            <type name="Gutter" c:type="GtkSourceGutter*"/>
+          </instance-parameter>
+          <parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a gutter renderer (must inherit from #GtkSourceGutterRenderer).</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </parameter>
+          <parameter name="position" transfer-ownership="none">
+            <doc xml:space="preserve">the renderer position.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="queue_draw"
+              c:identifier="gtk_source_gutter_queue_draw"
+              version="2.8">
+        <doc xml:space="preserve">Invalidates the drawable area of the gutter. You can use this to force a
+redraw of the gutter if something has changed and needs to be redrawn.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="gutter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutter.</doc>
+            <type name="Gutter" c:type="GtkSourceGutter*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="remove"
+              c:identifier="gtk_source_gutter_remove"
+              version="2.8">
+        <doc xml:space="preserve">Removes @renderer from @gutter.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="gutter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutter.</doc>
+            <type name="Gutter" c:type="GtkSourceGutter*"/>
+          </instance-parameter>
+          <parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer.</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="reorder"
+              c:identifier="gtk_source_gutter_reorder"
+              version="2.8">
+        <doc xml:space="preserve">Reorders @renderer in @gutter to new @position.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="gutter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer.</doc>
+            <type name="Gutter" c:type="GtkSourceGutter*"/>
+          </instance-parameter>
+          <parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkCellRenderer.</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </parameter>
+          <parameter name="position" transfer-ownership="none">
+            <doc xml:space="preserve">the new renderer position.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_padding"
+              c:identifier="gtk_source_gutter_set_padding"
+              deprecated="1"
+              deprecated-version="3.12">
+        <doc-deprecated xml:space="preserve">Use gtk_source_gutter_renderer_set_padding() instead.</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="gutter" transfer-ownership="none">
+            <type name="Gutter" c:type="GtkSourceGutter*"/>
+          </instance-parameter>
+          <parameter name="xpad" transfer-ownership="none">
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="ypad" transfer-ownership="none">
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="view"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The #GtkSourceView of the gutter.</doc>
+        <type name="View"/>
+      </property>
+      <property name="window-type"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The text window type on which the window is placed.</doc>
+        <type name="Gtk.TextWindowType"/>
+      </property>
+      <property name="xpad"
+                deprecated="1"
+                deprecated-version="3.12"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The x-padding.</doc>
+        <doc-deprecated xml:space="preserve">Use the #GtkSourceGutterRenderer's
+#GtkSourceGutterRenderer:xpad property instead.</doc-deprecated>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="ypad"
+                deprecated="1"
+                deprecated-version="3.12"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The y-padding.</doc>
+        <doc-deprecated xml:space="preserve">Use the #GtkSourceGutterRenderer's
+#GtkSourceGutterRenderer:ypad property instead.</doc-deprecated>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv">
+        <type name="GutterPrivate" c:type="GtkSourceGutterPrivate*"/>
+      </field>
+    </class>
+    <record name="GutterClass"
+            c:type="GtkSourceGutterClass"
+            glib:is-gtype-struct-for="Gutter">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+    </record>
+    <record name="GutterPrivate" c:type="GtkSourceGutterPrivate" disguised="1">
+    </record>
+    <class name="GutterRenderer"
+           c:symbol-prefix="gutter_renderer"
+           c:type="GtkSourceGutterRenderer"
+           parent="GObject.InitiallyUnowned"
+           abstract="1"
+           glib:type-name="GtkSourceGutterRenderer"
+           glib:get-type="gtk_source_gutter_renderer_get_type"
+           glib:type-struct="GutterRendererClass">
+      <virtual-method name="activate" invoker="activate">
+        <doc xml:space="preserve">Emits the #GtkSourceGutterRenderer::activate signal of the renderer. This is
+called from #GtkSourceGutter and should never have to be called manually.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter at the start of the line where the renderer is activated</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle of the cell area where the renderer is activated</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+          <parameter name="event" transfer-ownership="none">
+            <doc xml:space="preserve">the event that triggered the activation</doc>
+            <type name="Gdk.Event" c:type="GdkEvent*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="begin" invoker="begin">
+        <doc xml:space="preserve">Called when drawing a region begins. The region to be drawn is indicated
+by @start and @end. The purpose is to allow the implementation to precompute
+some state before the draw method is called for each cell.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="cr" transfer-ownership="none">
+            <doc xml:space="preserve">a #cairo_t</doc>
+            <type name="cairo.Context" c:type="cairo_t*"/>
+          </parameter>
+          <parameter name="background_area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+          <parameter name="cell_area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="change_buffer">
+        <doc xml:space="preserve">This is called when the text buffer changes for @renderer.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer.</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="old_buffer"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">the old #GtkTextBuffer.</doc>
+            <type name="Gtk.TextBuffer" c:type="GtkTextBuffer*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="change_view">
+        <doc xml:space="preserve">This is called when the text view changes for @renderer.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer.</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="old_view"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">the old #GtkTextView.</doc>
+            <type name="Gtk.TextView" c:type="GtkTextView*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="draw" invoker="draw">
+        <doc xml:space="preserve">Main renderering method. Implementations should implement this method to draw
+onto the cairo context. The @background_area indicates the total area of the
+cell to be drawn. The @cell_area indicates the area where content can be
+drawn (text, images, etc).
+
+The @background_area is the @cell_area plus the padding on each side (two
+times the #GtkSourceGutterRenderer:xpad horizontally and two times the
+#GtkSourceGutterRenderer:ypad vertically, so that the @cell_area is centered
+inside @background_area).
+
+The @state argument indicates the current state of the renderer and should
+be taken into account to properly draw the different possible states
+(cursor, prelit, selected) if appropriate.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="cr" transfer-ownership="none">
+            <doc xml:space="preserve">the cairo render context</doc>
+            <type name="cairo.Context" c:type="cairo_t*"/>
+          </parameter>
+          <parameter name="background_area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle indicating the total area to be drawn</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+          <parameter name="cell_area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle indicating the area to draw content</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="state" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRendererState</doc>
+            <type name="GutterRendererState"
+                  c:type="GtkSourceGutterRendererState"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="end" invoker="end">
+        <doc xml:space="preserve">Called when drawing a region of lines has ended.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="query_activatable" invoker="query_activatable">
+        <doc xml:space="preserve">Get whether the renderer is activatable at the location in @event. This is
+called from #GtkSourceGutter to determine whether a renderer is activatable
+using the mouse pointer.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the renderer can be activated, %FALSE otherwise</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter at the start of the line to be activated</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle of the cell area to be activated</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+          <parameter name="event" transfer-ownership="none">
+            <doc xml:space="preserve">the event that triggered the query</doc>
+            <type name="Gdk.Event" c:type="GdkEvent*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="query_data" invoker="query_data">
+        <doc xml:space="preserve">Emit the #GtkSourceGutterRenderer::query-data signal. This function is called
+to query for data just before rendering a cell. This is called from the
+#GtkSourceGutter.  Implementations can override the default signal handler or
+can connect a signal handler externally to the
+#GtkSourceGutterRenderer::query-data signal.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer.</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="state" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRendererState.</doc>
+            <type name="GutterRendererState"
+                  c:type="GtkSourceGutterRendererState"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="query_tooltip" invoker="query_tooltip">
+        <doc xml:space="preserve">Emits the #GtkSourceGutterRenderer::query-tooltip signal. This function is
+called from #GtkSourceGutter. Implementations can override the default signal
+handler or can connect to the signal externally.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the tooltip has been set, %FALSE otherwise</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer.</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle.</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+          <parameter name="x" transfer-ownership="none">
+            <doc xml:space="preserve">The x position of the tooltip.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="y" transfer-ownership="none">
+            <doc xml:space="preserve">The y position of the tooltip.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="tooltip" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTooltip.</doc>
+            <type name="Gtk.Tooltip" c:type="GtkTooltip*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="queue_draw" invoker="queue_draw">
+        <doc xml:space="preserve">Emits the #GtkSourceGutterRenderer::queue-draw signal of the renderer. Call
+this from an implementation to inform that the renderer has changed such that
+it needs to redraw.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <method name="activate"
+              c:identifier="gtk_source_gutter_renderer_activate">
+        <doc xml:space="preserve">Emits the #GtkSourceGutterRenderer::activate signal of the renderer. This is
+called from #GtkSourceGutter and should never have to be called manually.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter at the start of the line where the renderer is activated</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle of the cell area where the renderer is activated</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+          <parameter name="event" transfer-ownership="none">
+            <doc xml:space="preserve">the event that triggered the activation</doc>
+            <type name="Gdk.Event" c:type="GdkEvent*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="begin" c:identifier="gtk_source_gutter_renderer_begin">
+        <doc xml:space="preserve">Called when drawing a region begins. The region to be drawn is indicated
+by @start and @end. The purpose is to allow the implementation to precompute
+some state before the draw method is called for each cell.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="cr" transfer-ownership="none">
+            <doc xml:space="preserve">a #cairo_t</doc>
+            <type name="cairo.Context" c:type="cairo_t*"/>
+          </parameter>
+          <parameter name="background_area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+          <parameter name="cell_area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="draw" c:identifier="gtk_source_gutter_renderer_draw">
+        <doc xml:space="preserve">Main renderering method. Implementations should implement this method to draw
+onto the cairo context. The @background_area indicates the total area of the
+cell to be drawn. The @cell_area indicates the area where content can be
+drawn (text, images, etc).
+
+The @background_area is the @cell_area plus the padding on each side (two
+times the #GtkSourceGutterRenderer:xpad horizontally and two times the
+#GtkSourceGutterRenderer:ypad vertically, so that the @cell_area is centered
+inside @background_area).
+
+The @state argument indicates the current state of the renderer and should
+be taken into account to properly draw the different possible states
+(cursor, prelit, selected) if appropriate.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="cr" transfer-ownership="none">
+            <doc xml:space="preserve">the cairo render context</doc>
+            <type name="cairo.Context" c:type="cairo_t*"/>
+          </parameter>
+          <parameter name="background_area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle indicating the total area to be drawn</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+          <parameter name="cell_area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle indicating the area to draw content</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="state" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRendererState</doc>
+            <type name="GutterRendererState"
+                  c:type="GtkSourceGutterRendererState"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="end" c:identifier="gtk_source_gutter_renderer_end">
+        <doc xml:space="preserve">Called when drawing a region of lines has ended.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_alignment"
+              c:identifier="gtk_source_gutter_renderer_get_alignment">
+        <doc xml:space="preserve">Get the x-alignment and y-alignment of the gutter renderer.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="xalign"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">return location for the x-alignment (can be %NULL)</doc>
+            <type name="gfloat" c:type="gfloat*"/>
+          </parameter>
+          <parameter name="yalign"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">return location for the y-alignment (can be %NULL)</doc>
+            <type name="gfloat" c:type="gfloat*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_alignment_mode"
+              c:identifier="gtk_source_gutter_renderer_get_alignment_mode">
+        <doc xml:space="preserve">Get the alignment mode. The alignment mode describes the manner in which the
+renderer is aligned (see :xalign and :yalign).</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #GtkSourceGutterRendererAlignmentMode</doc>
+          <type name="GutterRendererAlignmentMode"
+                c:type="GtkSourceGutterRendererAlignmentMode"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_background"
+              c:identifier="gtk_source_gutter_renderer_get_background">
+        <doc xml:space="preserve">Get the background color of the renderer.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the background color is set, %FALSE otherwise</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="color"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">return value for a #GdkRGBA</doc>
+            <type name="Gdk.RGBA" c:type="GdkRGBA*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_padding"
+              c:identifier="gtk_source_gutter_renderer_get_padding">
+        <doc xml:space="preserve">Get the x-padding and y-padding of the gutter renderer.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="xpad"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">return location for the x-padding (can be %NULL)</doc>
+            <type name="gint" c:type="gint*"/>
+          </parameter>
+          <parameter name="ypad"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">return location for the y-padding (can be %NULL)</doc>
+            <type name="gint" c:type="gint*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_size"
+              c:identifier="gtk_source_gutter_renderer_get_size">
+        <doc xml:space="preserve">Get the size of the renderer.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the size of the renderer.</doc>
+          <type name="gint" c:type="gint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_view"
+              c:identifier="gtk_source_gutter_renderer_get_view">
+        <doc xml:space="preserve">Get the view associated to the gutter renderer</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #GtkTextView</doc>
+          <type name="Gtk.TextView" c:type="GtkTextView*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_visible"
+              c:identifier="gtk_source_gutter_renderer_get_visible">
+        <doc xml:space="preserve">Get whether the gutter renderer is visible.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the renderer is visible, %FALSE otherwise</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_window_type"
+              c:identifier="gtk_source_gutter_renderer_get_window_type">
+        <doc xml:space="preserve">Get the #GtkTextWindowType associated with the gutter renderer.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #GtkTextWindowType</doc>
+          <type name="Gtk.TextWindowType" c:type="GtkTextWindowType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="query_activatable"
+              c:identifier="gtk_source_gutter_renderer_query_activatable">
+        <doc xml:space="preserve">Get whether the renderer is activatable at the location in @event. This is
+called from #GtkSourceGutter to determine whether a renderer is activatable
+using the mouse pointer.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the renderer can be activated, %FALSE otherwise</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter at the start of the line to be activated</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle of the cell area to be activated</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+          <parameter name="event" transfer-ownership="none">
+            <doc xml:space="preserve">the event that triggered the query</doc>
+            <type name="Gdk.Event" c:type="GdkEvent*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="query_data"
+              c:identifier="gtk_source_gutter_renderer_query_data">
+        <doc xml:space="preserve">Emit the #GtkSourceGutterRenderer::query-data signal. This function is called
+to query for data just before rendering a cell. This is called from the
+#GtkSourceGutter.  Implementations can override the default signal handler or
+can connect a signal handler externally to the
+#GtkSourceGutterRenderer::query-data signal.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer.</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="state" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRendererState.</doc>
+            <type name="GutterRendererState"
+                  c:type="GtkSourceGutterRendererState"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="query_tooltip"
+              c:identifier="gtk_source_gutter_renderer_query_tooltip">
+        <doc xml:space="preserve">Emits the #GtkSourceGutterRenderer::query-tooltip signal. This function is
+called from #GtkSourceGutter. Implementations can override the default signal
+handler or can connect to the signal externally.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the tooltip has been set, %FALSE otherwise</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer.</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle.</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+          <parameter name="x" transfer-ownership="none">
+            <doc xml:space="preserve">The x position of the tooltip.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="y" transfer-ownership="none">
+            <doc xml:space="preserve">The y position of the tooltip.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="tooltip" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTooltip.</doc>
+            <type name="Gtk.Tooltip" c:type="GtkTooltip*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="queue_draw"
+              c:identifier="gtk_source_gutter_renderer_queue_draw">
+        <doc xml:space="preserve">Emits the #GtkSourceGutterRenderer::queue-draw signal of the renderer. Call
+this from an implementation to inform that the renderer has changed such that
+it needs to redraw.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_alignment"
+              c:identifier="gtk_source_gutter_renderer_set_alignment">
+        <doc xml:space="preserve">Set the alignment of the gutter renderer. Both @xalign and @yalign can be
+-1, which means the values will not be changed (this allows changing only
+one of the values).
+
+@xalign is the horizontal alignment. Set to 0 for a left alignment. 1 for a
+right alignment. And 0.5 for centering the cells. @yalign is the vertical
+alignment. Set to 0 for a top alignment. 1 for a bottom alignment.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="xalign" transfer-ownership="none">
+            <doc xml:space="preserve">the x-alignment</doc>
+            <type name="gfloat" c:type="gfloat"/>
+          </parameter>
+          <parameter name="yalign" transfer-ownership="none">
+            <doc xml:space="preserve">the y-alignment</doc>
+            <type name="gfloat" c:type="gfloat"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_alignment_mode"
+              c:identifier="gtk_source_gutter_renderer_set_alignment_mode">
+        <doc xml:space="preserve">Set the alignment mode. The alignment mode describes the manner in which the
+renderer is aligned (see :xalign and :yalign).</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="mode" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRendererAlignmentMode</doc>
+            <type name="GutterRendererAlignmentMode"
+                  c:type="GtkSourceGutterRendererAlignmentMode"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_background"
+              c:identifier="gtk_source_gutter_renderer_set_background">
+        <doc xml:space="preserve">Set the background color of the renderer. If @color is set to %NULL, the
+renderer will not have a background color.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="color"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a #GdkRGBA or %NULL</doc>
+            <type name="Gdk.RGBA" c:type="const GdkRGBA*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_padding"
+              c:identifier="gtk_source_gutter_renderer_set_padding">
+        <doc xml:space="preserve">Set the padding of the gutter renderer. Both @xpad and @ypad can be
+-1, which means the values will not be changed (this allows changing only
+one of the values).
+
+@xpad is the left and right padding. @ypad is the top and bottom padding.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="xpad" transfer-ownership="none">
+            <doc xml:space="preserve">the x-padding</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="ypad" transfer-ownership="none">
+            <doc xml:space="preserve">the y-padding</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_size"
+              c:identifier="gtk_source_gutter_renderer_set_size">
+        <doc xml:space="preserve">Sets the size of the renderer. A value of -1 specifies that the size
+is to be determined dynamically.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="size" transfer-ownership="none">
+            <doc xml:space="preserve">the size</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_visible"
+              c:identifier="gtk_source_gutter_renderer_set_visible">
+        <doc xml:space="preserve">Set whether the gutter renderer is visible.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+            <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+          </instance-parameter>
+          <parameter name="visible" transfer-ownership="none">
+            <doc xml:space="preserve">the visibility</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="alignment-mode"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The alignment mode of the renderer. This can be used to indicate
+that in the case a cell spans multiple lines (due to text wrapping)
+the alignment should work on either the full cell, the first line
+or the last line.</doc>
+        <type name="GutterRendererAlignmentMode"/>
+      </property>
+      <property name="background-rgba" writable="1" transfer-ownership="none">
+        <type name="Gdk.RGBA"/>
+      </property>
+      <property name="background-set"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="size"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="view" transfer-ownership="none">
+        <doc xml:space="preserve">The view on which the renderer is placed.</doc>
+        <type name="Gtk.TextView"/>
+      </property>
+      <property name="visible"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The visibility of the renderer.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="window-type" transfer-ownership="none">
+        <doc xml:space="preserve">The window type of the view on which the renderer is placed (left,
+or right).</doc>
+        <type name="Gtk.TextWindowType"/>
+      </property>
+      <property name="xalign"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The horizontal alignment of the renderer. Set to 0 for a left
+alignment. 1 for a right alignment. And 0.5 for centering the cells.
+A value lower than 0 doesn't modify the alignment.</doc>
+        <type name="gfloat" c:type="gfloat"/>
+      </property>
+      <property name="xpad"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The left and right padding of the renderer.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="yalign"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The vertical alignment of the renderer. Set to 0 for a top
+alignment. 1 for a bottom alignment. And 0.5 for centering the cells.
+A value lower than 0 doesn't modify the alignment.</doc>
+        <type name="gfloat" c:type="gfloat"/>
+      </property>
+      <property name="ypad"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The top and bottom padding of the renderer.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.InitiallyUnowned" c:type="GInitiallyUnowned"/>
+      </field>
+      <field name="priv" readable="0" private="1">
+        <type name="GutterRendererPrivate"
+              c:type="GtkSourceGutterRendererPrivate*"/>
+      </field>
+      <glib:signal name="activate" when="last">
+        <doc xml:space="preserve">The ::activate signal is emitted when the renderer is
+activated.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter"/>
+          </parameter>
+          <parameter name="area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle</doc>
+            <type name="Gdk.Rectangle"/>
+          </parameter>
+          <parameter name="event" transfer-ownership="none">
+            <doc xml:space="preserve">the event that caused the activation</doc>
+            <type name="Gdk.Event"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="query-activatable" when="last">
+        <doc xml:space="preserve">The ::query-activatable signal is emitted when the renderer
+can possibly be activated.</doc>
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter"/>
+          </parameter>
+          <parameter name="area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle</doc>
+            <type name="Gdk.Rectangle"/>
+          </parameter>
+          <parameter name="event" transfer-ownership="none">
+            <doc xml:space="preserve">the #GdkEvent that is causing the activatable query</doc>
+            <type name="Gdk.Event"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="query-data" when="last">
+        <doc xml:space="preserve">The ::query-data signal is emitted when the renderer needs
+to be filled with data just before a cell is drawn. This can
+be used by general renderer implementations to allow render
+data to be filled in externally.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter"/>
+          </parameter>
+          <parameter name="state" transfer-ownership="none">
+            <doc xml:space="preserve">the renderer state</doc>
+            <type name="GutterRendererState"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="query-tooltip" when="last">
+        <doc xml:space="preserve">The ::query-tooltip signal is emitted when the renderer can
+show a tooltip.</doc>
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter"/>
+          </parameter>
+          <parameter name="area" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRectangle</doc>
+            <type name="Gdk.Rectangle"/>
+          </parameter>
+          <parameter name="x" transfer-ownership="none">
+            <doc xml:space="preserve">the x position (in window coordinates)</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="y" transfer-ownership="none">
+            <doc xml:space="preserve">the y position (in window coordinates)</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="tooltip" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTooltip</doc>
+            <type name="Gtk.Tooltip"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="queue-draw" when="last">
+        <doc xml:space="preserve">The ::queue-draw signal is emitted when the renderer needs
+to be redrawn. Use gtk_source_gutter_renderer_queue_draw()
+to emit this signal from an implementation of the
+#GtkSourceGutterRenderer interface.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+    </class>
+    <enumeration name="GutterRendererAlignmentMode"
+                 glib:type-name="GtkSourceGutterRendererAlignmentMode"
+                 glib:get-type="gtk_source_gutter_renderer_alignment_mode_get_type"
+                 c:type="GtkSourceGutterRendererAlignmentMode">
+      <doc xml:space="preserve">The alignment mode of the renderer, when a cell spans multiple lines (due to
+text wrapping).</doc>
+      <member name="cell"
+              value="0"
+              c:identifier="GTK_SOURCE_GUTTER_RENDERER_ALIGNMENT_MODE_CELL"
+              glib:nick="cell">
+        <doc xml:space="preserve">The full cell.</doc>
+      </member>
+      <member name="first"
+              value="1"
+              c:identifier="GTK_SOURCE_GUTTER_RENDERER_ALIGNMENT_MODE_FIRST"
+              glib:nick="first">
+        <doc xml:space="preserve">The first line.</doc>
+      </member>
+      <member name="last"
+              value="2"
+              c:identifier="GTK_SOURCE_GUTTER_RENDERER_ALIGNMENT_MODE_LAST"
+              glib:nick="last">
+        <doc xml:space="preserve">The last line.</doc>
+      </member>
+    </enumeration>
+    <record name="GutterRendererClass"
+            c:type="GtkSourceGutterRendererClass"
+            glib:is-gtype-struct-for="GutterRenderer">
+      <field name="parent_class">
+        <type name="GObject.InitiallyUnownedClass"
+              c:type="GInitiallyUnownedClass"/>
+      </field>
+      <field name="begin">
+        <callback name="begin">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="renderer" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+              <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+            </parameter>
+            <parameter name="cr" transfer-ownership="none">
+              <doc xml:space="preserve">a #cairo_t</doc>
+              <type name="cairo.Context" c:type="cairo_t*"/>
+            </parameter>
+            <parameter name="background_area" transfer-ownership="none">
+              <doc xml:space="preserve">a #GdkRectangle</doc>
+              <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+            </parameter>
+            <parameter name="cell_area" transfer-ownership="none">
+              <doc xml:space="preserve">a #GdkRectangle</doc>
+              <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+            </parameter>
+            <parameter name="start" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkTextIter</doc>
+              <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+            </parameter>
+            <parameter name="end" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkTextIter</doc>
+              <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="draw">
+        <callback name="draw">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="renderer" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+              <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+            </parameter>
+            <parameter name="cr" transfer-ownership="none">
+              <doc xml:space="preserve">the cairo render context</doc>
+              <type name="cairo.Context" c:type="cairo_t*"/>
+            </parameter>
+            <parameter name="background_area" transfer-ownership="none">
+              <doc xml:space="preserve">a #GdkRectangle indicating the total area to be drawn</doc>
+              <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+            </parameter>
+            <parameter name="cell_area" transfer-ownership="none">
+              <doc xml:space="preserve">a #GdkRectangle indicating the area to draw content</doc>
+              <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+            </parameter>
+            <parameter name="start" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkTextIter</doc>
+              <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+            </parameter>
+            <parameter name="end" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkTextIter</doc>
+              <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+            </parameter>
+            <parameter name="state" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceGutterRendererState</doc>
+              <type name="GutterRendererState"
+                    c:type="GtkSourceGutterRendererState"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="end">
+        <callback name="end">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="renderer" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+              <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="change_view">
+        <callback name="change_view">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="renderer" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceGutterRenderer.</doc>
+              <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+            </parameter>
+            <parameter name="old_view"
+                       transfer-ownership="none"
+                       nullable="1"
+                       allow-none="1">
+              <doc xml:space="preserve">the old #GtkTextView.</doc>
+              <type name="Gtk.TextView" c:type="GtkTextView*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="change_buffer">
+        <callback name="change_buffer">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="renderer" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceGutterRenderer.</doc>
+              <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+            </parameter>
+            <parameter name="old_buffer"
+                       transfer-ownership="none"
+                       nullable="1"
+                       allow-none="1">
+              <doc xml:space="preserve">the old #GtkTextBuffer.</doc>
+              <type name="Gtk.TextBuffer" c:type="GtkTextBuffer*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="query_activatable">
+        <callback name="query_activatable">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE if the renderer can be activated, %FALSE otherwise</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </return-value>
+          <parameters>
+            <parameter name="renderer" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+              <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+            </parameter>
+            <parameter name="iter" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkTextIter at the start of the line to be activated</doc>
+              <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+            </parameter>
+            <parameter name="area" transfer-ownership="none">
+              <doc xml:space="preserve">a #GdkRectangle of the cell area to be activated</doc>
+              <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+            </parameter>
+            <parameter name="event" transfer-ownership="none">
+              <doc xml:space="preserve">the event that triggered the query</doc>
+              <type name="Gdk.Event" c:type="GdkEvent*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="activate">
+        <callback name="activate">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="renderer" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+              <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+            </parameter>
+            <parameter name="iter" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkTextIter at the start of the line where the renderer is activated</doc>
+              <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+            </parameter>
+            <parameter name="area" transfer-ownership="none">
+              <doc xml:space="preserve">a #GdkRectangle of the cell area where the renderer is activated</doc>
+              <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+            </parameter>
+            <parameter name="event" transfer-ownership="none">
+              <doc xml:space="preserve">the event that triggered the activation</doc>
+              <type name="Gdk.Event" c:type="GdkEvent*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="queue_draw">
+        <callback name="queue_draw">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="renderer" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceGutterRenderer</doc>
+              <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="query_tooltip">
+        <callback name="query_tooltip">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE if the tooltip has been set, %FALSE otherwise</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </return-value>
+          <parameters>
+            <parameter name="renderer" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceGutterRenderer.</doc>
+              <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+            </parameter>
+            <parameter name="iter" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkTextIter.</doc>
+              <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+            </parameter>
+            <parameter name="area" transfer-ownership="none">
+              <doc xml:space="preserve">a #GdkRectangle.</doc>
+              <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+            </parameter>
+            <parameter name="x" transfer-ownership="none">
+              <doc xml:space="preserve">The x position of the tooltip.</doc>
+              <type name="gint" c:type="gint"/>
+            </parameter>
+            <parameter name="y" transfer-ownership="none">
+              <doc xml:space="preserve">The y position of the tooltip.</doc>
+              <type name="gint" c:type="gint"/>
+            </parameter>
+            <parameter name="tooltip" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkTooltip.</doc>
+              <type name="Gtk.Tooltip" c:type="GtkTooltip*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="query_data">
+        <callback name="query_data">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="renderer" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceGutterRenderer.</doc>
+              <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+            </parameter>
+            <parameter name="start" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkTextIter.</doc>
+              <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+            </parameter>
+            <parameter name="end" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkTextIter.</doc>
+              <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+            </parameter>
+            <parameter name="state" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceGutterRendererState.</doc>
+              <type name="GutterRendererState"
+                    c:type="GtkSourceGutterRendererState"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+    </record>
+    <class name="GutterRendererPixbuf"
+           c:symbol-prefix="gutter_renderer_pixbuf"
+           c:type="GtkSourceGutterRendererPixbuf"
+           parent="GutterRenderer"
+           glib:type-name="GtkSourceGutterRendererPixbuf"
+           glib:get-type="gtk_source_gutter_renderer_pixbuf_get_type"
+           glib:type-struct="GutterRendererPixbufClass">
+      <constructor name="new"
+                   c:identifier="gtk_source_gutter_renderer_pixbuf_new">
+        <doc xml:space="preserve">Create a new #GtkSourceGutterRendererPixbuf.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">A #GtkSourceGutterRenderer</doc>
+          <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+        </return-value>
+      </constructor>
+      <method name="get_gicon"
+              c:identifier="gtk_source_gutter_renderer_pixbuf_get_gicon">
+        <doc xml:space="preserve">Get the gicon of the renderer</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #GIcon</doc>
+          <type name="Gio.Icon" c:type="GIcon*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRendererPixbuf</doc>
+            <type name="GutterRendererPixbuf"
+                  c:type="GtkSourceGutterRendererPixbuf*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_icon_name"
+              c:identifier="gtk_source_gutter_renderer_pixbuf_get_icon_name">
+        <return-value transfer-ownership="none">
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <type name="GutterRendererPixbuf"
+                  c:type="GtkSourceGutterRendererPixbuf*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_pixbuf"
+              c:identifier="gtk_source_gutter_renderer_pixbuf_get_pixbuf">
+        <doc xml:space="preserve">Get the pixbuf of the renderer.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #GdkPixbuf</doc>
+          <type name="GdkPixbuf.Pixbuf" c:type="GdkPixbuf*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRendererPixbuf</doc>
+            <type name="GutterRendererPixbuf"
+                  c:type="GtkSourceGutterRendererPixbuf*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_stock_id"
+              c:identifier="gtk_source_gutter_renderer_pixbuf_get_stock_id"
+              deprecated="1"
+              deprecated-version="3.10">
+        <doc-deprecated xml:space="preserve">Don't use this function.</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the stock id.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRendererPixbuf</doc>
+            <type name="GutterRendererPixbuf"
+                  c:type="GtkSourceGutterRendererPixbuf*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_gicon"
+              c:identifier="gtk_source_gutter_renderer_pixbuf_set_gicon">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRendererPixbuf</doc>
+            <type name="GutterRendererPixbuf"
+                  c:type="GtkSourceGutterRendererPixbuf*"/>
+          </instance-parameter>
+          <parameter name="icon"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">the icon</doc>
+            <type name="Gio.Icon" c:type="GIcon*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_icon_name"
+              c:identifier="gtk_source_gutter_renderer_pixbuf_set_icon_name">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRendererPixbuf</doc>
+            <type name="GutterRendererPixbuf"
+                  c:type="GtkSourceGutterRendererPixbuf*"/>
+          </instance-parameter>
+          <parameter name="icon_name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">the icon name</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_pixbuf"
+              c:identifier="gtk_source_gutter_renderer_pixbuf_set_pixbuf">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRendererPixbuf</doc>
+            <type name="GutterRendererPixbuf"
+                  c:type="GtkSourceGutterRendererPixbuf*"/>
+          </instance-parameter>
+          <parameter name="pixbuf"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">the pixbuf</doc>
+            <type name="GdkPixbuf.Pixbuf" c:type="GdkPixbuf*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_stock_id"
+              c:identifier="gtk_source_gutter_renderer_pixbuf_set_stock_id"
+              deprecated="1"
+              deprecated-version="3.10">
+        <doc-deprecated xml:space="preserve">Don't use this function.</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRendererPixbuf</doc>
+            <type name="GutterRendererPixbuf"
+                  c:type="GtkSourceGutterRendererPixbuf*"/>
+          </instance-parameter>
+          <parameter name="stock_id"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">the stock id</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="gicon" writable="1" transfer-ownership="none">
+        <type name="Gio.Icon"/>
+      </property>
+      <property name="icon-name" writable="1" transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="pixbuf" writable="1" transfer-ownership="none">
+        <type name="GdkPixbuf.Pixbuf"/>
+      </property>
+      <property name="stock-id"
+                deprecated="1"
+                deprecated-version="3.10"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The stock id.</doc>
+        <doc-deprecated xml:space="preserve">Don't use this property.</doc-deprecated>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <field name="parent" readable="0" private="1">
+        <type name="GutterRenderer" c:type="GtkSourceGutterRenderer"/>
+      </field>
+      <field name="priv" readable="0" private="1">
+        <type name="GutterRendererPixbufPrivate"
+              c:type="GtkSourceGutterRendererPixbufPrivate*"/>
+      </field>
+    </class>
+    <record name="GutterRendererPixbufClass"
+            c:type="GtkSourceGutterRendererPixbufClass"
+            glib:is-gtype-struct-for="GutterRendererPixbuf">
+      <field name="parent_class" readable="0" private="1">
+        <type name="GutterRendererClass"
+              c:type="GtkSourceGutterRendererClass"/>
+      </field>
+    </record>
+    <record name="GutterRendererPixbufPrivate"
+            c:type="GtkSourceGutterRendererPixbufPrivate"
+            disguised="1">
+    </record>
+    <record name="GutterRendererPrivate"
+            c:type="GtkSourceGutterRendererPrivate"
+            disguised="1">
+    </record>
+    <bitfield name="GutterRendererState"
+              glib:type-name="GtkSourceGutterRendererState"
+              glib:get-type="gtk_source_gutter_renderer_state_get_type"
+              c:type="GtkSourceGutterRendererState">
+      <member name="normal"
+              value="0"
+              c:identifier="GTK_SOURCE_GUTTER_RENDERER_STATE_NORMAL"
+              glib:nick="normal">
+        <doc xml:space="preserve">normal state</doc>
+      </member>
+      <member name="cursor"
+              value="1"
+              c:identifier="GTK_SOURCE_GUTTER_RENDERER_STATE_CURSOR"
+              glib:nick="cursor">
+        <doc xml:space="preserve">area in the renderer represents the
+line on which the insert cursor is currently positioned</doc>
+      </member>
+      <member name="prelit"
+              value="2"
+              c:identifier="GTK_SOURCE_GUTTER_RENDERER_STATE_PRELIT"
+              glib:nick="prelit">
+        <doc xml:space="preserve">the mouse pointer is currently
+over the activatable area of the renderer</doc>
+      </member>
+      <member name="selected"
+              value="4"
+              c:identifier="GTK_SOURCE_GUTTER_RENDERER_STATE_SELECTED"
+              glib:nick="selected">
+        <doc xml:space="preserve">area in the renderer represents
+a line in the buffer which contains part of the selection</doc>
+      </member>
+    </bitfield>
+    <class name="GutterRendererText"
+           c:symbol-prefix="gutter_renderer_text"
+           c:type="GtkSourceGutterRendererText"
+           parent="GutterRenderer"
+           glib:type-name="GtkSourceGutterRendererText"
+           glib:get-type="gtk_source_gutter_renderer_text_get_type"
+           glib:type-struct="GutterRendererTextClass">
+      <constructor name="new"
+                   c:identifier="gtk_source_gutter_renderer_text_new">
+        <doc xml:space="preserve">Create a new #GtkSourceGutterRendererText.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">A #GtkSourceGutterRenderer</doc>
+          <type name="GutterRenderer" c:type="GtkSourceGutterRenderer*"/>
+        </return-value>
+      </constructor>
+      <method name="measure"
+              c:identifier="gtk_source_gutter_renderer_text_measure">
+        <doc xml:space="preserve">Measures the text provided using the pango layout used by the
+#GtkSourceGutterRendererText.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRendererText.</doc>
+            <type name="GutterRendererText"
+                  c:type="GtkSourceGutterRendererText*"/>
+          </instance-parameter>
+          <parameter name="text" transfer-ownership="none">
+            <doc xml:space="preserve">the text to measure.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="width"
+                     direction="out"
+                     caller-allocates="0"
+                     transfer-ownership="full"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">location to store the width of the text in pixels,
+  or %NULL.</doc>
+            <type name="gint" c:type="gint*"/>
+          </parameter>
+          <parameter name="height"
+                     direction="out"
+                     caller-allocates="0"
+                     transfer-ownership="full"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">location to store the height of the text in
+  pixels, or %NULL.</doc>
+            <type name="gint" c:type="gint*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="measure_markup"
+              c:identifier="gtk_source_gutter_renderer_text_measure_markup">
+        <doc xml:space="preserve">Measures the pango markup provided using the pango layout used by the
+#GtkSourceGutterRendererText.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceGutterRendererText.</doc>
+            <type name="GutterRendererText"
+                  c:type="GtkSourceGutterRendererText*"/>
+          </instance-parameter>
+          <parameter name="markup" transfer-ownership="none">
+            <doc xml:space="preserve">the pango markup to measure.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="width"
+                     direction="out"
+                     caller-allocates="0"
+                     transfer-ownership="full"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">location to store the width of the text in pixels,
+  or %NULL.</doc>
+            <type name="gint" c:type="gint*"/>
+          </parameter>
+          <parameter name="height"
+                     direction="out"
+                     caller-allocates="0"
+                     transfer-ownership="full"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">location to store the height of the text in
+  pixels, or %NULL.</doc>
+            <type name="gint" c:type="gint*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_markup"
+              c:identifier="gtk_source_gutter_renderer_text_set_markup">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <type name="GutterRendererText"
+                  c:type="GtkSourceGutterRendererText*"/>
+          </instance-parameter>
+          <parameter name="markup" transfer-ownership="none">
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="length" transfer-ownership="none">
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_text"
+              c:identifier="gtk_source_gutter_renderer_text_set_text">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="renderer" transfer-ownership="none">
+            <type name="GutterRendererText"
+                  c:type="GtkSourceGutterRendererText*"/>
+          </instance-parameter>
+          <parameter name="text" transfer-ownership="none">
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="length" transfer-ownership="none">
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="markup"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="text"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <field name="parent" readable="0" private="1">
+        <type name="GutterRenderer" c:type="GtkSourceGutterRenderer"/>
+      </field>
+      <field name="priv" readable="0" private="1">
+        <type name="GutterRendererTextPrivate"
+              c:type="GtkSourceGutterRendererTextPrivate*"/>
+      </field>
+    </class>
+    <record name="GutterRendererTextClass"
+            c:type="GtkSourceGutterRendererTextClass"
+            glib:is-gtype-struct-for="GutterRendererText">
+      <field name="parent_class" readable="0" private="1">
+        <type name="GutterRendererClass"
+              c:type="GtkSourceGutterRendererClass"/>
+      </field>
+    </record>
+    <record name="GutterRendererTextPrivate"
+            c:type="GtkSourceGutterRendererTextPrivate"
+            disguised="1">
+    </record>
+    <class name="Language"
+           c:symbol-prefix="language"
+           c:type="GtkSourceLanguage"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceLanguage"
+           glib:get-type="gtk_source_language_get_type"
+           glib:type-struct="LanguageClass">
+      <method name="get_globs" c:identifier="gtk_source_language_get_globs">
+        <doc xml:space="preserve">Returns the globs associated to this language. This is just
+an utility wrapper around gtk_source_language_get_metadata() to
+retrieve the "globs" metadata property and split it into an array.</doc>
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">
+a newly-allocated %NULL terminated array containing the globs or %NULL
+if no globs are found.
+The returned array must be freed with g_strfreev().</doc>
+          <array c:type="gchar**">
+            <type name="utf8"/>
+          </array>
+        </return-value>
+        <parameters>
+          <instance-parameter name="language" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguage.</doc>
+            <type name="Language" c:type="GtkSourceLanguage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_hidden" c:identifier="gtk_source_language_get_hidden">
+        <doc xml:space="preserve">Returns whether the language should be hidden from the user.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the language should be hidden, %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="language" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguage</doc>
+            <type name="Language" c:type="GtkSourceLanguage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_id" c:identifier="gtk_source_language_get_id">
+        <doc xml:space="preserve">Returns the ID of the language. The ID is not locale-dependent.
+The returned string is owned by @language and should not be freed
+or modified.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the ID of @language.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="language" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguage.</doc>
+            <type name="Language" c:type="GtkSourceLanguage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_metadata"
+              c:identifier="gtk_source_language_get_metadata">
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">value of property @name stored in
+the metadata of @language or %NULL if language does not contain the
+specified metadata property.
+The returned string is owned by @language and should not be freed
+or modified.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="language" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguage.</doc>
+            <type name="Language" c:type="GtkSourceLanguage*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">metadata property name.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_mime_types"
+              c:identifier="gtk_source_language_get_mime_types">
+        <doc xml:space="preserve">Returns the mime types associated to this language. This is just
+an utility wrapper around gtk_source_language_get_metadata() to
+retrieve the "mimetypes" metadata property and split it into an
+array.</doc>
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">
+a newly-allocated %NULL terminated array containing the mime types
+or %NULL if no mime types are found.
+The returned array must be freed with g_strfreev().</doc>
+          <array c:type="gchar**">
+            <type name="utf8"/>
+          </array>
+        </return-value>
+        <parameters>
+          <instance-parameter name="language" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguage.</doc>
+            <type name="Language" c:type="GtkSourceLanguage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_name" c:identifier="gtk_source_language_get_name">
+        <doc xml:space="preserve">Returns the localized name of the language.
+The returned string is owned by @language and should not be freed
+or modified.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the name of @language.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="language" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguage.</doc>
+            <type name="Language" c:type="GtkSourceLanguage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_section"
+              c:identifier="gtk_source_language_get_section">
+        <doc xml:space="preserve">Returns the localized section of the language.
+Each language belong to a section (ex. HTML belogs to the
+Markup section).
+The returned string is owned by @language and should not be freed
+or modified.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the section of @language.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="language" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguage.</doc>
+            <type name="Language" c:type="GtkSourceLanguage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_style_fallback"
+              c:identifier="gtk_source_language_get_style_fallback"
+              version="3.4">
+        <doc xml:space="preserve">Returns the ID of the style to use if the specified @style_id
+is not present in the current style scheme.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the ID of the style to use if the
+specified @style_id is not present in the current style scheme or %NULL
+if the style has no fallback defined.
+The returned string is owned by the @language and must not be modified.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="language" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguage.</doc>
+            <type name="Language" c:type="GtkSourceLanguage*"/>
+          </instance-parameter>
+          <parameter name="style_id" transfer-ownership="none">
+            <doc xml:space="preserve">a style ID.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_style_ids"
+              c:identifier="gtk_source_language_get_style_ids">
+        <doc xml:space="preserve">Returns the ids of the styles defined by this @language.</doc>
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">
+a newly-allocated %NULL terminated array containing ids of the
+styles defined by this @language or %NULL if no style is defined.
+The returned array must be freed with g_strfreev().</doc>
+          <array c:type="gchar**">
+            <type name="utf8"/>
+          </array>
+        </return-value>
+        <parameters>
+          <instance-parameter name="language" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguage.</doc>
+            <type name="Language" c:type="GtkSourceLanguage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_style_name"
+              c:identifier="gtk_source_language_get_style_name">
+        <doc xml:space="preserve">Returns the name of the style with ID @style_id defined by this @language.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the name of the style with ID @style_id
+defined by this @language or %NULL if the style has no name or there is no
+style with ID @style_id defined by this @language.
+The returned string is owned by the @language and must not be modified.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="language" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguage.</doc>
+            <type name="Language" c:type="GtkSourceLanguage*"/>
+          </instance-parameter>
+          <parameter name="style_id" transfer-ownership="none">
+            <doc xml:space="preserve">a style ID.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="hidden" transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="id" transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="name" transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="section" transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <field name="parent_instance">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv">
+        <type name="LanguagePrivate" c:type="GtkSourceLanguagePrivate*"/>
+      </field>
+    </class>
+    <record name="LanguageClass"
+            c:type="GtkSourceLanguageClass"
+            glib:is-gtype-struct-for="Language">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_gtk_source_reserved1" introspectable="0">
+        <callback name="_gtk_source_reserved1">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved2" introspectable="0">
+        <callback name="_gtk_source_reserved2">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <class name="LanguageManager"
+           c:symbol-prefix="language_manager"
+           c:type="GtkSourceLanguageManager"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceLanguageManager"
+           glib:get-type="gtk_source_language_manager_get_type"
+           glib:type-struct="LanguageManagerClass">
+      <constructor name="new" c:identifier="gtk_source_language_manager_new">
+        <doc xml:space="preserve">Creates a new language manager. If you do not need more than one language
+manager or a private language manager instance then use
+gtk_source_language_manager_get_default() instead.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #GtkSourceLanguageManager.</doc>
+          <type name="LanguageManager" c:type="GtkSourceLanguageManager*"/>
+        </return-value>
+      </constructor>
+      <function name="get_default"
+                c:identifier="gtk_source_language_manager_get_default">
+        <doc xml:space="preserve">Returns the default #GtkSourceLanguageManager instance.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #GtkSourceLanguageManager.
+Return value is owned by GtkSourceView library and must not be unref'ed.</doc>
+          <type name="LanguageManager" c:type="GtkSourceLanguageManager*"/>
+        </return-value>
+      </function>
+      <method name="get_language"
+              c:identifier="gtk_source_language_manager_get_language">
+        <doc xml:space="preserve">Gets the #GtkSourceLanguage identified by the given @id in the language
+manager.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">a #GtkSourceLanguage, or %NULL
+if there is no language identified by the given @id. Return value is
+owned by @lm and should not be freed.</doc>
+          <type name="Language" c:type="GtkSourceLanguage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="lm" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguageManager.</doc>
+            <type name="LanguageManager" c:type="GtkSourceLanguageManager*"/>
+          </instance-parameter>
+          <parameter name="id" transfer-ownership="none">
+            <doc xml:space="preserve">a language id.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_language_ids"
+              c:identifier="gtk_source_language_manager_get_language_ids">
+        <doc xml:space="preserve">Returns the ids of the available languages.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">
+a %NULL-terminated array of strings containing the ids of the available
+languages or %NULL if no language is available.
+The array is sorted alphabetically according to the language name.
+The array is owned by @lm and must not be modified.</doc>
+          <array c:type="gchar**">
+            <type name="utf8"/>
+          </array>
+        </return-value>
+        <parameters>
+          <instance-parameter name="lm" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguageManager.</doc>
+            <type name="LanguageManager" c:type="GtkSourceLanguageManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_search_path"
+              c:identifier="gtk_source_language_manager_get_search_path">
+        <doc xml:space="preserve">Gets the list directories where @lm looks for language files.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%NULL-terminated array
+containg a list of language files directories.
+The array is owned by @lm and must not be modified.</doc>
+          <array c:type="gchar**">
+            <type name="utf8"/>
+          </array>
+        </return-value>
+        <parameters>
+          <instance-parameter name="lm" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguageManager.</doc>
+            <type name="LanguageManager" c:type="GtkSourceLanguageManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="guess_language"
+              c:identifier="gtk_source_language_manager_guess_language"
+              version="2.4">
+        <doc xml:space="preserve">Picks a #GtkSourceLanguage for given file name and content type,
+according to the information in lang files. Either @filename or
+@content_type may be %NULL. This function can be used as follows:
+
+&lt;informalexample&gt;&lt;programlisting&gt;
+  GtkSourceLanguage *lang;
+  lang = gtk_source_language_manager_guess_language (filename, NULL);
+  gtk_source_buffer_set_language (buffer, lang);
+&lt;/programlisting&gt;&lt;/informalexample&gt;
+
+or
+
+&lt;informalexample&gt;&lt;programlisting&gt;
+  GtkSourceLanguage *lang = NULL;
+  gboolean result_uncertain;
+  gchar *content_type;
+
+  content_type = g_content_type_guess (filename, NULL, 0, &amp;result_uncertain);
+  if (result_uncertain)
+    {
+      g_free (content_type);
+      content_type = NULL;
+    }
+
+  lang = gtk_source_language_manager_guess_language (manager, filename, content_type);
+  gtk_source_buffer_set_language (buffer, lang);
+
+  g_free (content_type);
+&lt;/programlisting&gt;&lt;/informalexample&gt;
+
+etc. Use gtk_source_language_get_mime_types() and gtk_source_language_get_globs()
+if you need full control over file -&gt; language mapping.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">a #GtkSourceLanguage, or %NULL if there
+is no suitable language for given @filename and/or @content_type. Return
+value is owned by @lm and should not be freed.</doc>
+          <type name="Language" c:type="GtkSourceLanguage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="lm" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguageManager.</doc>
+            <type name="LanguageManager" c:type="GtkSourceLanguageManager*"/>
+          </instance-parameter>
+          <parameter name="filename"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a filename in Glib filename encoding, or %NULL.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="content_type"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a content type (as in GIO API), or %NULL.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_search_path"
+              c:identifier="gtk_source_language_manager_set_search_path">
+        <doc xml:space="preserve">Sets the list of directories where the @lm looks for
+language files.
+If @dirs is %NULL, the search path is reset to default.
+
+&lt;note&gt;
+  &lt;para&gt;
+    At the moment this function can be called only before the
+    language files are loaded for the first time. In practice
+    to set a custom search path for a #GtkSourceLanguageManager,
+    you have to call this function right after creating it.
+  &lt;/para&gt;
+&lt;/note&gt;</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="lm" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceLanguageManager.</doc>
+            <type name="LanguageManager" c:type="GtkSourceLanguageManager*"/>
+          </instance-parameter>
+          <parameter name="dirs"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">
+a %NULL-terminated array of strings or %NULL.</doc>
+            <array c:type="gchar**">
+              <type name="utf8" c:type="gchar*"/>
+            </array>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="language-ids" transfer-ownership="none">
+        <array>
+          <type name="utf8"/>
+        </array>
+      </property>
+      <property name="search-path" writable="1" transfer-ownership="none">
+        <array>
+          <type name="utf8"/>
+        </array>
+      </property>
+      <field name="parent_instance">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv">
+        <type name="LanguageManagerPrivate"
+              c:type="GtkSourceLanguageManagerPrivate*"/>
+      </field>
+    </class>
+    <record name="LanguageManagerClass"
+            c:type="GtkSourceLanguageManagerClass"
+            glib:is-gtype-struct-for="LanguageManager">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_gtk_source_reserved1" introspectable="0">
+        <callback name="_gtk_source_reserved1">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved2" introspectable="0">
+        <callback name="_gtk_source_reserved2">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved3" introspectable="0">
+        <callback name="_gtk_source_reserved3">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved4" introspectable="0">
+        <callback name="_gtk_source_reserved4">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <record name="LanguageManagerPrivate"
+            c:type="GtkSourceLanguageManagerPrivate"
+            disguised="1">
+    </record>
+    <record name="LanguagePrivate"
+            c:type="GtkSourceLanguagePrivate"
+            disguised="1">
+    </record>
+    <class name="Map"
+           c:symbol-prefix="map"
+           c:type="GtkSourceMap"
+           parent="View"
+           glib:type-name="GtkSourceMap"
+           glib:get-type="gtk_source_map_get_type"
+           glib:type-struct="MapClass">
+      <implements name="Atk.ImplementorIface"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.Scrollable"/>
+      <constructor name="new" c:identifier="gtk_source_map_new" version="3.18">
+        <doc xml:space="preserve">Creates a new #GtkSourceMap.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a new #GtkSourceMap.</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_view"
+              c:identifier="gtk_source_map_get_view"
+              version="3.18">
+        <doc xml:space="preserve">Gets the #GtkSourceMap:view property, which is the view this widget is mapping.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">a #GtkSourceView or %NULL.</doc>
+          <type name="View" c:type="GtkSourceView*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="map" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMap.</doc>
+            <type name="Map" c:type="GtkSourceMap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_view"
+              c:identifier="gtk_source_map_set_view"
+              version="3.18">
+        <doc xml:space="preserve">Sets the view that @map will be doing the mapping to.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="map" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMap</doc>
+            <type name="Map" c:type="GtkSourceMap*"/>
+          </instance-parameter>
+          <parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="font-desc" writable="1" transfer-ownership="none">
+        <type name="Pango.FontDescription"/>
+      </property>
+      <property name="view" writable="1" transfer-ownership="none">
+        <type name="View"/>
+      </property>
+      <field name="parent_instance">
+        <type name="View" c:type="GtkSourceView"/>
+      </field>
+    </class>
+    <record name="MapClass"
+            c:type="GtkSourceMapClass"
+            glib:is-gtype-struct-for="Map">
+      <field name="parent_class">
+        <type name="ViewClass" c:type="GtkSourceViewClass"/>
+      </field>
+      <field name="padding">
+        <array zero-terminated="0" c:type="gpointer" fixed-size="10">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <class name="Mark"
+           c:symbol-prefix="mark"
+           c:type="GtkSourceMark"
+           parent="Gtk.TextMark"
+           glib:type-name="GtkSourceMark"
+           glib:get-type="gtk_source_mark_get_type"
+           glib:type-struct="MarkClass">
+      <constructor name="new" c:identifier="gtk_source_mark_new" version="2.2">
+        <doc xml:space="preserve">Creates a text mark. Add it to a buffer using gtk_text_buffer_add_mark().
+If name is NULL, the mark is anonymous; otherwise, the mark can be retrieved
+by name using gtk_text_buffer_get_mark().
+Normally marks are created using the utility function
+gtk_source_buffer_create_source_mark().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #GtkSourceMark that can be added using gtk_text_buffer_add_mark().</doc>
+          <type name="Mark" c:type="GtkSourceMark*"/>
+        </return-value>
+        <parameters>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">Name of the #GtkSourceMark, can be NULL when not using a name</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="category" transfer-ownership="none">
+            <doc xml:space="preserve">is used to classify marks according to common characteristics
+(e.g. all the marks representing a bookmark could belong to the "bookmark"
+category, or all the marks representing a compilation error could belong to
+"error" category).</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="get_category"
+              c:identifier="gtk_source_mark_get_category"
+              version="2.2">
+        <doc xml:space="preserve">Returns the mark category.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the category of the #GtkSourceMark.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="mark" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMark.</doc>
+            <type name="Mark" c:type="GtkSourceMark*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="next" c:identifier="gtk_source_mark_next" version="2.2">
+        <doc xml:space="preserve">Returns the next #GtkSourceMark in the buffer or %NULL if the mark
+was not added to a buffer. If there is no next mark, %NULL will be returned.
+
+If @category is %NULL, looks for marks of any category.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the next #GtkSourceMark, or %NULL.</doc>
+          <type name="Mark" c:type="GtkSourceMark*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="mark" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMark.</doc>
+            <type name="Mark" c:type="GtkSourceMark*"/>
+          </instance-parameter>
+          <parameter name="category"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a string specifying the mark category, or %NULL.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="prev" c:identifier="gtk_source_mark_prev" version="2.2">
+        <doc xml:space="preserve">Returns the previous #GtkSourceMark in the buffer or %NULL if the mark
+was not added to a buffer. If there is no previous mark, %NULL is returned.
+
+If @category is %NULL, looks for marks of any category</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the previous #GtkSourceMark, or %NULL.</doc>
+          <type name="Mark" c:type="GtkSourceMark*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="mark" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMark.</doc>
+            <type name="Mark" c:type="GtkSourceMark*"/>
+          </instance-parameter>
+          <parameter name="category" transfer-ownership="none">
+            <doc xml:space="preserve">a string specifying the mark category, or %NULL.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="category"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The category of the #GtkSourceMark, classifies the mark and controls
+which pixbuf is used and with which priority it is drawn.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <field name="parent_instance">
+        <type name="Gtk.TextMark" c:type="GtkTextMark"/>
+      </field>
+      <field name="priv">
+        <type name="MarkPrivate" c:type="GtkSourceMarkPrivate*"/>
+      </field>
+    </class>
+    <class name="MarkAttributes"
+           c:symbol-prefix="mark_attributes"
+           c:type="GtkSourceMarkAttributes"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceMarkAttributes"
+           glib:get-type="gtk_source_mark_attributes_get_type"
+           glib:type-struct="MarkAttributesClass">
+      <constructor name="new" c:identifier="gtk_source_mark_attributes_new">
+        <doc xml:space="preserve">Creates a new source mark attributes.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new source mark attributes.</doc>
+          <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+        </return-value>
+      </constructor>
+      <method name="get_background"
+              c:identifier="gtk_source_mark_attributes_get_background">
+        <doc xml:space="preserve">Stores background color in @background.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether background color for @attributes was set.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="attributes" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMarkAttributes.</doc>
+            <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+          </instance-parameter>
+          <parameter name="background"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRGBA.</doc>
+            <type name="Gdk.RGBA" c:type="GdkRGBA*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_gicon"
+              c:identifier="gtk_source_mark_attributes_get_gicon">
+        <doc xml:space="preserve">Gets a #GIcon to be used as a base for rendered icon. Note that the icon can
+be %NULL if it wasn't set earlier.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">An icon. The icon belongs to @attributes and should
+not be unreffed.</doc>
+          <type name="Gio.Icon" c:type="GIcon*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="attributes" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMarkAttributes.</doc>
+            <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_icon_name"
+              c:identifier="gtk_source_mark_attributes_get_icon_name">
+        <doc xml:space="preserve">Gets a name of an icon to be used as a base for rendered icon. Note that the
+icon name can be %NULL if it wasn't set earlier.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">An icon name. The string belongs to @attributes and
+should not be freed.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="attributes" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMarkAttributes.</doc>
+            <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_pixbuf"
+              c:identifier="gtk_source_mark_attributes_get_pixbuf">
+        <doc xml:space="preserve">Gets a #GdkPixbuf to be used as a base for rendered icon. Note that the
+pixbuf can be %NULL if it wasn't set earlier.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">A pixbuf. The pixbuf belongs to @attributes and
+should not be unreffed.</doc>
+          <type name="GdkPixbuf.Pixbuf" c:type="const GdkPixbuf*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="attributes" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMarkAttributes.</doc>
+            <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_stock_id"
+              c:identifier="gtk_source_mark_attributes_get_stock_id"
+              deprecated="1"
+              deprecated-version="3.10">
+        <doc xml:space="preserve">Gets a stock id of an icon used by this attributes. Note that the stock id can
+be %NULL if it wasn't set earlier.</doc>
+        <doc-deprecated xml:space="preserve">Don't use this function.</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">Stock id. Returned string is owned by @attributes and
+shouldn't be freed.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="attributes" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMarkAttributes.</doc>
+            <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_tooltip_markup"
+              c:identifier="gtk_source_mark_attributes_get_tooltip_markup">
+        <doc xml:space="preserve">Queries for a tooltip by emitting
+a #GtkSourceMarkAttributes::query-tooltip-markup signal. The tooltip may contain
+a markup.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">A tooltip. The returned string should be freed by
+using g_free() when done with it.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="attributes" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMarkAttributes.</doc>
+            <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+          </instance-parameter>
+          <parameter name="mark" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMark.</doc>
+            <type name="Mark" c:type="GtkSourceMark*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_tooltip_text"
+              c:identifier="gtk_source_mark_attributes_get_tooltip_text">
+        <doc xml:space="preserve">Queries for a tooltip by emitting
+a #GtkSourceMarkAttributes::query-tooltip-text signal. The tooltip is a plain
+text.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">A tooltip. The returned string should be freed by
+using g_free() when done with it.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="attributes" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMarkAttributes.</doc>
+            <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+          </instance-parameter>
+          <parameter name="mark" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMark.</doc>
+            <type name="Mark" c:type="GtkSourceMark*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="render_icon"
+              c:identifier="gtk_source_mark_attributes_render_icon">
+        <doc xml:space="preserve">Renders an icon of given size. The base of the icon is set by the last call
+to one of: gtk_source_mark_attributes_set_pixbuf(),
+gtk_source_mark_attributes_set_gicon(),
+gtk_source_mark_attributes_set_icon_name() or
+gtk_source_mark_attributes_set_stock_id(). @size cannot be lower than 1.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">A rendered pixbuf. The pixbuf belongs to @attributes
+and should not be unreffed.</doc>
+          <type name="GdkPixbuf.Pixbuf" c:type="const GdkPixbuf*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="attributes" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMarkAttributes.</doc>
+            <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+          </instance-parameter>
+          <parameter name="widget" transfer-ownership="none">
+            <doc xml:space="preserve">widget of which style settings may be used.</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+          <parameter name="size" transfer-ownership="none">
+            <doc xml:space="preserve">size of the rendered icon.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_background"
+              c:identifier="gtk_source_mark_attributes_set_background">
+        <doc xml:space="preserve">Sets background color to the one given in @background.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="attributes" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMarkAttributes.</doc>
+            <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+          </instance-parameter>
+          <parameter name="background" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkRGBA.</doc>
+            <type name="Gdk.RGBA" c:type="const GdkRGBA*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_gicon"
+              c:identifier="gtk_source_mark_attributes_set_gicon">
+        <doc xml:space="preserve">Sets an icon to be used as a base for rendered icon.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="attributes" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMarkAttributes.</doc>
+            <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+          </instance-parameter>
+          <parameter name="gicon" transfer-ownership="none">
+            <doc xml:space="preserve">a #GIcon to be used.</doc>
+            <type name="Gio.Icon" c:type="GIcon*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_icon_name"
+              c:identifier="gtk_source_mark_attributes_set_icon_name">
+        <doc xml:space="preserve">Sets a name of an icon to be used as a base for rendered icon.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="attributes" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMarkAttributes.</doc>
+            <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+          </instance-parameter>
+          <parameter name="icon_name" transfer-ownership="none">
+            <doc xml:space="preserve">name of an icon to be used.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_pixbuf"
+              c:identifier="gtk_source_mark_attributes_set_pixbuf">
+        <doc xml:space="preserve">Sets a pixbuf to be used as a base for rendered icon.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="attributes" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMarkAttributes.</doc>
+            <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+          </instance-parameter>
+          <parameter name="pixbuf" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkPixbuf to be used.</doc>
+            <type name="GdkPixbuf.Pixbuf" c:type="const GdkPixbuf*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_stock_id"
+              c:identifier="gtk_source_mark_attributes_set_stock_id"
+              deprecated="1"
+              deprecated-version="3.10">
+        <doc xml:space="preserve">Sets stock id to be used as a base for rendered icon.</doc>
+        <doc-deprecated xml:space="preserve">Don't use this function.</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="attributes" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceMarkAttributes.</doc>
+            <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+          </instance-parameter>
+          <parameter name="stock_id" transfer-ownership="none">
+            <doc xml:space="preserve">a stock id.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="background" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">A color used for background of a line.</doc>
+        <type name="Gdk.RGBA"/>
+      </property>
+      <property name="gicon" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">A #GIcon that may be a base of a rendered icon.</doc>
+        <type name="Gio.Icon"/>
+      </property>
+      <property name="icon-name" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">An icon name that may be a base of a rendered icon.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="pixbuf" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">A #GdkPixbuf that may be a base of a rendered icon.</doc>
+        <type name="GdkPixbuf.Pixbuf"/>
+      </property>
+      <property name="stock-id"
+                deprecated="1"
+                deprecated-version="3.10"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">A stock id that may be a base of a rendered icon.</doc>
+        <doc-deprecated xml:space="preserve">Don't use this property.</doc-deprecated>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <field name="parent" readable="0" private="1">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv" readable="0" private="1">
+        <type name="MarkAttributesPrivate"
+              c:type="GtkSourceMarkAttributesPrivate*"/>
+      </field>
+      <glib:signal name="query-tooltip-markup" when="last">
+        <doc xml:space="preserve">The code should connect to this signal to provide a tooltip for given
+@mark. The tooltip can contain a markup.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">A tooltip. The string should be freed with
+g_free() when done with it.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <parameter name="mark" transfer-ownership="none">
+            <doc xml:space="preserve">The #GtkSourceMark.</doc>
+            <type name="Mark"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="query-tooltip-text" when="last">
+        <doc xml:space="preserve">The code should connect to this signal to provide a tooltip for given
+@mark. The tooltip should be just a plain text.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">A tooltip. The string should be freed with
+g_free() when done with it.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <parameter name="mark" transfer-ownership="none">
+            <doc xml:space="preserve">The #GtkSourceMark.</doc>
+            <type name="Mark"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+    </class>
+    <record name="MarkAttributesClass"
+            c:type="GtkSourceMarkAttributesClass"
+            glib:is-gtype-struct-for="MarkAttributes">
+      <field name="parent_class" readable="0" private="1">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+    </record>
+    <record name="MarkAttributesPrivate"
+            c:type="GtkSourceMarkAttributesPrivate"
+            disguised="1">
+    </record>
+    <record name="MarkClass"
+            c:type="GtkSourceMarkClass"
+            glib:is-gtype-struct-for="Mark">
+      <field name="parent_class">
+        <type name="Gtk.TextMarkClass" c:type="GtkTextMarkClass"/>
+      </field>
+      <field name="_gtk_source_reserved1" introspectable="0">
+        <callback name="_gtk_source_reserved1">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved2" introspectable="0">
+        <callback name="_gtk_source_reserved2">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <record name="MarkPrivate" c:type="GtkSourceMarkPrivate" disguised="1">
+    </record>
+    <callback name="MountOperationFactory"
+              c:type="GtkSourceMountOperationFactory"
+              version="3.14"
+              introspectable="0">
+      <doc xml:space="preserve">Type definition for a function that will be called to create a
+#GMountOperation. This is useful for creating a #GtkMountOperation.</doc>
+      <return-value>
+        <type name="Gio.MountOperation" c:type="GMountOperation*"/>
+      </return-value>
+      <parameters>
+        <parameter name="file" transfer-ownership="none">
+          <doc xml:space="preserve">a #GtkSourceFile.</doc>
+          <type name="File" c:type="GtkSourceFile*"/>
+        </parameter>
+        <parameter name="userdata" transfer-ownership="none">
+          <doc xml:space="preserve">user data</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <enumeration name="NewlineType"
+                 version="3.14"
+                 glib:type-name="GtkSourceNewlineType"
+                 glib:get-type="gtk_source_newline_type_get_type"
+                 c:type="GtkSourceNewlineType">
+      <member name="lf"
+              value="0"
+              c:identifier="GTK_SOURCE_NEWLINE_TYPE_LF"
+              glib:nick="lf">
+        <doc xml:space="preserve">line feed, used on UNIX.</doc>
+      </member>
+      <member name="cr"
+              value="1"
+              c:identifier="GTK_SOURCE_NEWLINE_TYPE_CR"
+              glib:nick="cr">
+        <doc xml:space="preserve">carriage return, used on Mac.</doc>
+      </member>
+      <member name="cr_lf"
+              value="2"
+              c:identifier="GTK_SOURCE_NEWLINE_TYPE_CR_LF"
+              glib:nick="cr-lf">
+        <doc xml:space="preserve">carriage return followed by a line feed, used
+  on Windows.</doc>
+      </member>
+    </enumeration>
+    <class name="PrintCompositor"
+           c:symbol-prefix="print_compositor"
+           c:type="GtkSourcePrintCompositor"
+           parent="GObject.Object"
+           glib:type-name="GtkSourcePrintCompositor"
+           glib:get-type="gtk_source_print_compositor_get_type"
+           glib:type-struct="PrintCompositorClass">
+      <constructor name="new"
+                   c:identifier="gtk_source_print_compositor_new"
+                   version="2.2">
+        <doc xml:space="preserve">Creates a new print compositor that can be used to print @buffer.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new print compositor object.</doc>
+          <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+        </return-value>
+        <parameters>
+          <parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">the #GtkSourceBuffer to print.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_from_view"
+                   c:identifier="gtk_source_print_compositor_new_from_view"
+                   version="2.2">
+        <doc xml:space="preserve">Creates a new print compositor that can be used to print the buffer
+associated with @view.
+This constructor sets some configuration properties to make the
+printed output match @view as much as possible.  The properties set are
+#GtkSourcePrintCompositor:tab-width, #GtkSourcePrintCompositor:highlight-syntax,
+#GtkSourcePrintCompositor:wrap-mode, #GtkSourcePrintCompositor:body-font-name and
+#GtkSourcePrintCompositor:print-line-numbers.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new print compositor object.</doc>
+          <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+        </return-value>
+        <parameters>
+          <parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView to get configuration from.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="draw_page"
+              c:identifier="gtk_source_print_compositor_draw_page">
+        <doc xml:space="preserve">Draw page @page_nr for printing on the the Cairo context encapsuled in @context.
+
+This method has been designed to be called in the handler of the #GtkPrintOperation::draw_page signal
+as shown in the following example:
+
+&lt;informalexample&gt;&lt;programlisting&gt;
+// Signal handler for the GtkPrintOperation::draw_page signal
+
+static void
+draw_page (GtkPrintOperation *operation,
+           GtkPrintContext   *context,
+           gint               page_nr,
+           gpointer           user_data)
+{
+    GtkSourcePrintCompositor *compositor;
+
+    compositor = GTK_SOURCE_PRINT_COMPOSITOR (user_data);
+
+    gtk_source_print_compositor_draw_page (compositor,
+                                           context,
+                                           page_nr);
+}
+&lt;/programlisting&gt;&lt;/informalexample&gt;</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">the #GtkPrintContext encapsulating the context information that is required when
+          drawing the page for printing.</doc>
+            <type name="Gtk.PrintContext" c:type="GtkPrintContext*"/>
+          </parameter>
+          <parameter name="page_nr" transfer-ownership="none">
+            <doc xml:space="preserve">the number of the page to print.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_body_font_name"
+              c:identifier="gtk_source_print_compositor_get_body_font_name"
+              version="2.2">
+        <doc xml:space="preserve">Returns the name of the font used to print the text body. The returned string
+must be freed with g_free().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new string containing the name of the font used to print the
+text body.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_bottom_margin"
+              c:identifier="gtk_source_print_compositor_get_bottom_margin"
+              version="2.2">
+        <doc xml:space="preserve">Gets the bottom margin in units of @unit.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the bottom margin.</doc>
+          <type name="gdouble" c:type="gdouble"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="unit" transfer-ownership="none">
+            <doc xml:space="preserve">the unit for the return value.</doc>
+            <type name="Gtk.Unit" c:type="GtkUnit"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_buffer"
+              c:identifier="gtk_source_print_compositor_get_buffer"
+              version="2.2">
+        <doc xml:space="preserve">Gets the #GtkSourceBuffer associated with the compositor. The returned
+object reference is owned by the compositor object and
+should not be unreferenced.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #GtkSourceBuffer associated with the compositor.</doc>
+          <type name="Buffer" c:type="GtkSourceBuffer*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_footer_font_name"
+              c:identifier="gtk_source_print_compositor_get_footer_font_name"
+              version="2.2">
+        <doc xml:space="preserve">Returns the name of the font used to print the page footer.
+The returned string must be freed with g_free().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new string containing the name of the font used to print
+the page footer.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_header_font_name"
+              c:identifier="gtk_source_print_compositor_get_header_font_name"
+              version="2.2">
+        <doc xml:space="preserve">Returns the name of the font used to print the page header.
+The returned string must be freed with g_free().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new string containing the name of the font used to print
+the page header.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_highlight_syntax"
+              c:identifier="gtk_source_print_compositor_get_highlight_syntax"
+              version="2.2">
+        <doc xml:space="preserve">Determines whether the printed text will be highlighted according to the
+buffer rules.  Note that highlighting will happen
+only if the buffer to print has highlighting activated.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the printed output will be highlighted.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_left_margin"
+              c:identifier="gtk_source_print_compositor_get_left_margin"
+              version="2.2">
+        <doc xml:space="preserve">Gets the left margin in units of @unit.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the left margin</doc>
+          <type name="gdouble" c:type="gdouble"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="unit" transfer-ownership="none">
+            <doc xml:space="preserve">the unit for the return value.</doc>
+            <type name="Gtk.Unit" c:type="GtkUnit"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_line_numbers_font_name"
+              c:identifier="gtk_source_print_compositor_get_line_numbers_font_name"
+              version="2.2">
+        <doc xml:space="preserve">Returns the name of the font used to print line numbers on the left margin.
+The returned string must be freed with g_free().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new string containing the name of the font used to print
+line numbers on the left margin.</doc>
+          <type name="utf8" c:type="gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_n_pages"
+              c:identifier="gtk_source_print_compositor_get_n_pages"
+              version="2.2">
+        <doc xml:space="preserve">Returns the number of pages in the document or &lt;code&gt;-1&lt;/code&gt; if the
+document has not been completely paginated.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the number of pages in the document or &lt;code&gt;-1&lt;/code&gt; if the
+document has not been completely paginated.</doc>
+          <type name="gint" c:type="gint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_pagination_progress"
+              c:identifier="gtk_source_print_compositor_get_pagination_progress"
+              version="2.2">
+        <doc xml:space="preserve">Returns the current fraction of the document pagination that has been completed.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a fraction from 0.0 to 1.0 inclusive.</doc>
+          <type name="gdouble" c:type="gdouble"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_print_footer"
+              c:identifier="gtk_source_print_compositor_get_print_footer"
+              version="2.2">
+        <doc xml:space="preserve">Determines if a footer is set to be printed for each page.  A
+footer will be printed if this function returns %TRUE
+&lt;emphasis&gt;and&lt;/emphasis&gt; some format strings have been specified
+with gtk_source_print_compositor_set_footer_format().</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the footer is set to be printed.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_print_header"
+              c:identifier="gtk_source_print_compositor_get_print_header"
+              version="2.2">
+        <doc xml:space="preserve">Determines if a header is set to be printed for each page.  A
+header will be printed if this function returns %TRUE
+&lt;emphasis&gt;and&lt;/emphasis&gt; some format strings have been specified
+with gtk_source_print_compositor_set_header_format().</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the header is set to be printed.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_print_line_numbers"
+              c:identifier="gtk_source_print_compositor_get_print_line_numbers"
+              version="2.2">
+        <doc xml:space="preserve">Returns the interval used for line number printing.  If the
+value is 0, no line numbers will be printed.  The default value is
+1 (i.e. numbers printed in all lines).</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the interval of printed line numbers.</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_right_margin"
+              c:identifier="gtk_source_print_compositor_get_right_margin"
+              version="2.2">
+        <doc xml:space="preserve">Gets the right margin in units of @unit.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the right margin.</doc>
+          <type name="gdouble" c:type="gdouble"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="unit" transfer-ownership="none">
+            <doc xml:space="preserve">the unit for the return value.</doc>
+            <type name="Gtk.Unit" c:type="GtkUnit"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_tab_width"
+              c:identifier="gtk_source_print_compositor_get_tab_width"
+              version="2.2">
+        <doc xml:space="preserve">Returns the width of tabulation in characters for printed text.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">width of tab.</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_top_margin"
+              c:identifier="gtk_source_print_compositor_get_top_margin"
+              version="2.2">
+        <doc xml:space="preserve">Gets the top margin in units of @unit.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the top margin.</doc>
+          <type name="gdouble" c:type="gdouble"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="unit" transfer-ownership="none">
+            <doc xml:space="preserve">the unit for the return value.</doc>
+            <type name="Gtk.Unit" c:type="GtkUnit"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_wrap_mode"
+              c:identifier="gtk_source_print_compositor_get_wrap_mode"
+              version="2.2">
+        <doc xml:space="preserve">Gets the line wrapping mode for the printed text.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the line wrap mode.</doc>
+          <type name="Gtk.WrapMode" c:type="GtkWrapMode"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="paginate"
+              c:identifier="gtk_source_print_compositor_paginate"
+              version="2.2">
+        <doc xml:space="preserve">Paginate the document associated with the @compositor.
+
+In order to support non-blocking pagination, document is paginated in small chunks.
+Each time gtk_source_print_compositor_paginate() is invoked, a chunk of the document
+is paginated. To paginate the entire document, gtk_source_print_compositor_paginate()
+must be invoked multiple times.
+It returns %TRUE if the document has been completely paginated, otherwise it returns %FALSE.
+
+This method has been designed to be invoked in the handler of the #GtkPrintOperation::paginate signal,
+as shown in the following example:
+
+&lt;informalexample&gt;&lt;programlisting&gt;
+// Signal handler for the GtkPrintOperation::paginate signal
+
+static gboolean
+paginate (GtkPrintOperation *operation,
+          GtkPrintContext   *context,
+          gpointer           user_data)
+{
+    GtkSourcePrintCompositor *compositor;
+
+    compositor = GTK_SOURCE_PRINT_COMPOSITOR (user_data);
+
+    if (gtk_source_print_compositor_paginate (compositor, context))
+    {
+        gint n_pages;
+
+        n_pages = gtk_source_print_compositor_get_n_pages (compositor);
+        gtk_print_operation_set_n_pages (operation, n_pages);
+
+        return TRUE;
+    }
+
+    return FALSE;
+}
+&lt;/programlisting&gt;&lt;/informalexample&gt;
+
+If you don't need to do pagination in chunks, you can simply do it all in the
+#GtkPrintOperation::begin-print handler, and set the number of pages from there, like
+in the following example:
+
+&lt;informalexample&gt;&lt;programlisting&gt;
+// Signal handler for the GtkPrintOperation::begin-print signal
+
+static void
+begin_print (GtkPrintOperation *operation,
+             GtkPrintContext   *context,
+             gpointer           user_data)
+{
+    GtkSourcePrintCompositor *compositor;
+    gint n_pages;
+
+    compositor = GTK_SOURCE_PRINT_COMPOSITOR (user_data);
+
+    while (!gtk_source_print_compositor_paginate (compositor, context));
+
+    n_pages = gtk_source_print_compositor_get_n_pages (compositor);
+    gtk_print_operation_set_n_pages (operation, n_pages);
+}
+&lt;/programlisting&gt;&lt;/informalexample&gt;</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the document has been completely paginated, %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">the #GtkPrintContext whose parameters (e.g. paper size, print margins, etc.)
+are used by the the @compositor to paginate the document.</doc>
+            <type name="Gtk.PrintContext" c:type="GtkPrintContext*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_body_font_name"
+              c:identifier="gtk_source_print_compositor_set_body_font_name"
+              version="2.2">
+        <doc xml:space="preserve">Sets the default font for the printed text.
+
+@font_name should be a
+string representation of a font description Pango can understand.
+(e.g. &amp;quot;Monospace 10&amp;quot;). See pango_font_description_from_string()
+for a description of the format of the string representation.
+
+This function cannot be called anymore after the first call to the
+gtk_source_print_compositor_paginate() function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="font_name" transfer-ownership="none">
+            <doc xml:space="preserve">the name of the default font for the body text.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_bottom_margin"
+              c:identifier="gtk_source_print_compositor_set_bottom_margin"
+              version="2.2">
+        <doc xml:space="preserve">Sets the bottom margin used by @compositor.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="margin" transfer-ownership="none">
+            <doc xml:space="preserve">the new bottom margin in units of @unit.</doc>
+            <type name="gdouble" c:type="gdouble"/>
+          </parameter>
+          <parameter name="unit" transfer-ownership="none">
+            <doc xml:space="preserve">the units for @margin.</doc>
+            <type name="Gtk.Unit" c:type="GtkUnit"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_footer_font_name"
+              c:identifier="gtk_source_print_compositor_set_footer_font_name"
+              version="2.2">
+        <doc xml:space="preserve">Sets the font for printing the page footer. If
+%NULL is supplied, the default font (i.e. the one being used for the
+text) will be used instead.
+
+@font_name should be a
+string representation of a font description Pango can understand.
+(e.g. &amp;quot;Monospace 10&amp;quot;). See pango_font_description_from_string()
+for a description of the format of the string representation.
+
+This function cannot be called anymore after the first call to the
+gtk_source_print_compositor_paginate() function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="font_name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">the name of the font for the footer text, or %NULL.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_footer_format"
+              c:identifier="gtk_source_print_compositor_set_footer_format"
+              version="2.2">
+        <doc xml:space="preserve">See gtk_source_print_compositor_set_header_format() for more information
+about the parameters.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="separator" transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE if you want a separator line to be printed.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+          <parameter name="left"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a format string to print on the left of the footer.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="center"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a format string to print on the center of the footer.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="right"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a format string to print on the right of the footer.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_header_font_name"
+              c:identifier="gtk_source_print_compositor_set_header_font_name"
+              version="2.2">
+        <doc xml:space="preserve">Sets the font for printing the page header. If
+%NULL is supplied, the default font (i.e. the one being used for the
+text) will be used instead.
+
+@font_name should be a
+string representation of a font description Pango can understand.
+(e.g. &amp;quot;Monospace 10&amp;quot;). See pango_font_description_from_string()
+for a description of the format of the string representation.
+
+This function cannot be called anymore after the first call to the
+gtk_source_print_compositor_paginate() function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="font_name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">the name of the font for header text, or %NULL.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_header_format"
+              c:identifier="gtk_source_print_compositor_set_header_format"
+              version="2.2">
+        <doc xml:space="preserve">Sets strftime like header format strings, to be printed on the
+left, center and right of the top of each page.  The strings may
+include strftime(3) codes which will be expanded at print time.
+A subset of strftime() codes are accepted, see g_date_time_format()
+for more details on the accepted format specifiers.
+Additionally the following format specifiers are accepted:
+- #N: the page number
+- #Q: the page count.
+
+@separator specifies if a solid line should be drawn to separate
+the header from the document text.
+
+If %NULL is given for any of the three arguments, that particular
+string will not be printed.
+
+For the header to be printed, in
+addition to specifying format strings, you need to enable header
+printing with gtk_source_print_compositor_set_print_header().
+
+This function cannot be called anymore after the first call to the
+gtk_source_print_compositor_paginate() function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="separator" transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE if you want a separator line to be printed.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+          <parameter name="left"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a format string to print on the left of the header.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="center"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a format string to print on the center of the header.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="right"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a format string to print on the right of the header.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_highlight_syntax"
+              c:identifier="gtk_source_print_compositor_set_highlight_syntax"
+              version="2.2">
+        <doc xml:space="preserve">Sets whether the printed text will be highlighted according to the
+buffer rules.  Both color and font style are applied.
+
+This function cannot be called anymore after the first call to the
+gtk_source_print_compositor_paginate() function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="highlight" transfer-ownership="none">
+            <doc xml:space="preserve">whether syntax should be highlighted.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_left_margin"
+              c:identifier="gtk_source_print_compositor_set_left_margin"
+              version="2.2">
+        <doc xml:space="preserve">Sets the left margin used by @compositor.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="margin" transfer-ownership="none">
+            <doc xml:space="preserve">the new left margin in units of @unit.</doc>
+            <type name="gdouble" c:type="gdouble"/>
+          </parameter>
+          <parameter name="unit" transfer-ownership="none">
+            <doc xml:space="preserve">the units for @margin.</doc>
+            <type name="Gtk.Unit" c:type="GtkUnit"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_line_numbers_font_name"
+              c:identifier="gtk_source_print_compositor_set_line_numbers_font_name"
+              version="2.2">
+        <doc xml:space="preserve">Sets the font for printing line numbers on the left margin.  If
+%NULL is supplied, the default font (i.e. the one being used for the
+text) will be used instead.
+
+@font_name should be a
+string representation of a font description Pango can understand.
+(e.g. &amp;quot;Monospace 10&amp;quot;). See pango_font_description_from_string()
+for a description of the format of the string representation.
+
+This function cannot be called anymore after the first call to the
+gtk_source_print_compositor_paginate() function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="font_name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">the name of the font for line numbers, or %NULL.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_print_footer"
+              c:identifier="gtk_source_print_compositor_set_print_footer"
+              version="2.2">
+        <doc xml:space="preserve">Sets whether you want to print a footer in each page.  The
+footer consists of three pieces of text and an optional line
+separator, configurable with
+gtk_source_print_compositor_set_footer_format().
+
+Note that by default the footer format is unspecified, and if it's
+empty it will not be printed, regardless of this setting.
+
+This function cannot be called anymore after the first call to the
+gtk_source_print_compositor_paginate() function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="print" transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE if you want the footer to be printed.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_print_header"
+              c:identifier="gtk_source_print_compositor_set_print_header"
+              version="2.2">
+        <doc xml:space="preserve">Sets whether you want to print a header in each page.  The
+header consists of three pieces of text and an optional line
+separator, configurable with
+gtk_source_print_compositor_set_header_format().
+
+Note that by default the header format is unspecified, and if it's
+empty it will not be printed, regardless of this setting.
+
+This function cannot be called anymore after the first call to the
+gtk_source_print_compositor_paginate() function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="print" transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE if you want the header to be printed.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_print_line_numbers"
+              c:identifier="gtk_source_print_compositor_set_print_line_numbers"
+              version="2.2">
+        <doc xml:space="preserve">Sets the interval for printed line numbers.  If @interval is 0 no
+numbers will be printed.  If greater than 0, a number will be
+printed every @interval lines (i.e. 1 will print all line numbers).
+
+Maximum accepted value for @interval is 100.
+
+This function cannot be called anymore after the first call to the
+gtk_source_print_compositor_paginate() function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="interval" transfer-ownership="none">
+            <doc xml:space="preserve">interval for printed line numbers.</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_right_margin"
+              c:identifier="gtk_source_print_compositor_set_right_margin"
+              version="2.2">
+        <doc xml:space="preserve">Sets the right margin used by @compositor.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="margin" transfer-ownership="none">
+            <doc xml:space="preserve">the new right margin in units of @unit.</doc>
+            <type name="gdouble" c:type="gdouble"/>
+          </parameter>
+          <parameter name="unit" transfer-ownership="none">
+            <doc xml:space="preserve">the units for @margin.</doc>
+            <type name="Gtk.Unit" c:type="GtkUnit"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_tab_width"
+              c:identifier="gtk_source_print_compositor_set_tab_width"
+              version="2.2">
+        <doc xml:space="preserve">Sets the width of tabulation in characters for printed text.
+
+This function cannot be called anymore after the first call to the
+gtk_source_print_compositor_paginate() function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="width" transfer-ownership="none">
+            <doc xml:space="preserve">width of tab in characters.</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_top_margin"
+              c:identifier="gtk_source_print_compositor_set_top_margin"
+              version="2.2">
+        <doc xml:space="preserve">Sets the top margin used by @compositor.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="margin" transfer-ownership="none">
+            <doc xml:space="preserve">the new top margin in units of @unit</doc>
+            <type name="gdouble" c:type="gdouble"/>
+          </parameter>
+          <parameter name="unit" transfer-ownership="none">
+            <doc xml:space="preserve">the units for @margin</doc>
+            <type name="Gtk.Unit" c:type="GtkUnit"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_wrap_mode"
+              c:identifier="gtk_source_print_compositor_set_wrap_mode"
+              version="2.2">
+        <doc xml:space="preserve">Sets the line wrapping mode for the printed text.
+
+This function cannot be called anymore after the first call to the
+gtk_source_print_compositor_paginate() function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="compositor" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourcePrintCompositor.</doc>
+            <type name="PrintCompositor" c:type="GtkSourcePrintCompositor*"/>
+          </instance-parameter>
+          <parameter name="wrap_mode" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkWrapMode.</doc>
+            <type name="Gtk.WrapMode" c:type="GtkWrapMode"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="body-font-name"
+                version="2.2"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Name of the font used for the text body.
+
+Accepted values are strings representing a font description Pango can understand.
+(e.g. &amp;quot;Monospace 10&amp;quot;). See pango_font_description_from_string()
+for a description of the format of the string representation.
+
+The value of this property cannot be changed anymore after the first
+call to the gtk_source_print_compositor_paginate() function.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="buffer"
+                version="2.2"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The GtkSourceBuffer object to print.</doc>
+        <type name="Buffer"/>
+      </property>
+      <property name="footer-font-name"
+                version="2.2"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Name of the font used to print page footer.
+If this property is unspecified, the text body font is used.
+
+Accepted values are strings representing a font description Pango can understand.
+(e.g. &amp;quot;Monospace 10&amp;quot;). See pango_font_description_from_string()
+for a description of the format of the string representation.
+
+The value of this property cannot be changed anymore after the first
+call to the gtk_source_print_compositor_paginate() function.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="header-font-name"
+                version="2.2"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Name of the font used to print page header.
+If this property is unspecified, the text body font is used.
+
+Accepted values are strings representing a font description Pango can understand.
+(e.g. &amp;quot;Monospace 10&amp;quot;). See pango_font_description_from_string()
+for a description of the format of the string representation.
+
+The value of this property cannot be changed anymore after the first
+call to the gtk_source_print_compositor_paginate() function.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="highlight-syntax"
+                version="2.2"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Whether to print the document with highlighted syntax.
+
+The value of this property cannot be changed anymore after the first
+call to the gtk_source_print_compositor_paginate() function.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="line-numbers-font-name"
+                version="2.2"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Name of the font used to print line numbers on the left margin.
+If this property is unspecified, the text body font is used.
+
+Accepted values are strings representing a font description Pango can understand.
+(e.g. &amp;quot;Monospace 10&amp;quot;). See pango_font_description_from_string()
+for a description of the format of the string representation.
+
+The value of this property cannot be changed anymore after the first
+call to the gtk_source_print_compositor_paginate() function.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="n-pages" version="2.2" transfer-ownership="none">
+        <doc xml:space="preserve">The number of pages in the document or &lt;code&gt;-1&lt;/code&gt; if the
+document has not been completely paginated.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="print-footer"
+                version="2.2"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Whether to print a footer in each page.
+
+Note that by default the footer format is unspecified, and if it is
+unspecified the footer will not be printed, regardless of the value of
+this property.
+
+The value of this property cannot be changed anymore after the first
+call to the gtk_source_print_compositor_paginate() function.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="print-header"
+                version="2.2"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Whether to print a header in each page.
+
+Note that by default the header format is unspecified, and if it is
+unspecified the header will not be printed, regardless of the value of
+this property.
+
+The value of this property cannot be changed anymore after the first
+call to the gtk_source_print_compositor_paginate() function.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="print-line-numbers"
+                version="2.2"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Interval of printed line numbers. If this property is set to 0 no
+numbers will be printed.  If greater than 0, a number will be
+printed every "print-line-numbers" lines (i.e. 1 will print all line numbers).
+
+The value of this property cannot be changed anymore after the first
+call to the gtk_source_print_compositor_paginate() function.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="tab-width"
+                version="2.2"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Width of a tab character expressed in spaces.
+
+The value of this property cannot be changed anymore after the first
+call to the gtk_source_print_compositor_paginate() function.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="wrap-mode"
+                version="2.2"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Whether to wrap lines never, at word boundaries, or at character boundaries.
+
+The value of this property cannot be changed anymore after the first
+call to the gtk_source_print_compositor_paginate() function.</doc>
+        <type name="Gtk.WrapMode"/>
+      </property>
+      <field name="parent_instance">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv">
+        <type name="PrintCompositorPrivate"
+              c:type="GtkSourcePrintCompositorPrivate*"/>
+      </field>
+    </class>
+    <record name="PrintCompositorClass"
+            c:type="GtkSourcePrintCompositorClass"
+            glib:is-gtype-struct-for="PrintCompositor">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_gtk_source_reserved1" introspectable="0">
+        <callback name="_gtk_source_reserved1">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved2" introspectable="0">
+        <callback name="_gtk_source_reserved2">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <record name="PrintCompositorPrivate"
+            c:type="GtkSourcePrintCompositorPrivate"
+            disguised="1">
+    </record>
+    <class name="SearchContext"
+           c:symbol-prefix="search_context"
+           c:type="GtkSourceSearchContext"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceSearchContext"
+           glib:get-type="gtk_source_search_context_get_type"
+           glib:type-struct="SearchContextClass">
+      <constructor name="new"
+                   c:identifier="gtk_source_search_context_new"
+                   version="3.10">
+        <doc xml:space="preserve">Creates a new search context, associated with @buffer, and customized with
+@settings. If @settings is %NULL, a new #GtkSourceSearchSettings object will
+be created, that you can retrieve with
+gtk_source_search_context_get_settings().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new search context.</doc>
+          <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+        </return-value>
+        <parameters>
+          <parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </parameter>
+          <parameter name="settings"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a #GtkSourceSearchSettings, or %NULL.</doc>
+            <type name="SearchSettings" c:type="GtkSourceSearchSettings*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="backward"
+              c:identifier="gtk_source_search_context_backward"
+              version="3.10">
+        <doc xml:space="preserve">Synchronous backward search. It is recommended to use the asynchronous
+functions instead, to not block the user interface. However, if you are sure
+that the @buffer is small, this function is more convenient to use.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether a match was found.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">start of search.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+          <parameter name="match_start"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">return location for start of match, or %NULL.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="match_end"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">return location for end of match, or %NULL.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="backward_async"
+              c:identifier="gtk_source_search_context_backward_async"
+              version="3.10">
+        <doc xml:space="preserve">Asynchronous backward search. See the #GAsyncResult documentation to know
+how to use this function.
+
+If the operation is cancelled, the @callback will only be called if
+@cancellable was not %NULL. gtk_source_search_context_backward_async() takes
+ownership of @cancellable, so you can unref it after calling this function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">start of search.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+          <parameter name="cancellable"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a #GCancellable, or %NULL.</doc>
+            <type name="Gio.Cancellable" c:type="GCancellable*"/>
+          </parameter>
+          <parameter name="callback"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1"
+                     scope="async"
+                     closure="3">
+            <doc xml:space="preserve">a #GAsyncReadyCallback to call when the operation is finished.</doc>
+            <type name="Gio.AsyncReadyCallback" c:type="GAsyncReadyCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none">
+            <doc xml:space="preserve">the data to pass to the @callback function.</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="backward_finish"
+              c:identifier="gtk_source_search_context_backward_finish"
+              version="3.10"
+              throws="1">
+        <doc xml:space="preserve">Finishes a backward search started with
+gtk_source_search_context_backward_async().</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether a match was found.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+          <parameter name="result" transfer-ownership="none">
+            <doc xml:space="preserve">a #GAsyncResult.</doc>
+            <type name="Gio.AsyncResult" c:type="GAsyncResult*"/>
+          </parameter>
+          <parameter name="match_start"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">return location for start of match, or %NULL.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="match_end"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">return location for end of match, or %NULL.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="forward"
+              c:identifier="gtk_source_search_context_forward"
+              version="3.10">
+        <doc xml:space="preserve">Synchronous forward search. It is recommended to use the asynchronous
+functions instead, to not block the user interface. However, if you are sure
+that the @buffer is small, this function is more convenient to use.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether a match was found.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">start of search.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+          <parameter name="match_start"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">return location for start of match, or %NULL.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="match_end"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">return location for end of match, or %NULL.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="forward_async"
+              c:identifier="gtk_source_search_context_forward_async"
+              version="3.10">
+        <doc xml:space="preserve">Asynchronous forward search. See the #GAsyncResult documentation to know
+how to use this function.
+
+If the operation is cancelled, the @callback will only be called if
+@cancellable was not %NULL. gtk_source_search_context_forward_async() takes
+ownership of @cancellable, so you can unref it after calling this function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">start of search.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+          <parameter name="cancellable"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a #GCancellable, or %NULL.</doc>
+            <type name="Gio.Cancellable" c:type="GCancellable*"/>
+          </parameter>
+          <parameter name="callback"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1"
+                     scope="async"
+                     closure="3">
+            <doc xml:space="preserve">a #GAsyncReadyCallback to call when the operation is finished.</doc>
+            <type name="Gio.AsyncReadyCallback" c:type="GAsyncReadyCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none">
+            <doc xml:space="preserve">the data to pass to the @callback function.</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="forward_finish"
+              c:identifier="gtk_source_search_context_forward_finish"
+              version="3.10"
+              throws="1">
+        <doc xml:space="preserve">Finishes a forward search started with
+gtk_source_search_context_forward_async().</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether a match was found.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+          <parameter name="result" transfer-ownership="none">
+            <doc xml:space="preserve">a #GAsyncResult.</doc>
+            <type name="Gio.AsyncResult" c:type="GAsyncResult*"/>
+          </parameter>
+          <parameter name="match_start"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">return location for start of match, or %NULL.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="match_end"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none"
+                     optional="1"
+                     allow-none="1">
+            <doc xml:space="preserve">return location for end of match, or %NULL.</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_buffer"
+              c:identifier="gtk_source_search_context_get_buffer"
+              version="3.10">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the associated buffer.</doc>
+          <type name="Buffer" c:type="GtkSourceBuffer*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_highlight"
+              c:identifier="gtk_source_search_context_get_highlight"
+              version="3.10">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether to highlight the search occurrences.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_match_style"
+              c:identifier="gtk_source_search_context_get_match_style"
+              version="3.16">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #GtkSourceStyle to apply on search matches.</doc>
+          <type name="Style" c:type="GtkSourceStyle*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_occurrence_position"
+              c:identifier="gtk_source_search_context_get_occurrence_position"
+              version="3.10">
+        <doc xml:space="preserve">Gets the position of a search occurrence. If the buffer is not already fully
+scanned, the position may be unknown, and -1 is returned. If 0 is returned,
+it means that this part of the buffer has already been scanned, and that
+@match_start and @match_end don't delimit an occurrence.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the position of the search occurrence. The first occurrence has the
+position 1 (not 0). Returns 0 if @match_start and @match_end don't delimit
+an occurrence. Returns -1 if the position is not yet known.</doc>
+          <type name="gint" c:type="gint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+          <parameter name="match_start" transfer-ownership="none">
+            <doc xml:space="preserve">the start of the occurrence.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+          <parameter name="match_end" transfer-ownership="none">
+            <doc xml:space="preserve">the end of the occurrence.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_occurrences_count"
+              c:identifier="gtk_source_search_context_get_occurrences_count"
+              version="3.10">
+        <doc xml:space="preserve">Gets the total number of search occurrences. If the buffer is not already
+fully scanned, the total number of occurrences is unknown, and -1 is
+returned.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the total number of search occurrences, or -1 if unknown.</doc>
+          <type name="gint" c:type="gint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_regex_error"
+              c:identifier="gtk_source_search_context_get_regex_error"
+              version="3.10">
+        <doc xml:space="preserve">Regular expression patterns must follow certain rules. If
+#GtkSourceSearchSettings:search-text breaks a rule, the error can be retrieved
+with this function. The error domain is #G_REGEX_ERROR.
+
+Free the return value with g_error_free().</doc>
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">the #GError, or %NULL if the pattern is valid.</doc>
+          <type name="GLib.Error" c:type="GError*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_settings"
+              c:identifier="gtk_source_search_context_get_settings"
+              version="3.10">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the search settings.</doc>
+          <type name="SearchSettings" c:type="GtkSourceSearchSettings*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="replace"
+              c:identifier="gtk_source_search_context_replace"
+              version="3.10"
+              throws="1">
+        <doc xml:space="preserve">Replaces a search match by another text. If @match_start and @match_end
+doesn't correspond to a search match, %FALSE is returned.
+
+For a regular expression replacement, you can check if @replace is valid by
+calling g_regex_check_replacement(). The @replace text can contain
+backreferences; read the g_regex_replace() documentation for more details.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the match has been replaced.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+          <parameter name="match_start" transfer-ownership="none">
+            <doc xml:space="preserve">the start of the match to replace.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+          <parameter name="match_end" transfer-ownership="none">
+            <doc xml:space="preserve">the end of the match to replace.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+          <parameter name="replace" transfer-ownership="none">
+            <doc xml:space="preserve">the replacement text.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="replace_length" transfer-ownership="none">
+            <doc xml:space="preserve">the length of @replace in bytes, or -1.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="replace_all"
+              c:identifier="gtk_source_search_context_replace_all"
+              version="3.10"
+              throws="1">
+        <doc xml:space="preserve">Replaces all search matches by another text. It is a synchronous function, so
+it can block the user interface.
+
+For a regular expression replacement, you can check if @replace is valid by
+calling g_regex_check_replacement(). The @replace text can contain
+backreferences; read the g_regex_replace() documentation for more details.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the number of replaced matches.</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+          <parameter name="replace" transfer-ownership="none">
+            <doc xml:space="preserve">the replacement text.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="replace_length" transfer-ownership="none">
+            <doc xml:space="preserve">the length of @replace in bytes, or -1.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_highlight"
+              c:identifier="gtk_source_search_context_set_highlight"
+              version="3.10">
+        <doc xml:space="preserve">Enables or disables the search occurrences highlighting.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+          <parameter name="highlight" transfer-ownership="none">
+            <doc xml:space="preserve">the setting.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_match_style"
+              c:identifier="gtk_source_search_context_set_match_style"
+              version="3.16">
+        <doc xml:space="preserve">Set the style to apply on search matches. If @match_style is %NULL, default
+theme's scheme 'match-style' will be used.
+To enable or disable the search highlighting, use
+gtk_source_search_context_set_highlight().</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+          <parameter name="match_style"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">a #GtkSourceStyle.</doc>
+            <type name="Style" c:type="GtkSourceStyle*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_settings"
+              c:identifier="gtk_source_search_context_set_settings"
+              version="3.10">
+        <doc xml:space="preserve">Associate a #GtkSourceSearchSettings with the search context. If @settings is
+%NULL, a new one will be created.
+
+The search context holds a reference to @settings.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="search" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchContext.</doc>
+            <type name="SearchContext" c:type="GtkSourceSearchContext*"/>
+          </instance-parameter>
+          <parameter name="settings"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">the new #GtkSourceSearchSettings, or %NULL.</doc>
+            <type name="SearchSettings" c:type="GtkSourceSearchSettings*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="buffer"
+                version="3.10"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The #GtkSourceBuffer associated to the search context.</doc>
+        <type name="Buffer"/>
+      </property>
+      <property name="highlight"
+                version="3.10"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Highlight the search occurrences.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="match-style"
+                version="3.16"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">A #GtkSourceStyle, or %NULL for theme's scheme default style.</doc>
+        <type name="Style"/>
+      </property>
+      <property name="occurrences-count"
+                version="3.10"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The total number of search occurrences. If the search is disabled,
+the value is 0. If the buffer is not already fully scanned, the value
+is -1.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="regex-error" version="3.10" transfer-ownership="none">
+        <doc xml:space="preserve">If the regex search pattern doesn't follow all the rules, this
+property will be set. If the pattern is valid, the value is %NULL.
+
+Free with g_error_free().</doc>
+        <type name="gpointer" c:type="gpointer"/>
+      </property>
+      <property name="settings"
+                version="3.10"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The #GtkSourceSearchSettings associated to the search context.</doc>
+        <type name="SearchSettings"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv">
+        <type name="SearchContextPrivate"
+              c:type="GtkSourceSearchContextPrivate*"/>
+      </field>
+    </class>
+    <record name="SearchContextClass"
+            c:type="GtkSourceSearchContextClass"
+            glib:is-gtype-struct-for="SearchContext">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="padding">
+        <array zero-terminated="0" c:type="gpointer" fixed-size="10">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <record name="SearchContextPrivate"
+            c:type="GtkSourceSearchContextPrivate"
+            disguised="1">
+    </record>
+    <class name="SearchSettings"
+           c:symbol-prefix="search_settings"
+           c:type="GtkSourceSearchSettings"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceSearchSettings"
+           glib:get-type="gtk_source_search_settings_get_type"
+           glib:type-struct="SearchSettingsClass">
+      <constructor name="new"
+                   c:identifier="gtk_source_search_settings_new"
+                   version="3.10">
+        <doc xml:space="preserve">Creates a new search settings object.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new search settings object.</doc>
+          <type name="SearchSettings" c:type="GtkSourceSearchSettings*"/>
+        </return-value>
+      </constructor>
+      <method name="get_at_word_boundaries"
+              c:identifier="gtk_source_search_settings_get_at_word_boundaries"
+              version="3.10">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether to search at word boundaries.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="settings" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchSettings.</doc>
+            <type name="SearchSettings" c:type="GtkSourceSearchSettings*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_case_sensitive"
+              c:identifier="gtk_source_search_settings_get_case_sensitive"
+              version="3.10">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the search is case sensitive.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="settings" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchSettings.</doc>
+            <type name="SearchSettings" c:type="GtkSourceSearchSettings*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_regex_enabled"
+              c:identifier="gtk_source_search_settings_get_regex_enabled"
+              version="3.10">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether to search by regular expressions.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="settings" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchSettings.</doc>
+            <type name="SearchSettings" c:type="GtkSourceSearchSettings*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_search_text"
+              c:identifier="gtk_source_search_settings_get_search_text"
+              version="3.10">
+        <doc xml:space="preserve">Gets the text to search. The return value must not be freed.
+
+You may be interested to call gtk_source_utils_escape_search_text() after
+this function.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the text to search, or %NULL if the search is disabled.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="settings" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchSettings.</doc>
+            <type name="SearchSettings" c:type="GtkSourceSearchSettings*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_wrap_around"
+              c:identifier="gtk_source_search_settings_get_wrap_around"
+              version="3.10">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether to wrap around the search.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="settings" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchSettings.</doc>
+            <type name="SearchSettings" c:type="GtkSourceSearchSettings*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_at_word_boundaries"
+              c:identifier="gtk_source_search_settings_set_at_word_boundaries"
+              version="3.10">
+        <doc xml:space="preserve">Change whether the search is done at word boundaries. If @at_word_boundaries
+is %TRUE, a search match must start and end a word. The match can span
+multiple words. See also gtk_text_iter_starts_word() and
+gtk_text_iter_ends_word().</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="settings" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchSettings.</doc>
+            <type name="SearchSettings" c:type="GtkSourceSearchSettings*"/>
+          </instance-parameter>
+          <parameter name="at_word_boundaries" transfer-ownership="none">
+            <doc xml:space="preserve">the setting.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_case_sensitive"
+              c:identifier="gtk_source_search_settings_set_case_sensitive"
+              version="3.10">
+        <doc xml:space="preserve">Enables or disables the case sensitivity for the search.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="settings" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchSettings.</doc>
+            <type name="SearchSettings" c:type="GtkSourceSearchSettings*"/>
+          </instance-parameter>
+          <parameter name="case_sensitive" transfer-ownership="none">
+            <doc xml:space="preserve">the setting.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_regex_enabled"
+              c:identifier="gtk_source_search_settings_set_regex_enabled"
+              version="3.10">
+        <doc xml:space="preserve">Enables or disables whether to search by regular expressions.
+If enabled, the #GtkSourceSearchSettings:search-text property contains the
+pattern of the regular expression.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="settings" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchSettings.</doc>
+            <type name="SearchSettings" c:type="GtkSourceSearchSettings*"/>
+          </instance-parameter>
+          <parameter name="regex_enabled" transfer-ownership="none">
+            <doc xml:space="preserve">the setting.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_search_text"
+              c:identifier="gtk_source_search_settings_set_search_text"
+              version="3.10">
+        <doc xml:space="preserve">Sets the text to search. If @text is %NULL or is empty, the search will be
+disabled. A copy of @text will be made, so you can safely free @text after
+a call to this function.
+
+You may be interested to call gtk_source_utils_unescape_search_text() before
+this function.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="settings" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchSettings.</doc>
+            <type name="SearchSettings" c:type="GtkSourceSearchSettings*"/>
+          </instance-parameter>
+          <parameter name="search_text"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">the nul-terminated text to search, or %NULL to disable the search.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_wrap_around"
+              c:identifier="gtk_source_search_settings_set_wrap_around"
+              version="3.10">
+        <doc xml:space="preserve">Enables or disables the wrap around search. If @wrap_around is %TRUE, the
+forward search continues at the beginning of the buffer if no search
+occurrences are found. Similarly, the backward search continues to search at
+the end of the buffer.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="settings" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceSearchSettings.</doc>
+            <type name="SearchSettings" c:type="GtkSourceSearchSettings*"/>
+          </instance-parameter>
+          <parameter name="wrap_around" transfer-ownership="none">
+            <doc xml:space="preserve">the setting.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="at-word-boundaries"
+                version="3.10"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">If %TRUE, a search match must start and end a word. The match can
+span multiple words.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="case-sensitive"
+                version="3.10"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Whether the search is case sensitive.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="regex-enabled"
+                version="3.10"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Search by regular expressions with
+#GtkSourceSearchSettings:search-text as the pattern.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="search-text"
+                version="3.10"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">A search string, or %NULL if the search is disabled. If the regular
+expression search is enabled, #GtkSourceSearchSettings:search-text is
+the pattern.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="wrap-around"
+                version="3.10"
+                writable="1"
+                construct="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">For a forward search, continue at the beginning of the buffer if no
+search occurrence is found. For a backward search, continue at the
+end of the buffer.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv">
+        <type name="SearchSettingsPrivate"
+              c:type="GtkSourceSearchSettingsPrivate*"/>
+      </field>
+    </class>
+    <record name="SearchSettingsClass"
+            c:type="GtkSourceSearchSettingsClass"
+            glib:is-gtype-struct-for="SearchSettings">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="padding">
+        <array zero-terminated="0" c:type="gpointer" fixed-size="10">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <record name="SearchSettingsPrivate"
+            c:type="GtkSourceSearchSettingsPrivate"
+            disguised="1">
+    </record>
+    <enumeration name="SmartHomeEndType"
+                 glib:type-name="GtkSourceSmartHomeEndType"
+                 glib:get-type="gtk_source_smart_home_end_type_get_type"
+                 c:type="GtkSourceSmartHomeEndType">
+      <member name="disabled"
+              value="0"
+              c:identifier="GTK_SOURCE_SMART_HOME_END_DISABLED"
+              glib:nick="disabled">
+        <doc xml:space="preserve">smart-home-end disabled.</doc>
+      </member>
+      <member name="before"
+              value="1"
+              c:identifier="GTK_SOURCE_SMART_HOME_END_BEFORE"
+              glib:nick="before">
+        <doc xml:space="preserve">move to the first/last
+non-whitespace character on the first press of the HOME/END keys and
+to the beginning/end of the line on the second press.</doc>
+      </member>
+      <member name="after"
+              value="2"
+              c:identifier="GTK_SOURCE_SMART_HOME_END_AFTER"
+              glib:nick="after">
+        <doc xml:space="preserve">move to the beginning/end of the
+line on the first press of the HOME/END keys and to the first/last
+non-whitespace character on the second press.</doc>
+      </member>
+      <member name="always"
+              value="3"
+              c:identifier="GTK_SOURCE_SMART_HOME_END_ALWAYS"
+              glib:nick="always">
+        <doc xml:space="preserve">always move to the first/last
+non-whitespace character when the HOME/END keys are pressed.</doc>
+      </member>
+    </enumeration>
+    <bitfield name="SortFlags"
+              version="3.18"
+              glib:type-name="GtkSourceSortFlags"
+              glib:get-type="gtk_source_sort_flags_get_type"
+              c:type="GtkSourceSortFlags">
+      <member name="none"
+              value="0"
+              c:identifier="GTK_SOURCE_SORT_FLAGS_NONE"
+              glib:nick="none">
+        <doc xml:space="preserve">no flags specified</doc>
+      </member>
+      <member name="case_sensitive"
+              value="1"
+              c:identifier="GTK_SOURCE_SORT_FLAGS_CASE_SENSITIVE"
+              glib:nick="case-sensitive">
+        <doc xml:space="preserve">case sensitive sort</doc>
+      </member>
+      <member name="reverse_order"
+              value="2"
+              c:identifier="GTK_SOURCE_SORT_FLAGS_REVERSE_ORDER"
+              glib:nick="reverse-order">
+        <doc xml:space="preserve">sort in reverse order</doc>
+      </member>
+      <member name="remove_duplicates"
+              value="4"
+              c:identifier="GTK_SOURCE_SORT_FLAGS_REMOVE_DUPLICATES"
+              glib:nick="remove-duplicates">
+        <doc xml:space="preserve">remove duplicates</doc>
+      </member>
+    </bitfield>
+    <class name="Style"
+           c:symbol-prefix="style"
+           c:type="GtkSourceStyle"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceStyle"
+           glib:get-type="gtk_source_style_get_type"
+           glib:type-struct="StyleClass">
+      <method name="copy" c:identifier="gtk_source_style_copy" version="2.0">
+        <doc xml:space="preserve">Creates a copy of @style, that is a new #GtkSourceStyle instance which
+has the same attributes set.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">copy of @style, call g_object_unref()
+when you are done with it.</doc>
+          <type name="Style" c:type="GtkSourceStyle*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="style" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyle structure to copy.</doc>
+            <type name="Style" c:type="const GtkSourceStyle*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <property name="background"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="background-set"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="bold"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="bold-set"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="foreground"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="foreground-set"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="italic"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="italic-set"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="line-background"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="line-background-set"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="pango-underline"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="Pango.Underline"/>
+      </property>
+      <property name="scale"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="scale-set"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="strikethrough"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="strikethrough-set"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="underline"
+                deprecated="1"
+                deprecated-version="3.18"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc-deprecated xml:space="preserve">Use pango-underline.</doc-deprecated>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="underline-color"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="underline-color-set"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="underline-set"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+    </class>
+    <record name="StyleClass"
+            c:type="GtkSourceStyleClass"
+            disguised="1"
+            glib:is-gtype-struct-for="Style">
+    </record>
+    <class name="StyleScheme"
+           c:symbol-prefix="style_scheme"
+           c:type="GtkSourceStyleScheme"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceStyleScheme"
+           glib:get-type="gtk_source_style_scheme_get_type"
+           glib:type-struct="StyleSchemeClass">
+      <method name="get_authors"
+              c:identifier="gtk_source_style_scheme_get_authors"
+              version="2.0">
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">a
+%NULL-terminated array containing the @scheme authors or %NULL if
+no author is specified by the style scheme.</doc>
+          <array c:type="gchar**">
+            <type name="utf8"/>
+          </array>
+        </return-value>
+        <parameters>
+          <instance-parameter name="scheme" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleScheme.</doc>
+            <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_description"
+              c:identifier="gtk_source_style_scheme_get_description"
+              version="2.0">
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">@scheme description (if defined), or %NULL.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="scheme" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleScheme.</doc>
+            <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_filename"
+              c:identifier="gtk_source_style_scheme_get_filename"
+              version="2.0">
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">@scheme file name if the scheme was created
+parsing a style scheme file or %NULL in the other cases.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="scheme" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleScheme.</doc>
+            <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_id"
+              c:identifier="gtk_source_style_scheme_get_id"
+              version="2.0">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">@scheme id.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="scheme" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleScheme.</doc>
+            <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_name"
+              c:identifier="gtk_source_style_scheme_get_name"
+              version="2.0">
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">@scheme name.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="scheme" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleScheme.</doc>
+            <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_style"
+              c:identifier="gtk_source_style_scheme_get_style"
+              version="2.0">
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">style which corresponds to @style_id in
+the @scheme, or %NULL when no style with this name found.  It is owned by
+@scheme and may not be unref'ed.</doc>
+          <type name="Style" c:type="GtkSourceStyle*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="scheme" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleScheme.</doc>
+            <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+          </instance-parameter>
+          <parameter name="style_id" transfer-ownership="none">
+            <doc xml:space="preserve">id of the style to retrieve.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="description" transfer-ownership="none">
+        <doc xml:space="preserve">Style scheme description, a translatable string to present to the user.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="filename" transfer-ownership="none">
+        <doc xml:space="preserve">Style scheme filename or %NULL.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="id"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Style scheme id, a unique string used to identify the style scheme
+in #GtkSourceStyleSchemeManager.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="name" transfer-ownership="none">
+        <doc xml:space="preserve">Style scheme name, a translatable string to present to the user.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <field name="base">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv">
+        <type name="StyleSchemePrivate" c:type="GtkSourceStyleSchemePrivate*"/>
+      </field>
+    </class>
+    <interface name="StyleSchemeChooser"
+               c:symbol-prefix="style_scheme_chooser"
+               c:type="GtkSourceStyleSchemeChooser"
+               glib:type-name="GtkSourceStyleSchemeChooser"
+               glib:get-type="gtk_source_style_scheme_chooser_get_type"
+               glib:type-struct="StyleSchemeChooserInterface">
+      <virtual-method name="get_style_scheme"
+                      invoker="get_style_scheme"
+                      version="3.16">
+        <doc xml:space="preserve">Gets the currently-selected scheme.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the currently-selected scheme.</doc>
+          <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="chooser" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleSchemeChooser</doc>
+            <type name="StyleSchemeChooser"
+                  c:type="GtkSourceStyleSchemeChooser*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="set_style_scheme"
+                      invoker="set_style_scheme"
+                      version="3.16">
+        <doc xml:space="preserve">Sets the scheme.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="chooser" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleSchemeChooser</doc>
+            <type name="StyleSchemeChooser"
+                  c:type="GtkSourceStyleSchemeChooser*"/>
+          </instance-parameter>
+          <parameter name="scheme" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleScheme</doc>
+            <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <method name="get_style_scheme"
+              c:identifier="gtk_source_style_scheme_chooser_get_style_scheme"
+              version="3.16">
+        <doc xml:space="preserve">Gets the currently-selected scheme.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the currently-selected scheme.</doc>
+          <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="chooser" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleSchemeChooser</doc>
+            <type name="StyleSchemeChooser"
+                  c:type="GtkSourceStyleSchemeChooser*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_style_scheme"
+              c:identifier="gtk_source_style_scheme_chooser_set_style_scheme"
+              version="3.16">
+        <doc xml:space="preserve">Sets the scheme.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="chooser" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleSchemeChooser</doc>
+            <type name="StyleSchemeChooser"
+                  c:type="GtkSourceStyleSchemeChooser*"/>
+          </instance-parameter>
+          <parameter name="scheme" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleScheme</doc>
+            <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="style-scheme"
+                version="3.16"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">The :style-scheme property contains the currently selected style
+scheme. The property can be set to change
+the current selection programmatically.</doc>
+        <type name="StyleScheme"/>
+      </property>
+    </interface>
+    <class name="StyleSchemeChooserButton"
+           c:symbol-prefix="style_scheme_chooser_button"
+           c:type="GtkSourceStyleSchemeChooserButton"
+           parent="Gtk.Button"
+           glib:type-name="GtkSourceStyleSchemeChooserButton"
+           glib:get-type="gtk_source_style_scheme_chooser_button_get_type"
+           glib:type-struct="StyleSchemeChooserButtonClass">
+      <implements name="Atk.ImplementorIface"/>
+      <implements name="Gtk.Actionable"/>
+      <implements name="Gtk.Activatable"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="StyleSchemeChooser"/>
+      <constructor name="new"
+                   c:identifier="gtk_source_style_scheme_chooser_button_new"
+                   version="3.16">
+        <doc xml:space="preserve">Creates a new #GtkSourceStyleSchemeChooserButton.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a new #GtkSourceStyleSchemeChooserButton.</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <field name="parent">
+        <type name="Gtk.Button" c:type="GtkButton"/>
+      </field>
+    </class>
+    <record name="StyleSchemeChooserButtonClass"
+            c:type="GtkSourceStyleSchemeChooserButtonClass"
+            glib:is-gtype-struct-for="StyleSchemeChooserButton">
+      <field name="parent">
+        <type name="Gtk.ButtonClass" c:type="GtkButtonClass"/>
+      </field>
+    </record>
+    <record name="StyleSchemeChooserInterface"
+            c:type="GtkSourceStyleSchemeChooserInterface"
+            glib:is-gtype-struct-for="StyleSchemeChooser">
+      <field name="base_interface">
+        <type name="GObject.TypeInterface" c:type="GTypeInterface"/>
+      </field>
+      <field name="get_style_scheme">
+        <callback name="get_style_scheme">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">the currently-selected scheme.</doc>
+            <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+          </return-value>
+          <parameters>
+            <parameter name="chooser" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceStyleSchemeChooser</doc>
+              <type name="StyleSchemeChooser"
+                    c:type="GtkSourceStyleSchemeChooser*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="set_style_scheme">
+        <callback name="set_style_scheme">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="chooser" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceStyleSchemeChooser</doc>
+              <type name="StyleSchemeChooser"
+                    c:type="GtkSourceStyleSchemeChooser*"/>
+            </parameter>
+            <parameter name="scheme" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceStyleScheme</doc>
+              <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="padding">
+        <array zero-terminated="0" c:type="gpointer" fixed-size="12">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <class name="StyleSchemeChooserWidget"
+           c:symbol-prefix="style_scheme_chooser_widget"
+           c:type="GtkSourceStyleSchemeChooserWidget"
+           parent="Gtk.Bin"
+           glib:type-name="GtkSourceStyleSchemeChooserWidget"
+           glib:get-type="gtk_source_style_scheme_chooser_widget_get_type"
+           glib:type-struct="StyleSchemeChooserWidgetClass">
+      <implements name="Atk.ImplementorIface"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="StyleSchemeChooser"/>
+      <constructor name="new"
+                   c:identifier="gtk_source_style_scheme_chooser_widget_new"
+                   version="3.16">
+        <doc xml:space="preserve">Creates a new #GtkSourceStyleSchemeChooserWidget.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a new  #GtkSourceStyleSchemeChooserWidget.</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <field name="parent">
+        <type name="Gtk.Bin" c:type="GtkBin"/>
+      </field>
+    </class>
+    <record name="StyleSchemeChooserWidgetClass"
+            c:type="GtkSourceStyleSchemeChooserWidgetClass"
+            glib:is-gtype-struct-for="StyleSchemeChooserWidget">
+      <field name="parent">
+        <type name="Gtk.BinClass" c:type="GtkBinClass"/>
+      </field>
+    </record>
+    <record name="StyleSchemeClass"
+            c:type="GtkSourceStyleSchemeClass"
+            glib:is-gtype-struct-for="StyleScheme">
+      <field name="base_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_gtk_source_reserved1" introspectable="0">
+        <callback name="_gtk_source_reserved1">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved2" introspectable="0">
+        <callback name="_gtk_source_reserved2">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <class name="StyleSchemeManager"
+           c:symbol-prefix="style_scheme_manager"
+           c:type="GtkSourceStyleSchemeManager"
+           parent="GObject.Object"
+           glib:type-name="GtkSourceStyleSchemeManager"
+           glib:get-type="gtk_source_style_scheme_manager_get_type"
+           glib:type-struct="StyleSchemeManagerClass">
+      <constructor name="new"
+                   c:identifier="gtk_source_style_scheme_manager_new">
+        <doc xml:space="preserve">Creates a new style manager. If you do not need more than one style
+manager then use gtk_source_style_scheme_manager_get_default() instead.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #GtkSourceStyleSchemeManager.</doc>
+          <type name="StyleSchemeManager"
+                c:type="GtkSourceStyleSchemeManager*"/>
+        </return-value>
+      </constructor>
+      <function name="get_default"
+                c:identifier="gtk_source_style_scheme_manager_get_default">
+        <doc xml:space="preserve">Returns the default #GtkSourceStyleSchemeManager instance.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #GtkSourceStyleSchemeManager. Return value
+is owned by GtkSourceView library and must not be unref'ed.</doc>
+          <type name="StyleSchemeManager"
+                c:type="GtkSourceStyleSchemeManager*"/>
+        </return-value>
+      </function>
+      <method name="append_search_path"
+              c:identifier="gtk_source_style_scheme_manager_append_search_path">
+        <doc xml:space="preserve">Appends @path to the list of directories where the @manager looks for
+style scheme files.
+See gtk_source_style_scheme_manager_set_search_path() for details.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleSchemeManager.</doc>
+            <type name="StyleSchemeManager"
+                  c:type="GtkSourceStyleSchemeManager*"/>
+          </instance-parameter>
+          <parameter name="path" transfer-ownership="none">
+            <doc xml:space="preserve">a directory or a filename.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="force_rescan"
+              c:identifier="gtk_source_style_scheme_manager_force_rescan">
+        <doc xml:space="preserve">Mark any currently cached information about the available style scehems
+as invalid. All the available style schemes will be reloaded next time
+the @manager is accessed.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleSchemeManager.</doc>
+            <type name="StyleSchemeManager"
+                  c:type="GtkSourceStyleSchemeManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_scheme"
+              c:identifier="gtk_source_style_scheme_manager_get_scheme">
+        <doc xml:space="preserve">Looks up style scheme by id.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #GtkSourceStyleScheme object. Returned value is owned by
+@manager and must not be unref'ed.</doc>
+          <type name="StyleScheme" c:type="GtkSourceStyleScheme*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleSchemeManager.</doc>
+            <type name="StyleSchemeManager"
+                  c:type="GtkSourceStyleSchemeManager*"/>
+          </instance-parameter>
+          <parameter name="scheme_id" transfer-ownership="none">
+            <doc xml:space="preserve">style scheme id to find.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_scheme_ids"
+              c:identifier="gtk_source_style_scheme_manager_get_scheme_ids">
+        <doc xml:space="preserve">Returns the ids of the available style schemes.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">
+a %NULL-terminated array of strings containing the ids of the available
+style schemes or %NULL if no style scheme is available.
+The array is sorted alphabetically according to the scheme name.
+The array is owned by the @manager and must not be modified.</doc>
+          <array c:type="gchar**">
+            <type name="utf8"/>
+          </array>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleSchemeManager.</doc>
+            <type name="StyleSchemeManager"
+                  c:type="GtkSourceStyleSchemeManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_search_path"
+              c:identifier="gtk_source_style_scheme_manager_get_search_path">
+        <doc xml:space="preserve">Returns the current search path for the @manager.
+See gtk_source_style_scheme_manager_set_search_path() for details.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a %NULL-terminated array
+of string containing the search path.
+The array is owned by the @manager and must not be modified.</doc>
+          <array c:type="gchar**">
+            <type name="utf8"/>
+          </array>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleSchemeManager.</doc>
+            <type name="StyleSchemeManager"
+                  c:type="GtkSourceStyleSchemeManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="prepend_search_path"
+              c:identifier="gtk_source_style_scheme_manager_prepend_search_path">
+        <doc xml:space="preserve">Prepends @path to the list of directories where the @manager looks
+for style scheme files.
+See gtk_source_style_scheme_manager_set_search_path() for details.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleSchemeManager.</doc>
+            <type name="StyleSchemeManager"
+                  c:type="GtkSourceStyleSchemeManager*"/>
+          </instance-parameter>
+          <parameter name="path" transfer-ownership="none">
+            <doc xml:space="preserve">a directory or a filename.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_search_path"
+              c:identifier="gtk_source_style_scheme_manager_set_search_path">
+        <doc xml:space="preserve">Sets the list of directories where the @manager looks for
+style scheme files.
+If @path is %NULL, the search path is reset to default.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceStyleSchemeManager.</doc>
+            <type name="StyleSchemeManager"
+                  c:type="GtkSourceStyleSchemeManager*"/>
+          </instance-parameter>
+          <parameter name="path"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">
+a %NULL-terminated array of strings or %NULL.</doc>
+            <array c:type="gchar**">
+              <type name="utf8" c:type="gchar*"/>
+            </array>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="scheme-ids" transfer-ownership="none">
+        <array>
+          <type name="utf8"/>
+        </array>
+      </property>
+      <property name="search-path" writable="1" transfer-ownership="none">
+        <array>
+          <type name="utf8"/>
+        </array>
+      </property>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv">
+        <type name="StyleSchemeManagerPrivate"
+              c:type="GtkSourceStyleSchemeManagerPrivate*"/>
+      </field>
+    </class>
+    <record name="StyleSchemeManagerClass"
+            c:type="GtkSourceStyleSchemeManagerClass"
+            glib:is-gtype-struct-for="StyleSchemeManager">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_gtk_source_reserved1" introspectable="0">
+        <callback name="_gtk_source_reserved1">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved2" introspectable="0">
+        <callback name="_gtk_source_reserved2">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved3" introspectable="0">
+        <callback name="_gtk_source_reserved3">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_gtk_source_reserved4" introspectable="0">
+        <callback name="_gtk_source_reserved4">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <record name="StyleSchemeManagerPrivate"
+            c:type="GtkSourceStyleSchemeManagerPrivate"
+            disguised="1">
+    </record>
+    <record name="StyleSchemePrivate"
+            c:type="GtkSourceStyleSchemePrivate"
+            disguised="1">
+    </record>
+    <class name="Tag"
+           c:symbol-prefix="tag"
+           c:type="GtkSourceTag"
+           parent="Gtk.TextTag"
+           glib:type-name="GtkSourceTag"
+           glib:get-type="gtk_source_tag_get_type"
+           glib:type-struct="TagClass">
+      <constructor name="new" c:identifier="gtk_source_tag_new" version="3.20">
+        <doc xml:space="preserve">Creates a #GtkSourceTag. Configure the tag using object arguments,
+i.e. using g_object_set().
+
+For usual cases, gtk_source_buffer_create_source_tag() is more convenient to
+use.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #GtkSourceTag.</doc>
+          <type name="Gtk.TextTag" c:type="GtkTextTag*"/>
+        </return-value>
+        <parameters>
+          <parameter name="name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve">tag name, or %NULL.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <property name="draw-spaces"
+                version="3.20"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Whether to draw spaces. This property takes precedence over the value
+defined by the GtkSourceView's #GtkSourceView:draw-spaces property
+(only where the tag is applied).
+
+Setting this property also changes #GtkSourceTag:draw-spaces-set to
+%TRUE.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="draw-spaces-set"
+                version="3.20"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Whether the #GtkSourceTag:draw-spaces property is set and must be
+taken into account.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <field name="parent_instance">
+        <type name="Gtk.TextTag" c:type="GtkTextTag"/>
+      </field>
+    </class>
+    <record name="TagClass"
+            c:type="GtkSourceTagClass"
+            glib:is-gtype-struct-for="Tag">
+      <field name="parent_class">
+        <type name="Gtk.TextTagClass" c:type="GtkTextTagClass"/>
+      </field>
+      <field name="padding">
+        <array zero-terminated="0" c:type="gpointer" fixed-size="10">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <interface name="UndoManager"
+               c:symbol-prefix="undo_manager"
+               c:type="GtkSourceUndoManager"
+               glib:type-name="GtkSourceUndoManager"
+               glib:get-type="gtk_source_undo_manager_get_type"
+               glib:type-struct="UndoManagerIface">
+      <virtual-method name="begin_not_undoable_action"
+                      invoker="begin_not_undoable_action"
+                      version="2.10">
+        <doc xml:space="preserve">Begin a not undoable action on the buffer. All changes between this call
+and the call to gtk_source_undo_manager_end_not_undoable_action() cannot
+be undone. This function should be re-entrant.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="can_redo" invoker="can_redo" version="2.10">
+        <doc xml:space="preserve">Get whether there are redo operations available.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if there are redo operations available, %FALSE otherwise</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="can_redo_changed"
+                      invoker="can_redo_changed"
+                      version="2.10">
+        <doc xml:space="preserve">Emits the #GtkSourceUndoManager::can-redo-changed signal.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="can_undo" invoker="can_undo" version="2.10">
+        <doc xml:space="preserve">Get whether there are undo operations available.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if there are undo operations available, %FALSE otherwise</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="can_undo_changed"
+                      invoker="can_undo_changed"
+                      version="2.10">
+        <doc xml:space="preserve">Emits the #GtkSourceUndoManager::can-undo-changed signal.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="end_not_undoable_action"
+                      invoker="end_not_undoable_action"
+                      version="2.10">
+        <doc xml:space="preserve">Ends a not undoable action on the buffer.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="redo" invoker="redo" version="2.10">
+        <doc xml:space="preserve">Perform a single redo. Calling this function when there are no redo operations
+available is an error. Use gtk_source_undo_manager_can_redo() to find out
+if there are redo operations available.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="undo" invoker="undo" version="2.10">
+        <doc xml:space="preserve">Perform a single undo. Calling this function when there are no undo operations
+available is an error. Use gtk_source_undo_manager_can_undo() to find out
+if there are undo operations available.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <method name="begin_not_undoable_action"
+              c:identifier="gtk_source_undo_manager_begin_not_undoable_action"
+              version="2.10">
+        <doc xml:space="preserve">Begin a not undoable action on the buffer. All changes between this call
+and the call to gtk_source_undo_manager_end_not_undoable_action() cannot
+be undone. This function should be re-entrant.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="can_redo"
+              c:identifier="gtk_source_undo_manager_can_redo"
+              version="2.10">
+        <doc xml:space="preserve">Get whether there are redo operations available.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if there are redo operations available, %FALSE otherwise</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="can_redo_changed"
+              c:identifier="gtk_source_undo_manager_can_redo_changed"
+              version="2.10">
+        <doc xml:space="preserve">Emits the #GtkSourceUndoManager::can-redo-changed signal.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="can_undo"
+              c:identifier="gtk_source_undo_manager_can_undo"
+              version="2.10">
+        <doc xml:space="preserve">Get whether there are undo operations available.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if there are undo operations available, %FALSE otherwise</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="can_undo_changed"
+              c:identifier="gtk_source_undo_manager_can_undo_changed"
+              version="2.10">
+        <doc xml:space="preserve">Emits the #GtkSourceUndoManager::can-undo-changed signal.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="end_not_undoable_action"
+              c:identifier="gtk_source_undo_manager_end_not_undoable_action"
+              version="2.10">
+        <doc xml:space="preserve">Ends a not undoable action on the buffer.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="redo"
+              c:identifier="gtk_source_undo_manager_redo"
+              version="2.10">
+        <doc xml:space="preserve">Perform a single redo. Calling this function when there are no redo operations
+available is an error. Use gtk_source_undo_manager_can_redo() to find out
+if there are redo operations available.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="undo"
+              c:identifier="gtk_source_undo_manager_undo"
+              version="2.10">
+        <doc xml:space="preserve">Perform a single undo. Calling this function when there are no undo operations
+available is an error. Use gtk_source_undo_manager_can_undo() to find out
+if there are undo operations available.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+            <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <glib:signal name="can-redo-changed"
+                   when="last"
+                   action="1"
+                   version="2.10">
+        <doc xml:space="preserve">Emitted when the ability to redo has changed.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+      <glib:signal name="can-undo-changed"
+                   when="last"
+                   action="1"
+                   version="2.10">
+        <doc xml:space="preserve">Emitted when the ability to undo has changed.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+    </interface>
+    <record name="UndoManagerIface"
+            c:type="GtkSourceUndoManagerIface"
+            glib:is-gtype-struct-for="UndoManager">
+      <field name="parent">
+        <type name="GObject.TypeInterface" c:type="GTypeInterface"/>
+      </field>
+      <field name="can_undo">
+        <callback name="can_undo">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE if there are undo operations available, %FALSE otherwise</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </return-value>
+          <parameters>
+            <parameter name="manager" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+              <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="can_redo">
+        <callback name="can_redo">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE if there are redo operations available, %FALSE otherwise</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </return-value>
+          <parameters>
+            <parameter name="manager" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+              <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="undo">
+        <callback name="undo">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="manager" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+              <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="redo">
+        <callback name="redo">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="manager" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+              <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="begin_not_undoable_action">
+        <callback name="begin_not_undoable_action">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="manager" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+              <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="end_not_undoable_action">
+        <callback name="end_not_undoable_action">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="manager" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+              <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="can_undo_changed">
+        <callback name="can_undo_changed">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="manager" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+              <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="can_redo_changed">
+        <callback name="can_redo_changed">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="manager" transfer-ownership="none">
+              <doc xml:space="preserve">a #GtkSourceUndoManager.</doc>
+              <type name="UndoManager" c:type="GtkSourceUndoManager*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+    </record>
+    <class name="View"
+           c:symbol-prefix="view"
+           c:type="GtkSourceView"
+           parent="Gtk.TextView"
+           glib:type-name="GtkSourceView"
+           glib:get-type="gtk_source_view_get_type"
+           glib:type-struct="ViewClass">
+      <implements name="Atk.ImplementorIface"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.Scrollable"/>
+      <constructor name="new" c:identifier="gtk_source_view_new">
+        <doc xml:space="preserve">Creates a new #GtkSourceView. An empty default #GtkSourceBuffer will be
+created for you and can be retrieved with gtk_text_view_get_buffer(). If you
+want to specify your own buffer, consider gtk_source_view_new_with_buffer().</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a new #GtkSourceView.</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <constructor name="new_with_buffer"
+                   c:identifier="gtk_source_view_new_with_buffer">
+        <doc xml:space="preserve">Creates a new #GtkSourceView widget displaying the buffer
+@buffer. One buffer can be shared among many widgets.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a new #GtkSourceView.</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <parameter name="buffer" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceBuffer.</doc>
+            <type name="Buffer" c:type="GtkSourceBuffer*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <virtual-method name="line_mark_activated">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="event" transfer-ownership="none">
+            <type name="Gdk.Event" c:type="GdkEvent*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="move_lines">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="copy" transfer-ownership="none">
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+          <parameter name="step" transfer-ownership="none">
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="move_words">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="step" transfer-ownership="none">
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="redo">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="show_completion">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="undo">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <method name="get_auto_indent"
+              c:identifier="gtk_source_view_get_auto_indent">
+        <doc xml:space="preserve">Returns whether auto-indentation of text is enabled.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if auto indentation is enabled.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_background_pattern"
+              c:identifier="gtk_source_view_get_background_pattern"
+              version="3.16">
+        <doc xml:space="preserve">Returns the #GtkSourceBackgroundPatternType specifying if and how
+the background pattern should be displayed for this @view.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #GtkSourceBackgroundPatternType.</doc>
+          <type name="BackgroundPatternType"
+                c:type="GtkSourceBackgroundPatternType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_completion"
+              c:identifier="gtk_source_view_get_completion">
+        <doc xml:space="preserve">Gets the #GtkSourceCompletion associated with @view.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">
+the #GtkSourceCompletion associated with @view.</doc>
+          <type name="Completion" c:type="GtkSourceCompletion*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_draw_spaces"
+              c:identifier="gtk_source_view_get_draw_spaces">
+        <doc xml:space="preserve">Returns the #GtkSourceDrawSpacesFlags specifying if and how spaces
+should be displayed for this @view.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #GtkSourceDrawSpacesFlags, 0 if no spaces should be drawn.</doc>
+          <type name="DrawSpacesFlags" c:type="GtkSourceDrawSpacesFlags"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_gutter"
+              c:identifier="gtk_source_view_get_gutter"
+              version="2.8">
+        <doc xml:space="preserve">Returns the #GtkSourceGutter object associated with @window_type for @view.
+Only GTK_TEXT_WINDOW_LEFT and GTK_TEXT_WINDOW_RIGHT are supported,
+respectively corresponding to the left and right gutter. The line numbers
+and mark category icons are rendered in the left gutter.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #GtkSourceGutter.</doc>
+          <type name="Gutter" c:type="GtkSourceGutter*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="window_type" transfer-ownership="none">
+            <doc xml:space="preserve">the gutter window type.</doc>
+            <type name="Gtk.TextWindowType" c:type="GtkTextWindowType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_highlight_current_line"
+              c:identifier="gtk_source_view_get_highlight_current_line">
+        <doc xml:space="preserve">Returns whether the current line is highlighted.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the current line is highlighted.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_indent_on_tab"
+              c:identifier="gtk_source_view_get_indent_on_tab">
+        <doc xml:space="preserve">Returns whether when the tab key is pressed the current selection
+should get indented instead of replaced with the \t character.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the selection is indented when tab is pressed.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_indent_width"
+              c:identifier="gtk_source_view_get_indent_width">
+        <doc xml:space="preserve">Returns the number of spaces to use for each step of indent.
+See gtk_source_view_set_indent_width() for details.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">indent width.</doc>
+          <type name="gint" c:type="gint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_insert_spaces_instead_of_tabs"
+              c:identifier="gtk_source_view_get_insert_spaces_instead_of_tabs">
+        <doc xml:space="preserve">Returns whether when inserting a tabulator character it should
+be replaced by a group of space characters.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if spaces are inserted instead of tabs.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_mark_attributes"
+              c:identifier="gtk_source_view_get_mark_attributes">
+        <doc xml:space="preserve">Gets attributes and priority for the @category.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">#GtkSourceMarkAttributes for the @category.
+The object belongs to @view, so it must not be unreffed.</doc>
+          <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="category" transfer-ownership="none">
+            <doc xml:space="preserve">the category.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="priority" transfer-ownership="none">
+            <doc xml:space="preserve">place where priority of the category will be stored.</doc>
+            <type name="gint" c:type="gint*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_right_margin_position"
+              c:identifier="gtk_source_view_get_right_margin_position">
+        <doc xml:space="preserve">Gets the position of the right margin in the given @view.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the position of the right margin.</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_show_line_marks"
+              c:identifier="gtk_source_view_get_show_line_marks"
+              version="2.2">
+        <doc xml:space="preserve">Returns whether line marks are displayed beside the text.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the line marks are displayed.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_show_line_numbers"
+              c:identifier="gtk_source_view_get_show_line_numbers">
+        <doc xml:space="preserve">Returns whether line numbers are displayed beside the text.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the line numbers are displayed.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_show_right_margin"
+              c:identifier="gtk_source_view_get_show_right_margin">
+        <doc xml:space="preserve">Returns whether a right margin is displayed.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the right margin is shown.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_smart_backspace"
+              c:identifier="gtk_source_view_get_smart_backspace"
+              version="3.18">
+        <doc xml:space="preserve">Returns %TRUE if pressing the Backspace key will try to delete spaces
+up to the previous tab stop.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if smart Backspace handling is enabled.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_smart_home_end"
+              c:identifier="gtk_source_view_get_smart_home_end">
+        <doc xml:space="preserve">Returns a #GtkSourceSmartHomeEndType end value specifying
+how the cursor will move when HOME and END keys are pressed.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #GtkSourceSmartHomeEndType value.</doc>
+          <type name="SmartHomeEndType" c:type="GtkSourceSmartHomeEndType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_tab_width"
+              c:identifier="gtk_source_view_get_tab_width">
+        <doc xml:space="preserve">Returns the width of tabulation in characters.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">width of tab.</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_visual_column"
+              c:identifier="gtk_source_view_get_visual_column">
+        <doc xml:space="preserve">Determines the visual column at @iter taking into consideration the
+#GtkSourceView:tab-width of @view.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the visual column at @iter.</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a position in @view.</doc>
+            <type name="Gtk.TextIter" c:type="const GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="indent_lines"
+              c:identifier="gtk_source_view_indent_lines"
+              version="3.16">
+        <doc xml:space="preserve">Insert one indentation level at the beginning of the
+specified lines.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">#GtkTextIter of the first line to indent</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">#GtkTextIter of the last line to indent</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_auto_indent"
+              c:identifier="gtk_source_view_set_auto_indent">
+        <doc xml:space="preserve">If %TRUE auto-indentation of text is enabled.
+
+When Enter is pressed to create a new line, the auto-indentation inserts the
+same indentation as the previous line. This is &lt;emphasis&gt;not&lt;/emphasis&gt; a
+"smart indentation" where an indentation level is added or removed depending
+on the context.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="enable" transfer-ownership="none">
+            <doc xml:space="preserve">whether to enable auto indentation.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_background_pattern"
+              c:identifier="gtk_source_view_set_background_pattern"
+              version="3.16">
+        <doc xml:space="preserve">Set if and how the background pattern should be displayed.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="background_pattern" transfer-ownership="none">
+            <doc xml:space="preserve">the #GtkSourceBackgroundPatternType.</doc>
+            <type name="BackgroundPatternType"
+                  c:type="GtkSourceBackgroundPatternType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_draw_spaces"
+              c:identifier="gtk_source_view_set_draw_spaces">
+        <doc xml:space="preserve">Set if and how the spaces should be visualized. Specifying @flags as 0 will
+disable display of spaces.
+
+For a finer-grained method, there is also the GtkSourceTag's
+#GtkSourceTag:draw-spaces property.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="flags" transfer-ownership="none">
+            <doc xml:space="preserve">#GtkSourceDrawSpacesFlags specifing how white spaces should
+be displayed</doc>
+            <type name="DrawSpacesFlags" c:type="GtkSourceDrawSpacesFlags"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_highlight_current_line"
+              c:identifier="gtk_source_view_set_highlight_current_line">
+        <doc xml:space="preserve">If @highlight is %TRUE the current line will be highlighted.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="highlight" transfer-ownership="none">
+            <doc xml:space="preserve">whether to highlight the current line.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_indent_on_tab"
+              c:identifier="gtk_source_view_set_indent_on_tab">
+        <doc xml:space="preserve">If %TRUE, when the tab key is pressed when several lines are selected, the
+selected lines are indented of one level instead of being replaced with a \t
+character. Shift+Tab unindents the selection.
+
+If the first or last line is not selected completely, it is also indented or
+unindented.
+
+When the selection doesn't span several lines, the tab key always replaces
+the selection with a normal \t character.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="enable" transfer-ownership="none">
+            <doc xml:space="preserve">whether to indent a block when tab is pressed.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_indent_width"
+              c:identifier="gtk_source_view_set_indent_width">
+        <doc xml:space="preserve">Sets the number of spaces to use for each step of indent when the tab key is
+pressed. If @width is -1, the value of the #GtkSourceView:tab-width property
+will be used.
+
+The #GtkSourceView:indent-width interacts with the
+#GtkSourceView:insert-spaces-instead-of-tabs property and
+#GtkSourceView:tab-width. An example will be clearer: if the
+#GtkSourceView:indent-width is 4 and
+#GtkSourceView:tab-width is 8 and
+#GtkSourceView:insert-spaces-instead-of-tabs is %FALSE, then pressing the tab
+key at the beginning of a line will insert 4 spaces. So far so good. Pressing
+the tab key a second time will remove the 4 spaces and insert a \t character
+instead (since #GtkSourceView:tab-width is 8). On the other hand, if
+#GtkSourceView:insert-spaces-instead-of-tabs is %TRUE, the second tab key
+pressed will insert 4 more spaces for a total of 8 spaces in the
+#GtkTextBuffer.
+
+The test-widget program (available in the GtkSourceView repository) may be
+useful to better understand the indentation settings (enable the space
+drawing!).</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="width" transfer-ownership="none">
+            <doc xml:space="preserve">indent width in characters.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_insert_spaces_instead_of_tabs"
+              c:identifier="gtk_source_view_set_insert_spaces_instead_of_tabs">
+        <doc xml:space="preserve">If %TRUE a tab key pressed is replaced by a group of space characters. Of
+course it is still possible to insert a real \t programmatically with the
+#GtkTextBuffer API.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="enable" transfer-ownership="none">
+            <doc xml:space="preserve">whether to insert spaces instead of tabs.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_mark_attributes"
+              c:identifier="gtk_source_view_set_mark_attributes">
+        <doc xml:space="preserve">Sets attributes and priority for the @category.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="category" transfer-ownership="none">
+            <doc xml:space="preserve">the category.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="attributes" transfer-ownership="none">
+            <doc xml:space="preserve">mark attributes.</doc>
+            <type name="MarkAttributes" c:type="GtkSourceMarkAttributes*"/>
+          </parameter>
+          <parameter name="priority" transfer-ownership="none">
+            <doc xml:space="preserve">priority of the category.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_right_margin_position"
+              c:identifier="gtk_source_view_set_right_margin_position">
+        <doc xml:space="preserve">Sets the position of the right margin in the given @view.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="pos" transfer-ownership="none">
+            <doc xml:space="preserve">the width in characters where to position the right margin.</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_show_line_marks"
+              c:identifier="gtk_source_view_set_show_line_marks"
+              version="2.2">
+        <doc xml:space="preserve">If %TRUE line marks will be displayed beside the text.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="show" transfer-ownership="none">
+            <doc xml:space="preserve">whether line marks should be displayed.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_show_line_numbers"
+              c:identifier="gtk_source_view_set_show_line_numbers">
+        <doc xml:space="preserve">If %TRUE line numbers will be displayed beside the text.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="show" transfer-ownership="none">
+            <doc xml:space="preserve">whether line numbers should be displayed.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_show_right_margin"
+              c:identifier="gtk_source_view_set_show_right_margin">
+        <doc xml:space="preserve">If %TRUE a right margin is displayed.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="show" transfer-ownership="none">
+            <doc xml:space="preserve">whether to show a right margin.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_smart_backspace"
+              c:identifier="gtk_source_view_set_smart_backspace"
+              version="3.18">
+        <doc xml:space="preserve">When set to %TRUE, pressing the Backspace key will try to delete spaces
+up to the previous tab stop.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="smart_backspace" transfer-ownership="none">
+            <doc xml:space="preserve">whether to enable smart Backspace handling.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_smart_home_end"
+              c:identifier="gtk_source_view_set_smart_home_end">
+        <doc xml:space="preserve">Set the desired movement of the cursor when HOME and END keys
+are pressed.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="smart_home_end" transfer-ownership="none">
+            <doc xml:space="preserve">the desired behavior among #GtkSourceSmartHomeEndType.</doc>
+            <type name="SmartHomeEndType" c:type="GtkSourceSmartHomeEndType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_tab_width"
+              c:identifier="gtk_source_view_set_tab_width">
+        <doc xml:space="preserve">Sets the width of tabulation in characters. The #GtkTextBuffer still contains
+\t characters, but they can take a different visual width in a #GtkSourceView
+widget.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="width" transfer-ownership="none">
+            <doc xml:space="preserve">width of tab in characters.</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="unindent_lines"
+              c:identifier="gtk_source_view_unindent_lines"
+              version="3.16">
+        <doc xml:space="preserve">Removes one indentation level at the beginning of the
+specified lines.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="view" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkSourceView.</doc>
+            <type name="View" c:type="GtkSourceView*"/>
+          </instance-parameter>
+          <parameter name="start" transfer-ownership="none">
+            <doc xml:space="preserve">#GtkTextIter of the first line to indent</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+          <parameter name="end" transfer-ownership="none">
+            <doc xml:space="preserve">#GtkTextIter of the last line to indent</doc>
+            <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="auto-indent" writable="1" transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="background-pattern"
+                version="3.16"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Draw a specific background pattern on the view.</doc>
+        <type name="BackgroundPatternType"/>
+      </property>
+      <property name="completion" transfer-ownership="none">
+        <doc xml:space="preserve">The completion object associated with the view</doc>
+        <type name="Completion"/>
+      </property>
+      <property name="draw-spaces"
+                version="2.4"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Set if and how the spaces should be visualized.
+
+For a finer-grained method, there is also the GtkSourceTag's
+#GtkSourceTag:draw-spaces property.</doc>
+        <type name="DrawSpacesFlags"/>
+      </property>
+      <property name="highlight-current-line"
+                writable="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="indent-on-tab" writable="1" transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="indent-width" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">Width of an indentation step expressed in number of spaces.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="insert-spaces-instead-of-tabs"
+                writable="1"
+                transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="right-margin-position"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Position of the right margin.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="show-line-marks" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">Whether to display line mark pixbufs</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="show-line-numbers"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Whether to display line numbers</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="show-right-margin"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Whether to display the right margin.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="smart-backspace"
+                version="3.18"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Whether smart Backspace should be used.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="smart-home-end"
+                version="2.0"
+                writable="1"
+                transfer-ownership="none">
+        <doc xml:space="preserve">Set the behavior of the HOME and END keys.</doc>
+        <type name="SmartHomeEndType"/>
+      </property>
+      <property name="tab-width" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">Width of a tab character expressed in number of spaces.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <field name="parent">
+        <type name="Gtk.TextView" c:type="GtkTextView"/>
+      </field>
+      <field name="priv">
+        <type name="ViewPrivate" c:type="GtkSourceViewPrivate*"/>
+      </field>
+      <glib:signal name="change-case" when="last" action="1" version="3.16">
+        <doc xml:space="preserve">Keybinding signal to change case of the text at the current cursor position.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="case_type" transfer-ownership="none">
+            <doc xml:space="preserve">the case to use</doc>
+            <type name="ChangeCaseType"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="change-number" when="last" action="1" version="3.16">
+        <doc xml:space="preserve">Keybinding signal to edit a number at the current cursor position.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="count" transfer-ownership="none">
+            <doc xml:space="preserve">the number to add to the number at the current position</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="join-lines" when="last" action="1" version="3.16">
+        <doc xml:space="preserve">Keybinding signal to join the lines currently selected.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+      <glib:signal name="line-mark-activated" when="last">
+        <doc xml:space="preserve">Emitted when a line mark has been activated (for instance when there
+was a button press in the line marks gutter). You can use @iter to
+determine on which line the activation took place.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter"/>
+          </parameter>
+          <parameter name="event" transfer-ownership="none">
+            <doc xml:space="preserve">the #GdkEvent that activated the event</doc>
+            <type name="Gdk.Event"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="move-lines" when="last" action="1" version="2.10">
+        <doc xml:space="preserve">The ::move-lines signal is a keybinding which gets emitted
+when the user initiates moving a line. The default binding key
+is Alt+Up/Down arrow. And moves the currently selected lines,
+or the current line by @count. For the moment, only
+@count of -1 or 1 is valid.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="copy" transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE if the line should be copied,
+       %FALSE if it should be moved</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+          <parameter name="count" transfer-ownership="none">
+            <doc xml:space="preserve">the number of lines to move over.</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="move-to-matching-bracket"
+                   when="last"
+                   action="1"
+                   version="3.16">
+        <doc xml:space="preserve">Keybinding signal to move the cursor to the matching bracket.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="extend_selection" transfer-ownership="none">
+            <doc xml:space="preserve">%TRUE if the move should extend the selection</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="move-words" when="last" action="1" version="3.0">
+        <doc xml:space="preserve">The ::move-words signal is a keybinding which gets emitted
+when the user initiates moving a word. The default binding key
+is Alt+Left/Right Arrow and moves the current selection, or the current
+word by one word.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="count" transfer-ownership="none">
+            <doc xml:space="preserve">the number of words to move over</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="redo" when="last" action="1">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+      <glib:signal name="show-completion" when="last" action="1">
+        <doc xml:space="preserve">The ::show-completion signal is a key binding signal which gets
+emitted when the user requests a completion, by pressing
+&lt;keycombo&gt;&lt;keycap&gt;Control&lt;/keycap&gt;&lt;keycap&gt;space&lt;/keycap&gt;&lt;/keycombo&gt;.
+
+This will create a #GtkSourceCompletionContext with the activation
+type as %GTK_SOURCE_COMPLETION_ACTIVATION_USER_REQUESTED.
+
+Applications should not connect to it, but may emit it with
+g_signal_emit_by_name() if they need to activate the completion by
+another means, for example with another key binding or a menu entry.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+      <glib:signal name="smart-home-end" when="last" version="3.0">
+        <doc xml:space="preserve">Emitted when a the cursor was moved according to the smart home
+end setting. The signal is emitted after the cursor is moved, but
+during the GtkTextView::move-cursor action. This can be used to find
+out whether the cursor was moved by a normal home/end or by a smart
+home/end.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="iter" transfer-ownership="none">
+            <doc xml:space="preserve">a #GtkTextIter</doc>
+            <type name="Gtk.TextIter"/>
+          </parameter>
+          <parameter name="count" transfer-ownership="none">
+            <doc xml:space="preserve">the count</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="undo" when="last" action="1">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+    </class>
+    <record name="ViewClass"
+            c:type="GtkSourceViewClass"
+            glib:is-gtype-struct-for="View">
+      <field name="parent_class">
+        <type name="Gtk.TextViewClass" c:type="GtkTextViewClass"/>
+      </field>
+      <field name="undo">
+        <callback name="undo">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="view" transfer-ownership="none">
+              <type name="View" c:type="GtkSourceView*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="redo">
+        <callback name="redo">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="view" transfer-ownership="none">
+              <type name="View" c:type="GtkSourceView*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="line_mark_activated">
+        <callback name="line_mark_activated">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="view" transfer-ownership="none">
+              <type name="View" c:type="GtkSourceView*"/>
+            </parameter>
+            <parameter name="iter" transfer-ownership="none">
+              <type name="Gtk.TextIter" c:type="GtkTextIter*"/>
+            </parameter>
+            <parameter name="event" transfer-ownership="none">
+              <type name="Gdk.Event" c:type="GdkEvent*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="show_completion">
+        <callback name="show_completion">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="view" transfer-ownership="none">
+              <type name="View" c:type="GtkSourceView*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="move_lines">
+        <callback name="move_lines">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="view" transfer-ownership="none">
+              <type name="View" c:type="GtkSourceView*"/>
+            </parameter>
+            <parameter name="copy" transfer-ownership="none">
+              <type name="gboolean" c:type="gboolean"/>
+            </parameter>
+            <parameter name="step" transfer-ownership="none">
+              <type name="gint" c:type="gint"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="move_words">
+        <callback name="move_words">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="view" transfer-ownership="none">
+              <type name="View" c:type="GtkSourceView*"/>
+            </parameter>
+            <parameter name="step" transfer-ownership="none">
+              <type name="gint" c:type="gint"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+    </record>
+    <enumeration name="ViewGutterPosition"
+                 glib:type-name="GtkSourceViewGutterPosition"
+                 glib:get-type="gtk_source_view_gutter_position_get_type"
+                 c:type="GtkSourceViewGutterPosition">
+      <member name="lines"
+              value="-30"
+              c:identifier="GTK_SOURCE_VIEW_GUTTER_POSITION_LINES"
+              glib:nick="lines">
+        <doc xml:space="preserve">the gutter position of the lines
+renderer</doc>
+      </member>
+      <member name="marks"
+              value="-20"
+              c:identifier="GTK_SOURCE_VIEW_GUTTER_POSITION_MARKS"
+              glib:nick="marks">
+        <doc xml:space="preserve">the gutter position of the marks
+renderer</doc>
+      </member>
+    </enumeration>
+    <record name="ViewPrivate" c:type="GtkSourceViewPrivate" disguised="1">
+    </record>
+    <function name="completion_error_quark"
+              c:identifier="gtk_source_completion_error_quark"
+              moved-to="CompletionError.quark">
+      <return-value transfer-ownership="none">
+        <type name="GLib.Quark" c:type="GQuark"/>
+      </return-value>
+    </function>
+    <function name="encoding_get_all"
+              c:identifier="gtk_source_encoding_get_all"
+              moved-to="Encoding.get_all"
+              version="3.14">
+      <doc xml:space="preserve">Gets all encodings.</doc>
+      <return-value transfer-ownership="container">
+        <doc xml:space="preserve">a list of
+all #GtkSourceEncoding's. Free with g_slist_free().</doc>
+        <type name="GLib.SList" c:type="GSList*">
+          <type name="Encoding"/>
+        </type>
+      </return-value>
+    </function>
+    <function name="encoding_get_current"
+              c:identifier="gtk_source_encoding_get_current"
+              moved-to="Encoding.get_current"
+              version="3.14">
+      <doc xml:space="preserve">Gets the #GtkSourceEncoding for the current locale. See also g_get_charset().</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">the current locale encoding.</doc>
+        <type name="Encoding" c:type="const GtkSourceEncoding*"/>
+      </return-value>
+    </function>
+    <function name="encoding_get_default_candidates"
+              c:identifier="gtk_source_encoding_get_default_candidates"
+              moved-to="Encoding.get_default_candidates"
+              version="3.18">
+      <doc xml:space="preserve">Gets the list of default candidate encodings to try when loading a file. See
+gtk_source_file_loader_set_candidate_encodings().
+
+This function returns a different list depending on the current locale (i.e.
+language, country and default encoding). The UTF-8 encoding and the current
+locale encoding are guaranteed to be present in the returned list.</doc>
+      <return-value transfer-ownership="container">
+        <doc xml:space="preserve">the list of
+default candidate encodings. Free with g_slist_free().</doc>
+        <type name="GLib.SList" c:type="GSList*">
+          <type name="Encoding"/>
+        </type>
+      </return-value>
+    </function>
+    <function name="encoding_get_from_charset"
+              c:identifier="gtk_source_encoding_get_from_charset"
+              moved-to="Encoding.get_from_charset"
+              version="3.14">
+      <doc xml:space="preserve">Gets a #GtkSourceEncoding from a character set such as "UTF-8" or
+"ISO-8859-1".</doc>
+      <return-value transfer-ownership="none" nullable="1">
+        <doc xml:space="preserve">the corresponding #GtkSourceEncoding, or %NULL
+if not found.</doc>
+        <type name="Encoding" c:type="const GtkSourceEncoding*"/>
+      </return-value>
+      <parameters>
+        <parameter name="charset" transfer-ownership="none">
+          <doc xml:space="preserve">a character set.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="encoding_get_utf8"
+              c:identifier="gtk_source_encoding_get_utf8"
+              moved-to="Encoding.get_utf8"
+              version="3.14">
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">the UTF-8 encoding.</doc>
+        <type name="Encoding" c:type="const GtkSourceEncoding*"/>
+      </return-value>
+    </function>
+    <function name="file_loader_error_quark"
+              c:identifier="gtk_source_file_loader_error_quark"
+              moved-to="FileLoaderError.quark">
+      <return-value transfer-ownership="none">
+        <type name="GLib.Quark" c:type="GQuark"/>
+      </return-value>
+    </function>
+    <function name="file_saver_error_quark"
+              c:identifier="gtk_source_file_saver_error_quark"
+              moved-to="FileSaverError.quark">
+      <return-value transfer-ownership="none">
+        <type name="GLib.Quark" c:type="GQuark"/>
+      </return-value>
+    </function>
+    <function name="utils_escape_search_text"
+              c:identifier="gtk_source_utils_escape_search_text"
+              version="3.10">
+      <doc xml:space="preserve">Use this function to escape the following characters: \n, \r, \t and \.
+
+For a regular expression search, use g_regex_escape_string() instead.
+
+One possible use case is to take the #GtkTextBuffer's selection and put it in a
+search entry. The selection can contain tabulations, newlines, etc. So it's
+better to escape those special characters to better fit in the search entry.
+
+See also: gtk_source_utils_unescape_search_text().
+
+&lt;warning&gt;
+Warning: the escape and unescape functions are not reciprocal! For example,
+escape (unescape (\)) = \\. So avoid cycles such as: search entry -&gt; unescape
+-&gt; search settings -&gt; escape -&gt; search entry. The original search entry text
+may be modified.
+&lt;/warning&gt;</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">the escaped @text.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </return-value>
+      <parameters>
+        <parameter name="text" transfer-ownership="none">
+          <doc xml:space="preserve">the text to escape.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="utils_unescape_search_text"
+              c:identifier="gtk_source_utils_unescape_search_text"
+              version="3.10">
+      <doc xml:space="preserve">Use this function before gtk_source_search_settings_set_search_text(), to
+unescape the following sequences of characters: \n, \r, \t and \\.
+The purpose is to easily write those characters in a search entry.
+
+Note that unescaping the search text is not needed for regular expression
+searches.
+
+See also: gtk_source_utils_escape_search_text().</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">the unescaped @text.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </return-value>
+      <parameters>
+        <parameter name="text" transfer-ownership="none">
+          <doc xml:space="preserve">the text to unescape.</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </parameter>
+      </parameters>
+    </function>
+  </namespace>
+</repository>


### PR DESCRIPTION
@EPashkin: With this gir file, when I try to generate the sys part with:

```
RUST_BACKTRACE=1 cargo run  -- -c ../sourceview/gir-sourceview.toml -d ../gir-files/ -m sys -o ../sourceview/sourceview-sys/
```

It breaks when trying to unwrap the package name. Any idea why? The output just in case:

```
> RUST_BACKTRACE=1 cargo run  -- -c ../sourceview/gir-sourceview.toml -d ../gir-files/ -m sys -o ../sourceview/sourceview-sys/
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/gir -c ../sourceview/gir-sourceview.toml -d ../gir-files/ -m sys -o ../sourceview/sourceview-sys/`
generating sys for GtkSourceView
Generating file "../sourceview/sourceview-sys/src/lib.rs"
generating sys build script for GtkSourceView
Generating file "../sourceview/sourceview-sys/build.rs"
thread 'main' panicked at 'Package name doesn't exist', src/libcore/option.rs:794
stack backtrace:
   0: std::sys::imp::backtrace::tracing::imp::unwind_backtrace
   1: std::panicking::default_hook::{{closure}}
   2: std::panicking::default_hook
   3: std::panicking::rust_panic_with_hook
   4: std::panicking::begin_panic
   5: std::panicking::begin_panic_fmt
   6: rust_begin_unwind
   7: core::panicking::panic_fmt
   8: core::option::expect_failed
   9: <core::option::Option<T>>::expect
  10: gir::codegen::sys::build::generate_build_script
  11: gir::codegen::sys::build::generate::{{closure}}
  12: gir::file_saver::save_to_file
  13: gir::codegen::sys::build::generate
  14: gir::codegen::sys::generate
  15: gir::codegen::generate
  16: gir::do_main
  17: gir::main
  18: __rust_maybe_catch_panic
  19: std::rt::lang_start
  20: main
```