### PR TITLE
Add missing includes in GLib, GObject, GdkPixbuf, Gtk and Pango.

### DIFF
--- a/GLib-2.0.gir
+++ b/GLib-2.0.gir
@@ -5,7 +5,7 @@ and/or use gtk-doc annotations.  -->
 <repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0" version="1.2">
   <package name="glib-2.0"/>
   <c:include name="glib.h"/>
-  <namespace name="GLib" version="2.0" shared-library="libglib-2.0.so.0,libgobject-2.0.so.0" c:identifier-prefixes="G" c:symbol-prefixes="g,glib">
+  <c:include name="glib-object.h"/><namespace name="GLib" version="2.0" shared-library="libglib-2.0.so.0,libgobject-2.0.so.0" c:identifier-prefixes="G" c:symbol-prefixes="g,glib">
     <alias name="DateDay" c:type="GDateDay">
       <doc xml:space="preserve">Integer representing a day of the month; between 1 and 31.
 #G_DATE_BAD_DAY represents an invalid day of the month.</doc>

--- a/GObject-2.0.gir
+++ b/GObject-2.0.gir
@@ -6,7 +6,7 @@ and/or use gtk-doc annotations.  -->
   <include name="GLib" version="2.0"/>
   <package name="gobject-2.0"/>
   <c:include name="glib-object.h"/>
-  <namespace name="GObject" version="2.0" shared-library="libgobject-2.0.so.0" c:identifier-prefixes="G" c:symbol-prefixes="g">
+  <c:include name="gobject/gvaluecollector.h"/><namespace name="GObject" version="2.0" shared-library="libgobject-2.0.so.0" c:identifier-prefixes="G" c:symbol-prefixes="g">
     <alias name="SignalCMarshaller" c:type="GSignalCMarshaller">
       <doc xml:space="preserve">This is the signature of marshaller functions, required to marshall
 arrays of parameter values to signal emissions into C language callback

--- a/GObject-2.0.gir
+++ b/GObject-2.0.gir
@@ -2,18 +2,11 @@
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
-<repository version="1.2"
-            xmlns="http://www.gtk.org/introspection/core/1.0"
-            xmlns:c="http://www.gtk.org/introspection/c/1.0"
-            xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+<repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0" version="1.2">
   <include name="GLib" version="2.0"/>
   <package name="gobject-2.0"/>
   <c:include name="glib-object.h"/>
-  <namespace name="GObject"
-             version="2.0"
-             shared-library="libgobject-2.0.so.0"
-             c:identifier-prefixes="G"
-             c:symbol-prefixes="g">
+  <namespace name="GObject" version="2.0" shared-library="libgobject-2.0.so.0" c:identifier-prefixes="G" c:symbol-prefixes="g">
     <alias name="SignalCMarshaller" c:type="GSignalCMarshaller">
       <doc xml:space="preserve">This is the signature of marshaller functions, required to marshall
 arrays of parameter values to signal emissions into C language callback
@@ -68,13 +61,7 @@ initialization process.</doc>
         </parameter>
       </parameters>
     </callback>
-    <class name="Binding"
-           c:symbol-prefix="binding"
-           c:type="GBinding"
-           version="2.26"
-           parent="Object"
-           glib:type-name="GBinding"
-           glib:get-type="g_binding_get_type">
+    <class name="Binding" c:symbol-prefix="binding" c:type="GBinding" version="2.26" parent="Object" glib:type-name="GBinding" glib:get-type="g_binding_get_type">
       <doc xml:space="preserve">#GBinding is the representation of a binding between a property on a
 #GObject instance (or source) and another property on another #GObject
 instance (or target). Whenever the source property changes, the same
@@ -152,9 +139,7 @@ and target properties, instead of relying on the last reference on the
 binding, source, and target instances to drop.
 
 #GBinding is available since GObject 2.26</doc>
-      <method name="get_flags"
-              c:identifier="g_binding_get_flags"
-              version="2.26">
+      <method name="get_flags" c:identifier="g_binding_get_flags" version="2.26">
         <doc xml:space="preserve">Retrieves the flags passed when constructing the #GBinding.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the #GBindingFlags used by the #GBinding</doc>
@@ -167,9 +152,7 @@ binding, source, and target instances to drop.
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_source"
-              c:identifier="g_binding_get_source"
-              version="2.26">
+      <method name="get_source" c:identifier="g_binding_get_source" version="2.26">
         <doc xml:space="preserve">Retrieves the #GObject instance used as the source of the binding.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the source #GObject</doc>
@@ -182,9 +165,7 @@ binding, source, and target instances to drop.
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_source_property"
-              c:identifier="g_binding_get_source_property"
-              version="2.26">
+      <method name="get_source_property" c:identifier="g_binding_get_source_property" version="2.26">
         <doc xml:space="preserve">Retrieves the name of the property of #GBinding:source used as the source
 of the binding.</doc>
         <return-value transfer-ownership="none">
@@ -198,9 +179,7 @@ of the binding.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_target"
-              c:identifier="g_binding_get_target"
-              version="2.26">
+      <method name="get_target" c:identifier="g_binding_get_target" version="2.26">
         <doc xml:space="preserve">Retrieves the #GObject instance used as the target of the binding.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the target #GObject</doc>
@@ -213,9 +192,7 @@ of the binding.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_target_property"
-              c:identifier="g_binding_get_target_property"
-              version="2.26">
+      <method name="get_target_property" c:identifier="g_binding_get_target_property" version="2.26">
         <doc xml:space="preserve">Retrieves the name of the property of #GBinding:target used as the target
 of the binding.</doc>
         <return-value transfer-ownership="none">
@@ -247,85 +224,49 @@ to it.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <property name="flags"
-                version="2.26"
-                writable="1"
-                construct-only="1"
-                transfer-ownership="none">
+      <property name="flags" version="2.26" writable="1" construct-only="1" transfer-ownership="none">
         <doc xml:space="preserve">Flags to be used to control the #GBinding</doc>
         <type name="BindingFlags"/>
       </property>
-      <property name="source"
-                version="2.26"
-                writable="1"
-                construct-only="1"
-                transfer-ownership="none">
+      <property name="source" version="2.26" writable="1" construct-only="1" transfer-ownership="none">
         <doc xml:space="preserve">The #GObject that should be used as the source of the binding</doc>
         <type name="Object"/>
       </property>
-      <property name="source-property"
-                version="2.26"
-                writable="1"
-                construct-only="1"
-                transfer-ownership="none">
+      <property name="source-property" version="2.26" writable="1" construct-only="1" transfer-ownership="none">
         <doc xml:space="preserve">The name of the property of #GBinding:source that should be used
 as the source of the binding</doc>
         <type name="utf8" c:type="gchar*"/>
       </property>
-      <property name="target"
-                version="2.26"
-                writable="1"
-                construct-only="1"
-                transfer-ownership="none">
+      <property name="target" version="2.26" writable="1" construct-only="1" transfer-ownership="none">
         <doc xml:space="preserve">The #GObject that should be used as the target of the binding</doc>
         <type name="Object"/>
       </property>
-      <property name="target-property"
-                version="2.26"
-                writable="1"
-                construct-only="1"
-                transfer-ownership="none">
+      <property name="target-property" version="2.26" writable="1" construct-only="1" transfer-ownership="none">
         <doc xml:space="preserve">The name of the property of #GBinding:target that should be used
 as the target of the binding</doc>
         <type name="utf8" c:type="gchar*"/>
       </property>
     </class>
-    <bitfield name="BindingFlags"
-              version="2.26"
-              glib:type-name="GBindingFlags"
-              glib:get-type="g_binding_flags_get_type"
-              c:type="GBindingFlags">
+    <bitfield name="BindingFlags" version="2.26" glib:type-name="GBindingFlags" glib:get-type="g_binding_flags_get_type" c:type="GBindingFlags">
       <doc xml:space="preserve">Flags to be passed to g_object_bind_property() or
 g_object_bind_property_full().
 
 This enumeration can be extended at later date.</doc>
-      <member name="default"
-              value="0"
-              c:identifier="G_BINDING_DEFAULT"
-              glib:nick="default">
+      <member name="default" value="0" c:identifier="G_BINDING_DEFAULT" glib:nick="default">
         <doc xml:space="preserve">The default binding; if the source property
   changes, the target property is updated with its value.</doc>
       </member>
-      <member name="bidirectional"
-              value="1"
-              c:identifier="G_BINDING_BIDIRECTIONAL"
-              glib:nick="bidirectional">
+      <member name="bidirectional" value="1" c:identifier="G_BINDING_BIDIRECTIONAL" glib:nick="bidirectional">
         <doc xml:space="preserve">Bidirectional binding; if either the
   property of the source or the property of the target changes,
   the other is updated.</doc>
       </member>
-      <member name="sync_create"
-              value="2"
-              c:identifier="G_BINDING_SYNC_CREATE"
-              glib:nick="sync-create">
+      <member name="sync_create" value="2" c:identifier="G_BINDING_SYNC_CREATE" glib:nick="sync-create">
         <doc xml:space="preserve">Synchronize the values of the source and
   target properties when creating the binding; the direction of
   the synchronization is always from the source to the target.</doc>
       </member>
-      <member name="invert_boolean"
-              value="4"
-              c:identifier="G_BINDING_INVERT_BOOLEAN"
-              glib:nick="invert-boolean">
+      <member name="invert_boolean" value="4" c:identifier="G_BINDING_INVERT_BOOLEAN" glib:nick="invert-boolean">
         <doc xml:space="preserve">If the two properties being bound are
   booleans, setting one to %TRUE will result in the other being
   set to %FALSE and vice versa. This flag will only work for
@@ -333,9 +274,7 @@ This enumeration can be extended at later date.</doc>
   transformation functions to g_object_bind_property_full().</doc>
       </member>
     </bitfield>
-    <callback name="BindingTransformFunc"
-              c:type="GBindingTransformFunc"
-              version="2.26">
+    <callback name="BindingTransformFunc" c:type="GBindingTransformFunc" version="2.26">
       <doc xml:space="preserve">A function to be called to transform @from_value to @to_value. If
 this is the @transform_to function of a binding, then @from_value
 is the @source_property on the @source object, and @to_value is the
@@ -360,11 +299,7 @@ then those roles are reversed.</doc>
           <doc xml:space="preserve">the #GValue in which to store the transformed value</doc>
           <type name="Value" c:type="GValue*"/>
         </parameter>
-        <parameter name="user_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1"
-                   closure="3">
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="3">
           <doc xml:space="preserve">data passed to the transform function</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -407,8 +342,7 @@ structure passed.</doc>
         <doc xml:space="preserve">the callback function</doc>
         <type name="gpointer" c:type="gpointer"/>
       </field>
-      <function name="marshal_BOOLEAN__BOXED_BOXED"
-                c:identifier="g_cclosure_marshal_BOOLEAN__BOXED_BOXED">
+      <function name="marshal_BOOLEAN__BOXED_BOXED" c:identifier="g_cclosure_marshal_BOOLEAN__BOXED_BOXED">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with handlers that
 take two boxed pointers as arguments and return a boolean.  If you
 have such a signal, you will probably also need to use an
@@ -435,18 +369,12 @@ accumulator, such as g_signal_accumulator_true_handled().</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -454,9 +382,7 @@ accumulator, such as g_signal_accumulator_true_handled().</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_BOOLEAN__BOXED_BOXEDv"
-                c:identifier="g_cclosure_marshal_BOOLEAN__BOXED_BOXEDv"
-                introspectable="0">
+      <function name="marshal_BOOLEAN__BOXED_BOXEDv" c:identifier="g_cclosure_marshal_BOOLEAN__BOXED_BOXEDv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_BOOLEAN__BOXED_BOXED().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -466,10 +392,7 @@ accumulator, such as g_signal_accumulator_true_handled().</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -483,10 +406,7 @@ accumulator, such as g_signal_accumulator_true_handled().</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -505,8 +425,7 @@ accumulator, such as g_signal_accumulator_true_handled().</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_BOOLEAN__FLAGS"
-                c:identifier="g_cclosure_marshal_BOOLEAN__FLAGS">
+      <function name="marshal_BOOLEAN__FLAGS" c:identifier="g_cclosure_marshal_BOOLEAN__FLAGS">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with handlers that
 take a flags type as an argument and return a boolean.  If you have
 such a signal, you will probably also need to use an accumulator,
@@ -533,18 +452,12 @@ such as g_signal_accumulator_true_handled().</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -552,9 +465,7 @@ such as g_signal_accumulator_true_handled().</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_BOOLEAN__FLAGSv"
-                c:identifier="g_cclosure_marshal_BOOLEAN__FLAGSv"
-                introspectable="0">
+      <function name="marshal_BOOLEAN__FLAGSv" c:identifier="g_cclosure_marshal_BOOLEAN__FLAGSv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_BOOLEAN__FLAGS().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -564,10 +475,7 @@ such as g_signal_accumulator_true_handled().</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -581,10 +489,7 @@ such as g_signal_accumulator_true_handled().</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -603,8 +508,7 @@ such as g_signal_accumulator_true_handled().</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_STRING__OBJECT_POINTER"
-                c:identifier="g_cclosure_marshal_STRING__OBJECT_POINTER">
+      <function name="marshal_STRING__OBJECT_POINTER" c:identifier="g_cclosure_marshal_STRING__OBJECT_POINTER">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with handlers that
 take a #GObject and a pointer and produce a string.  It is highly
 unlikely that your signal handler fits this description.</doc>
@@ -630,18 +534,12 @@ unlikely that your signal handler fits this description.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -649,9 +547,7 @@ unlikely that your signal handler fits this description.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_STRING__OBJECT_POINTERv"
-                c:identifier="g_cclosure_marshal_STRING__OBJECT_POINTERv"
-                introspectable="0">
+      <function name="marshal_STRING__OBJECT_POINTERv" c:identifier="g_cclosure_marshal_STRING__OBJECT_POINTERv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_STRING__OBJECT_POINTER().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -661,10 +557,7 @@ unlikely that your signal handler fits this description.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -678,10 +571,7 @@ unlikely that your signal handler fits this description.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -700,8 +590,7 @@ unlikely that your signal handler fits this description.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__BOOLEAN"
-                c:identifier="g_cclosure_marshal_VOID__BOOLEAN">
+      <function name="marshal_VOID__BOOLEAN" c:identifier="g_cclosure_marshal_VOID__BOOLEAN">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 boolean argument.</doc>
         <return-value transfer-ownership="none">
@@ -726,18 +615,12 @@ boolean argument.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -745,9 +628,7 @@ boolean argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__BOOLEANv"
-                c:identifier="g_cclosure_marshal_VOID__BOOLEANv"
-                introspectable="0">
+      <function name="marshal_VOID__BOOLEANv" c:identifier="g_cclosure_marshal_VOID__BOOLEANv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__BOOLEAN().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -757,10 +638,7 @@ boolean argument.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -774,10 +652,7 @@ boolean argument.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -796,8 +671,7 @@ boolean argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__BOXED"
-                c:identifier="g_cclosure_marshal_VOID__BOXED">
+      <function name="marshal_VOID__BOXED" c:identifier="g_cclosure_marshal_VOID__BOXED">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 argument which is any boxed pointer type.</doc>
         <return-value transfer-ownership="none">
@@ -822,18 +696,12 @@ argument which is any boxed pointer type.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -841,9 +709,7 @@ argument which is any boxed pointer type.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__BOXEDv"
-                c:identifier="g_cclosure_marshal_VOID__BOXEDv"
-                introspectable="0">
+      <function name="marshal_VOID__BOXEDv" c:identifier="g_cclosure_marshal_VOID__BOXEDv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__BOXED().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -853,10 +719,7 @@ argument which is any boxed pointer type.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -870,10 +733,7 @@ argument which is any boxed pointer type.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -892,8 +752,7 @@ argument which is any boxed pointer type.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__CHAR"
-                c:identifier="g_cclosure_marshal_VOID__CHAR">
+      <function name="marshal_VOID__CHAR" c:identifier="g_cclosure_marshal_VOID__CHAR">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 character argument.</doc>
         <return-value transfer-ownership="none">
@@ -918,18 +777,12 @@ character argument.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -937,9 +790,7 @@ character argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__CHARv"
-                c:identifier="g_cclosure_marshal_VOID__CHARv"
-                introspectable="0">
+      <function name="marshal_VOID__CHARv" c:identifier="g_cclosure_marshal_VOID__CHARv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__CHAR().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -949,10 +800,7 @@ character argument.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -966,10 +814,7 @@ character argument.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -988,8 +833,7 @@ character argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__DOUBLE"
-                c:identifier="g_cclosure_marshal_VOID__DOUBLE">
+      <function name="marshal_VOID__DOUBLE" c:identifier="g_cclosure_marshal_VOID__DOUBLE">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with one
 double-precision floating point argument.</doc>
         <return-value transfer-ownership="none">
@@ -1014,18 +858,12 @@ double-precision floating point argument.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -1033,9 +871,7 @@ double-precision floating point argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__DOUBLEv"
-                c:identifier="g_cclosure_marshal_VOID__DOUBLEv"
-                introspectable="0">
+      <function name="marshal_VOID__DOUBLEv" c:identifier="g_cclosure_marshal_VOID__DOUBLEv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__DOUBLE().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -1045,10 +881,7 @@ double-precision floating point argument.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -1062,10 +895,7 @@ double-precision floating point argument.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -1084,8 +914,7 @@ double-precision floating point argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__ENUM"
-                c:identifier="g_cclosure_marshal_VOID__ENUM">
+      <function name="marshal_VOID__ENUM" c:identifier="g_cclosure_marshal_VOID__ENUM">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 argument with an enumerated type.</doc>
         <return-value transfer-ownership="none">
@@ -1110,18 +939,12 @@ argument with an enumerated type.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -1129,9 +952,7 @@ argument with an enumerated type.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__ENUMv"
-                c:identifier="g_cclosure_marshal_VOID__ENUMv"
-                introspectable="0">
+      <function name="marshal_VOID__ENUMv" c:identifier="g_cclosure_marshal_VOID__ENUMv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__ENUM().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -1141,10 +962,7 @@ argument with an enumerated type.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -1158,10 +976,7 @@ argument with an enumerated type.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -1180,8 +995,7 @@ argument with an enumerated type.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__FLAGS"
-                c:identifier="g_cclosure_marshal_VOID__FLAGS">
+      <function name="marshal_VOID__FLAGS" c:identifier="g_cclosure_marshal_VOID__FLAGS">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 argument with a flags types.</doc>
         <return-value transfer-ownership="none">
@@ -1206,18 +1020,12 @@ argument with a flags types.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -1225,9 +1033,7 @@ argument with a flags types.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__FLAGSv"
-                c:identifier="g_cclosure_marshal_VOID__FLAGSv"
-                introspectable="0">
+      <function name="marshal_VOID__FLAGSv" c:identifier="g_cclosure_marshal_VOID__FLAGSv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__FLAGS().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -1237,10 +1043,7 @@ argument with a flags types.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -1254,10 +1057,7 @@ argument with a flags types.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -1276,8 +1076,7 @@ argument with a flags types.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__FLOAT"
-                c:identifier="g_cclosure_marshal_VOID__FLOAT">
+      <function name="marshal_VOID__FLOAT" c:identifier="g_cclosure_marshal_VOID__FLOAT">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with one
 single-precision floating point argument.</doc>
         <return-value transfer-ownership="none">
@@ -1302,18 +1101,12 @@ single-precision floating point argument.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -1321,9 +1114,7 @@ single-precision floating point argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__FLOATv"
-                c:identifier="g_cclosure_marshal_VOID__FLOATv"
-                introspectable="0">
+      <function name="marshal_VOID__FLOATv" c:identifier="g_cclosure_marshal_VOID__FLOATv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__FLOAT().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -1333,10 +1124,7 @@ single-precision floating point argument.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -1350,10 +1138,7 @@ single-precision floating point argument.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -1372,8 +1157,7 @@ single-precision floating point argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__INT"
-                c:identifier="g_cclosure_marshal_VOID__INT">
+      <function name="marshal_VOID__INT" c:identifier="g_cclosure_marshal_VOID__INT">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 integer argument.</doc>
         <return-value transfer-ownership="none">
@@ -1398,18 +1182,12 @@ integer argument.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -1417,9 +1195,7 @@ integer argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__INTv"
-                c:identifier="g_cclosure_marshal_VOID__INTv"
-                introspectable="0">
+      <function name="marshal_VOID__INTv" c:identifier="g_cclosure_marshal_VOID__INTv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__INT().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -1429,10 +1205,7 @@ integer argument.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -1446,10 +1219,7 @@ integer argument.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -1468,8 +1238,7 @@ integer argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__LONG"
-                c:identifier="g_cclosure_marshal_VOID__LONG">
+      <function name="marshal_VOID__LONG" c:identifier="g_cclosure_marshal_VOID__LONG">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with with a single
 long integer argument.</doc>
         <return-value transfer-ownership="none">
@@ -1494,18 +1263,12 @@ long integer argument.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -1513,9 +1276,7 @@ long integer argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__LONGv"
-                c:identifier="g_cclosure_marshal_VOID__LONGv"
-                introspectable="0">
+      <function name="marshal_VOID__LONGv" c:identifier="g_cclosure_marshal_VOID__LONGv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__LONG().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -1525,10 +1286,7 @@ long integer argument.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -1542,10 +1300,7 @@ long integer argument.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -1564,8 +1319,7 @@ long integer argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__OBJECT"
-                c:identifier="g_cclosure_marshal_VOID__OBJECT">
+      <function name="marshal_VOID__OBJECT" c:identifier="g_cclosure_marshal_VOID__OBJECT">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 #GObject argument.</doc>
         <return-value transfer-ownership="none">
@@ -1590,18 +1344,12 @@ long integer argument.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -1609,9 +1357,7 @@ long integer argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__OBJECTv"
-                c:identifier="g_cclosure_marshal_VOID__OBJECTv"
-                introspectable="0">
+      <function name="marshal_VOID__OBJECTv" c:identifier="g_cclosure_marshal_VOID__OBJECTv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__OBJECT().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -1621,10 +1367,7 @@ long integer argument.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -1638,10 +1381,7 @@ long integer argument.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -1660,8 +1400,7 @@ long integer argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__PARAM"
-                c:identifier="g_cclosure_marshal_VOID__PARAM">
+      <function name="marshal_VOID__PARAM" c:identifier="g_cclosure_marshal_VOID__PARAM">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 argument of type #GParamSpec.</doc>
         <return-value transfer-ownership="none">
@@ -1686,18 +1425,12 @@ argument of type #GParamSpec.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -1705,9 +1438,7 @@ argument of type #GParamSpec.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__PARAMv"
-                c:identifier="g_cclosure_marshal_VOID__PARAMv"
-                introspectable="0">
+      <function name="marshal_VOID__PARAMv" c:identifier="g_cclosure_marshal_VOID__PARAMv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__PARAM().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -1717,10 +1448,7 @@ argument of type #GParamSpec.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -1734,10 +1462,7 @@ argument of type #GParamSpec.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -1756,8 +1481,7 @@ argument of type #GParamSpec.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__POINTER"
-                c:identifier="g_cclosure_marshal_VOID__POINTER">
+      <function name="marshal_VOID__POINTER" c:identifier="g_cclosure_marshal_VOID__POINTER">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single raw
 pointer argument type.
 
@@ -1786,18 +1510,12 @@ g_cclosure_marshal_VOID__OBJECT().</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -1805,9 +1523,7 @@ g_cclosure_marshal_VOID__OBJECT().</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__POINTERv"
-                c:identifier="g_cclosure_marshal_VOID__POINTERv"
-                introspectable="0">
+      <function name="marshal_VOID__POINTERv" c:identifier="g_cclosure_marshal_VOID__POINTERv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__POINTER().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -1817,10 +1533,7 @@ g_cclosure_marshal_VOID__OBJECT().</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -1834,10 +1547,7 @@ g_cclosure_marshal_VOID__OBJECT().</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -1856,8 +1566,7 @@ g_cclosure_marshal_VOID__OBJECT().</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__STRING"
-                c:identifier="g_cclosure_marshal_VOID__STRING">
+      <function name="marshal_VOID__STRING" c:identifier="g_cclosure_marshal_VOID__STRING">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single string
 argument.</doc>
         <return-value transfer-ownership="none">
@@ -1882,18 +1591,12 @@ argument.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -1901,9 +1604,7 @@ argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__STRINGv"
-                c:identifier="g_cclosure_marshal_VOID__STRINGv"
-                introspectable="0">
+      <function name="marshal_VOID__STRINGv" c:identifier="g_cclosure_marshal_VOID__STRINGv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__STRING().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -1913,10 +1614,7 @@ argument.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -1930,10 +1628,7 @@ argument.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -1952,8 +1647,7 @@ argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__UCHAR"
-                c:identifier="g_cclosure_marshal_VOID__UCHAR">
+      <function name="marshal_VOID__UCHAR" c:identifier="g_cclosure_marshal_VOID__UCHAR">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 unsigned character argument.</doc>
         <return-value transfer-ownership="none">
@@ -1978,18 +1672,12 @@ unsigned character argument.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -1997,9 +1685,7 @@ unsigned character argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__UCHARv"
-                c:identifier="g_cclosure_marshal_VOID__UCHARv"
-                introspectable="0">
+      <function name="marshal_VOID__UCHARv" c:identifier="g_cclosure_marshal_VOID__UCHARv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__UCHAR().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -2009,10 +1695,7 @@ unsigned character argument.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -2026,10 +1709,7 @@ unsigned character argument.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -2048,8 +1728,7 @@ unsigned character argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__UINT"
-                c:identifier="g_cclosure_marshal_VOID__UINT">
+      <function name="marshal_VOID__UINT" c:identifier="g_cclosure_marshal_VOID__UINT">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with with a single
 unsigned integer argument.</doc>
         <return-value transfer-ownership="none">
@@ -2074,18 +1753,12 @@ unsigned integer argument.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -2093,8 +1766,7 @@ unsigned integer argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__UINT_POINTER"
-                c:identifier="g_cclosure_marshal_VOID__UINT_POINTER">
+      <function name="marshal_VOID__UINT_POINTER" c:identifier="g_cclosure_marshal_VOID__UINT_POINTER">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a unsigned int
 and a pointer as arguments.</doc>
         <return-value transfer-ownership="none">
@@ -2119,18 +1791,12 @@ and a pointer as arguments.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -2138,9 +1804,7 @@ and a pointer as arguments.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__UINT_POINTERv"
-                c:identifier="g_cclosure_marshal_VOID__UINT_POINTERv"
-                introspectable="0">
+      <function name="marshal_VOID__UINT_POINTERv" c:identifier="g_cclosure_marshal_VOID__UINT_POINTERv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__UINT_POINTER().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -2150,10 +1814,7 @@ and a pointer as arguments.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -2167,10 +1828,7 @@ and a pointer as arguments.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -2189,9 +1847,7 @@ and a pointer as arguments.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__UINTv"
-                c:identifier="g_cclosure_marshal_VOID__UINTv"
-                introspectable="0">
+      <function name="marshal_VOID__UINTv" c:identifier="g_cclosure_marshal_VOID__UINTv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__UINT().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -2201,10 +1857,7 @@ and a pointer as arguments.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -2218,10 +1871,7 @@ and a pointer as arguments.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -2240,8 +1890,7 @@ and a pointer as arguments.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__ULONG"
-                c:identifier="g_cclosure_marshal_VOID__ULONG">
+      <function name="marshal_VOID__ULONG" c:identifier="g_cclosure_marshal_VOID__ULONG">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 unsigned long integer argument.</doc>
         <return-value transfer-ownership="none">
@@ -2266,18 +1915,12 @@ unsigned long integer argument.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -2285,9 +1928,7 @@ unsigned long integer argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__ULONGv"
-                c:identifier="g_cclosure_marshal_VOID__ULONGv"
-                introspectable="0">
+      <function name="marshal_VOID__ULONGv" c:identifier="g_cclosure_marshal_VOID__ULONGv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__ULONG().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -2297,10 +1938,7 @@ unsigned long integer argument.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -2314,10 +1952,7 @@ unsigned long integer argument.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -2336,8 +1971,7 @@ unsigned long integer argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__VARIANT"
-                c:identifier="g_cclosure_marshal_VOID__VARIANT">
+      <function name="marshal_VOID__VARIANT" c:identifier="g_cclosure_marshal_VOID__VARIANT">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 #GVariant argument.</doc>
         <return-value transfer-ownership="none">
@@ -2362,18 +1996,12 @@ unsigned long integer argument.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -2381,9 +2009,7 @@ unsigned long integer argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__VARIANTv"
-                c:identifier="g_cclosure_marshal_VOID__VARIANTv"
-                introspectable="0">
+      <function name="marshal_VOID__VARIANTv" c:identifier="g_cclosure_marshal_VOID__VARIANTv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__VARIANT().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -2393,10 +2019,7 @@ unsigned long integer argument.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -2410,10 +2033,7 @@ unsigned long integer argument.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -2432,8 +2052,7 @@ unsigned long integer argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__VOID"
-                c:identifier="g_cclosure_marshal_VOID__VOID">
+      <function name="marshal_VOID__VOID" c:identifier="g_cclosure_marshal_VOID__VOID">
         <doc xml:space="preserve">A #GClosureMarshal function for use with signals with no arguments.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -2457,18 +2076,12 @@ unsigned long integer argument.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -2476,9 +2089,7 @@ unsigned long integer argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_VOID__VOIDv"
-                c:identifier="g_cclosure_marshal_VOID__VOIDv"
-                introspectable="0">
+      <function name="marshal_VOID__VOIDv" c:identifier="g_cclosure_marshal_VOID__VOIDv" introspectable="0">
         <doc xml:space="preserve">The #GVaClosureMarshal equivalent to g_cclosure_marshal_VOID__VOID().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -2488,10 +2099,7 @@ unsigned long integer argument.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -2505,10 +2113,7 @@ unsigned long integer argument.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -2527,9 +2132,7 @@ unsigned long integer argument.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_generic"
-                c:identifier="g_cclosure_marshal_generic"
-                version="2.30">
+      <function name="marshal_generic" c:identifier="g_cclosure_marshal_generic" version="2.30">
         <doc xml:space="preserve">A generic marshaller function implemented via
 [libffi](http://sourceware.org/libffi/).
 
@@ -2557,18 +2160,12 @@ but used automatically by GLib when specifying a %NULL marshaller.</doc>
   on which to invoke the callback of closure.</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -2576,10 +2173,7 @@ but used automatically by GLib when specifying a %NULL marshaller.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="marshal_generic_va"
-                c:identifier="g_cclosure_marshal_generic_va"
-                version="2.30"
-                introspectable="0">
+      <function name="marshal_generic_va" c:identifier="g_cclosure_marshal_generic_va" version="2.30" introspectable="0">
         <doc xml:space="preserve">A generic #GVaClosureMarshal function implemented via
 [libffi](http://sourceware.org/libffi/).</doc>
         <return-value transfer-ownership="none">
@@ -2590,10 +2184,7 @@ but used automatically by GLib when specifying a %NULL marshaller.</doc>
             <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
             <type name="Closure" c:type="GClosure*"/>
           </parameter>
-          <parameter name="return_value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -2608,10 +2199,7 @@ but used automatically by GLib when specifying a %NULL marshaller.</doc>
             <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
             <type name="va_list" c:type="va_list"/>
           </parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -2638,19 +2226,11 @@ the last parameter.</doc>
           <type name="Closure" c:type="GClosure*"/>
         </return-value>
         <parameters>
-          <parameter name="callback_func"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     closure="1">
+          <parameter name="callback_func" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
             <doc xml:space="preserve">the function to invoke</doc>
             <type name="Callback" c:type="GCallback"/>
           </parameter>
-          <parameter name="user_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     closure="0">
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="0">
             <doc xml:space="preserve">user data to pass to @callback_func</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -2660,9 +2240,7 @@ the last parameter.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="new_object"
-                c:identifier="g_cclosure_new_object"
-                introspectable="0">
+      <function name="new_object" c:identifier="g_cclosure_new_object" introspectable="0">
         <doc xml:space="preserve">A variant of g_cclosure_new() which uses @object as @user_data and
 calls g_object_watch_closure() on @object and the created
 closure. This function is useful when you have a callback closely
@@ -2683,9 +2261,7 @@ after the object is is freed.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="new_object_swap"
-                c:identifier="g_cclosure_new_object_swap"
-                introspectable="0">
+      <function name="new_object_swap" c:identifier="g_cclosure_new_object_swap" introspectable="0">
         <doc xml:space="preserve">A variant of g_cclosure_new_swap() which uses @object as @user_data
 and calls g_object_watch_closure() on @object and the created
 closure. This function is useful when you have a callback closely
@@ -2706,9 +2282,7 @@ after the object is is freed.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="new_swap"
-                c:identifier="g_cclosure_new_swap"
-                introspectable="0">
+      <function name="new_swap" c:identifier="g_cclosure_new_swap" introspectable="0">
         <doc xml:space="preserve">Creates a new closure which invokes @callback_func with @user_data as
 the first parameter.</doc>
         <return-value transfer-ownership="full">
@@ -2716,19 +2290,11 @@ the first parameter.</doc>
           <type name="Closure" c:type="GClosure*"/>
         </return-value>
         <parameters>
-          <parameter name="callback_func"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     closure="1">
+          <parameter name="callback_func" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
             <doc xml:space="preserve">the function to invoke</doc>
             <type name="Callback" c:type="GCallback"/>
           </parameter>
-          <parameter name="user_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     closure="0">
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="0">
             <doc xml:space="preserve">user data to pass to @callback_func</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -2765,10 +2331,7 @@ reference count drops to zero).</doc>
           <doc xml:space="preserve">The #GTypeClass structure to finalize</doc>
           <type name="TypeClass" c:type="gpointer"/>
         </parameter>
-        <parameter name="class_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="class_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The @class_data member supplied via the #GTypeInfo structure</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -2878,20 +2441,13 @@ time.</doc>
           <doc xml:space="preserve">The #GTypeClass structure to initialize.</doc>
           <type name="TypeClass" c:type="gpointer"/>
         </parameter>
-        <parameter name="class_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="class_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The @class_data member supplied via the #GTypeInfo structure.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
       </parameters>
     </callback>
-    <record name="Closure"
-            c:type="GClosure"
-            glib:type-name="GClosure"
-            glib:get-type="g_closure_get_type"
-            c:symbol-prefix="closure">
+    <record name="Closure" c:type="GClosure" glib:type-name="GClosure" glib:get-type="g_closure_get_type" c:symbol-prefix="closure">
       <doc xml:space="preserve">A #GClosure represents a callback supplied by the programmer. It
 will generally comprise a function of some kind and a marshaller
 used to call it. It is the responsibility of the marshaller to
@@ -3069,18 +2625,13 @@ MyClosure *my_closure_new (gpointer data)
                  `sizeof (GClosure)`</doc>
             <type name="guint" c:type="guint"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">data to store in the @data field of the newly allocated #GClosure</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </constructor>
-      <method name="add_finalize_notifier"
-              c:identifier="g_closure_add_finalize_notifier"
-              introspectable="0">
+      <method name="add_finalize_notifier" c:identifier="g_closure_add_finalize_notifier" introspectable="0">
         <doc xml:space="preserve">Registers a finalization notifier which will be called when the
 reference count of @closure goes down to 0. Multiple finalization
 notifiers on a single closure are invoked in unspecified order. If
@@ -3095,26 +2646,17 @@ be run before the finalize notifiers.</doc>
             <doc xml:space="preserve">a #GClosure</doc>
             <type name="Closure" c:type="GClosure*"/>
           </instance-parameter>
-          <parameter name="notify_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     closure="1">
+          <parameter name="notify_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
             <doc xml:space="preserve">data to pass to @notify_func</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="notify_func"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="notify_func" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the callback function to register</doc>
             <type name="ClosureNotify" c:type="GClosureNotify"/>
           </parameter>
         </parameters>
       </method>
-      <method name="add_invalidate_notifier"
-              c:identifier="g_closure_add_invalidate_notifier"
-              introspectable="0">
+      <method name="add_invalidate_notifier" c:identifier="g_closure_add_invalidate_notifier" introspectable="0">
         <doc xml:space="preserve">Registers an invalidation notifier which will be called when the
 @closure is invalidated with g_closure_invalidate(). Invalidation
 notifiers are invoked before finalization notifiers, in an
@@ -3127,26 +2669,17 @@ unspecified order.</doc>
             <doc xml:space="preserve">a #GClosure</doc>
             <type name="Closure" c:type="GClosure*"/>
           </instance-parameter>
-          <parameter name="notify_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     closure="1">
+          <parameter name="notify_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
             <doc xml:space="preserve">data to pass to @notify_func</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="notify_func"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="notify_func" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the callback function to register</doc>
             <type name="ClosureNotify" c:type="GClosureNotify"/>
           </parameter>
         </parameters>
       </method>
-      <method name="add_marshal_guards"
-              c:identifier="g_closure_add_marshal_guards"
-              introspectable="0">
+      <method name="add_marshal_guards" c:identifier="g_closure_add_marshal_guards" introspectable="0">
         <doc xml:space="preserve">Adds a pair of notifiers which get invoked before and after the
 closure callback, respectively. This is typically used to protect
 the extra arguments for the duration of the callback. See
@@ -3159,36 +2692,21 @@ g_object_watch_closure() for an example of marshal guards.</doc>
             <doc xml:space="preserve">a #GClosure</doc>
             <type name="Closure" c:type="GClosure*"/>
           </instance-parameter>
-          <parameter name="pre_marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     closure="1">
+          <parameter name="pre_marshal_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
             <doc xml:space="preserve">data to pass
  to @pre_marshal_notify</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="pre_marshal_notify"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     closure="2">
+          <parameter name="pre_marshal_notify" transfer-ownership="none" nullable="1" allow-none="1" closure="2">
             <doc xml:space="preserve">a function to call before the closure callback</doc>
             <type name="ClosureNotify" c:type="GClosureNotify"/>
           </parameter>
-          <parameter name="post_marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     closure="3">
+          <parameter name="post_marshal_data" transfer-ownership="none" nullable="1" allow-none="1" closure="3">
             <doc xml:space="preserve">data to pass
  to @post_marshal_notify</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="post_marshal_notify"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="post_marshal_notify" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a function to call after the closure callback</doc>
             <type name="ClosureNotify" c:type="GClosureNotify"/>
           </parameter>
@@ -3228,12 +2746,7 @@ been invalidated before).</doc>
             <doc xml:space="preserve">a #GClosure</doc>
             <type name="Closure" c:type="GClosure*"/>
           </instance-parameter>
-          <parameter name="return_value"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="return_value" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">a #GValue to store the return
                value. May be %NULL if the callback of @closure
                doesn't return a value.</doc>
@@ -3251,10 +2764,7 @@ been invalidated before).</doc>
               <type name="Value" c:type="GValue"/>
             </array>
           </parameter>
-          <parameter name="invocation_hint"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a context-dependent invocation hint</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -3274,9 +2784,7 @@ alive while the caller holds a pointer to it.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="remove_finalize_notifier"
-              c:identifier="g_closure_remove_finalize_notifier"
-              introspectable="0">
+      <method name="remove_finalize_notifier" c:identifier="g_closure_remove_finalize_notifier" introspectable="0">
         <doc xml:space="preserve">Removes a finalization notifier.
 
 Notice that notifiers are automatically removed after they are run.</doc>
@@ -3288,10 +2796,7 @@ Notice that notifiers are automatically removed after they are run.</doc>
             <doc xml:space="preserve">a #GClosure</doc>
             <type name="Closure" c:type="GClosure*"/>
           </instance-parameter>
-          <parameter name="notify_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="notify_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">data which was passed to g_closure_add_finalize_notifier()
  when registering @notify_func</doc>
             <type name="gpointer" c:type="gpointer"/>
@@ -3302,9 +2807,7 @@ Notice that notifiers are automatically removed after they are run.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="remove_invalidate_notifier"
-              c:identifier="g_closure_remove_invalidate_notifier"
-              introspectable="0">
+      <method name="remove_invalidate_notifier" c:identifier="g_closure_remove_invalidate_notifier" introspectable="0">
         <doc xml:space="preserve">Removes an invalidation notifier.
 
 Notice that notifiers are automatically removed after they are run.</doc>
@@ -3316,10 +2819,7 @@ Notice that notifiers are automatically removed after they are run.</doc>
             <doc xml:space="preserve">a #GClosure</doc>
             <type name="Closure" c:type="GClosure*"/>
           </instance-parameter>
-          <parameter name="notify_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="notify_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">data which was passed to g_closure_add_invalidate_notifier()
               when registering @notify_func</doc>
             <type name="gpointer" c:type="gpointer"/>
@@ -3330,9 +2830,7 @@ Notice that notifiers are automatically removed after they are run.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_marshal"
-              c:identifier="g_closure_set_marshal"
-              introspectable="0">
+      <method name="set_marshal" c:identifier="g_closure_set_marshal" introspectable="0">
         <doc xml:space="preserve">Sets the marshaller of @closure. The `marshal_data`
 of @marshal provides a way for a meta marshaller to provide additional
 information to the marshaller. (See g_closure_set_meta_marshal().) For
@@ -3353,9 +2851,7 @@ functions), what it provides is a callback function to use instead of
           </parameter>
         </parameters>
       </method>
-      <method name="set_meta_marshal"
-              c:identifier="g_closure_set_meta_marshal"
-              introspectable="0">
+      <method name="set_meta_marshal" c:identifier="g_closure_set_meta_marshal" introspectable="0">
         <doc xml:space="preserve">Sets the meta marshaller of @closure.  A meta marshaller wraps
 @closure-&gt;marshal and modifies the way it is called in some
 fashion. The most common use of this facility is for C callbacks.
@@ -3378,19 +2874,12 @@ the right callback and passes it to the marshaller as the
             <doc xml:space="preserve">a #GClosure</doc>
             <type name="Closure" c:type="GClosure*"/>
           </instance-parameter>
-          <parameter name="marshal_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     closure="1">
+          <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
             <doc xml:space="preserve">context-dependent data to pass
  to @meta_marshal</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="meta_marshal"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="meta_marshal" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GClosureMarshal function</doc>
             <type name="ClosureMarshal" c:type="GClosureMarshal"/>
           </parameter>
@@ -3473,10 +2962,7 @@ closure, then the closure will be destroyed and freed.</doc>
           <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
           <type name="Closure" c:type="GClosure*"/>
         </parameter>
-        <parameter name="return_value"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -3494,18 +2980,12 @@ closure, then the closure will be destroyed and freed.</doc>
             <type name="Value" c:type="GValue"/>
           </array>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">the invocation hint given as the
  last argument to g_closure_invoke()</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -3520,10 +3000,7 @@ on closures.</doc>
         <type name="none" c:type="void"/>
       </return-value>
       <parameters>
-        <parameter name="data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">data specified when registering the notification callback</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -3631,13 +3108,7 @@ nickname.</doc>
         <type name="utf8" c:type="const gchar*"/>
       </field>
     </record>
-    <class name="InitiallyUnowned"
-           c:symbol-prefix="initially_unowned"
-           c:type="GInitiallyUnowned"
-           parent="Object"
-           glib:type-name="GInitiallyUnowned"
-           glib:get-type="g_initially_unowned_get_type"
-           glib:type-struct="InitiallyUnownedClass">
+    <class name="InitiallyUnowned" c:symbol-prefix="initially_unowned" c:type="GInitiallyUnowned" parent="Object" glib:type-name="GInitiallyUnowned" glib:get-type="g_initially_unowned_get_type" glib:type-struct="InitiallyUnownedClass">
       <doc xml:space="preserve">All the fields in the GInitiallyUnowned structure
 are private to the #GInitiallyUnowned implementation and should never be
 accessed directly.</doc>
@@ -3651,9 +3122,7 @@ accessed directly.</doc>
         <type name="GLib.Data" c:type="GData*"/>
       </field>
     </class>
-    <record name="InitiallyUnownedClass"
-            c:type="GInitiallyUnownedClass"
-            glib:is-gtype-struct-for="InitiallyUnowned">
+    <record name="InitiallyUnownedClass" c:type="GInitiallyUnownedClass" glib:is-gtype-struct-for="InitiallyUnowned">
       <doc xml:space="preserve">The class structure for the GInitiallyUnowned type.</doc>
       <field name="g_type_class">
         <doc xml:space="preserve">the parent class</doc>
@@ -3677,8 +3146,7 @@ accessed directly.</doc>
               <type name="guint" c:type="guint"/>
             </parameter>
             <parameter name="construct_properties" transfer-ownership="none">
-              <type name="ObjectConstructParam"
-                    c:type="GObjectConstructParam*"/>
+              <type name="ObjectConstructParam" c:type="GObjectConstructParam*"/>
             </parameter>
           </parameters>
         </callback>
@@ -3843,10 +3311,7 @@ allocated by the corresponding GInterfaceInitFunc() function.</doc>
           <doc xml:space="preserve">The interface structure to finalize</doc>
           <type name="TypeInterface" c:type="gpointer"/>
         </parameter>
-        <parameter name="iface_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="iface_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The @interface_data supplied via the #GInterfaceInfo structure</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -3883,27 +3348,16 @@ zeros before this function is called.</doc>
           <doc xml:space="preserve">The interface structure to initialize</doc>
           <type name="TypeInterface" c:type="gpointer"/>
         </parameter>
-        <parameter name="iface_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="iface_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The @interface_data supplied via the #GInterfaceInfo structure</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
       </parameters>
     </callback>
-    <class name="Object"
-           c:symbol-prefix="object"
-           c:type="GObject"
-           glib:type-name="GObject"
-           glib:get-type="g_object_get_type"
-           glib:type-struct="ObjectClass">
+    <class name="Object" c:symbol-prefix="object" c:type="GObject" glib:type-name="GObject" glib:get-type="g_object_get_type" glib:type-struct="ObjectClass">
       <doc xml:space="preserve">All the fields in the GObject structure are private
 to the #GObject implementation and should never be accessed directly.</doc>
-      <constructor name="new"
-                   c:identifier="g_object_new"
-                   shadowed-by="new_with_properties"
-                   introspectable="0">
+      <constructor name="new" c:identifier="g_object_new" shadowed-by="new_with_properties" introspectable="0">
         <doc xml:space="preserve">Creates a new instance of a #GObject subtype and sets its properties.
 
 Construction parameters (see #G_PARAM_CONSTRUCT, #G_PARAM_CONSTRUCT_ONLY)
@@ -3929,9 +3383,7 @@ which are not explicitly specified are set to their default values.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_valist"
-                   c:identifier="g_object_new_valist"
-                   introspectable="0">
+      <constructor name="new_valist" c:identifier="g_object_new_valist" introspectable="0">
         <doc xml:space="preserve">Creates a new instance of a #GObject subtype and sets its properties.
 
 Construction parameters (see #G_PARAM_CONSTRUCT, #G_PARAM_CONSTRUCT_ONLY)
@@ -3956,10 +3408,7 @@ which are not explicitly specified are set to their default values.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_with_properties"
-                   c:identifier="g_object_new_with_properties"
-                   shadows="new"
-                   version="2.54">
+      <constructor name="new_with_properties" c:identifier="g_object_new_with_properties" shadows="new" version="2.54">
         <doc xml:space="preserve">Creates a new instance of a #GObject subtype and sets its properties using
 the provided arrays. Both arrays must have exactly @n_properties elements,
 and the names and values correspond by index.
@@ -3994,10 +3443,7 @@ which are not explicitly specified are set to their default values.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="newv"
-                   c:identifier="g_object_newv"
-                   deprecated="1"
-                   deprecated-version="2.54">
+      <constructor name="newv" c:identifier="g_object_newv" deprecated="1" deprecated-version="2.54">
         <doc xml:space="preserve">Creates a new instance of a #GObject subtype and sets its properties.
 
 Construction parameters (see #G_PARAM_CONSTRUCT, #G_PARAM_CONSTRUCT_ONLY)
@@ -4034,17 +3480,12 @@ deprecated. See #GParameter for more information.</doc-deprecated>
           <parameter name="what" transfer-ownership="none">
             <type name="gsize" c:type="gsize"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </function>
-      <function name="interface_find_property"
-                c:identifier="g_object_interface_find_property"
-                version="2.4">
+      <function name="interface_find_property" c:identifier="g_object_interface_find_property" version="2.4">
         <doc xml:space="preserve">Find the #GParamSpec with the given name for an
 interface. Generally, the interface vtable passed in as @g_iface
 will be the default vtable from g_type_default_interface_ref(), or,
@@ -4068,9 +3509,7 @@ g_type_default_interface_peek().</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="interface_install_property"
-                c:identifier="g_object_interface_install_property"
-                version="2.4">
+      <function name="interface_install_property" c:identifier="g_object_interface_install_property" version="2.4">
         <doc xml:space="preserve">Add a property to an interface; this is only useful for interfaces
 that are added to GObject-derived types. Adding a property to an
 interface forces all objects classes with that interface to have a
@@ -4101,9 +3540,7 @@ been called for any object types implementing this interface.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="interface_list_properties"
-                c:identifier="g_object_interface_list_properties"
-                version="2.4">
+      <function name="interface_list_properties" c:identifier="g_object_interface_list_properties" version="2.4">
         <doc xml:space="preserve">Lists the properties of an interface.Generally, the interface
 vtable passed in as @g_iface will be the default vtable from
 g_type_default_interface_ref(), or, if you know the interface has
@@ -4124,10 +3561,7 @@ already been loaded, g_type_default_interface_peek().</doc>
  interface, or the default vtable for the interface</doc>
             <type name="TypeInterface" c:type="gpointer"/>
           </parameter>
-          <parameter name="n_properties_p"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="n_properties_p" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store number of properties returned.</doc>
             <type name="guint" c:type="guint*"/>
           </parameter>
@@ -4241,10 +3675,7 @@ called.</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <method name="add_toggle_ref"
-              c:identifier="g_object_add_toggle_ref"
-              version="2.8"
-              introspectable="0">
+      <method name="add_toggle_ref" c:identifier="g_object_add_toggle_ref" version="2.8" introspectable="0">
         <doc xml:space="preserve">Increases the reference count of the object by one and sets a
 callback to be called when all other references to the object are
 dropped, or when this is already the last reference to the object
@@ -4287,18 +3718,13 @@ is important state in the proxy object.</doc>
  the last reference.</doc>
             <type name="ToggleNotify" c:type="GToggleNotify"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">data to pass to @notify</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="add_weak_pointer"
-              c:identifier="g_object_add_weak_pointer"
-              introspectable="0">
+      <method name="add_weak_pointer" c:identifier="g_object_add_weak_pointer" introspectable="0">
         <doc xml:space="preserve">Adds a weak reference from weak_pointer to @object to indicate that
 the pointer located at @weak_pointer_location is only valid during
 the lifetime of @object. When the @object is finalized,
@@ -4316,19 +3742,14 @@ thread. Use #GWeakRef if thread-safety is required.</doc>
             <doc xml:space="preserve">The object that should be weak referenced.</doc>
             <type name="Object" c:type="GObject*"/>
           </instance-parameter>
-          <parameter name="weak_pointer_location"
-                     direction="inout"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="weak_pointer_location" direction="inout" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">The memory address
    of a pointer.</doc>
             <type name="gpointer" c:type="gpointer*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="bind_property"
-              c:identifier="g_object_bind_property"
-              version="2.26">
+      <method name="bind_property" c:identifier="g_object_bind_property" version="2.26">
         <doc xml:space="preserve">Creates a binding between @source_property on @source and @target_property
 on @target. Whenever the @source_property is changed the @target_property is
 updated using the same value. For instance:
@@ -4380,10 +3801,7 @@ A #GObject can have multiple bindings.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="bind_property_full"
-              c:identifier="g_object_bind_property_full"
-              shadowed-by="bind_property_with_closures"
-              version="2.26">
+      <method name="bind_property_full" c:identifier="g_object_bind_property_full" shadowed-by="bind_property_with_closures" version="2.26">
         <doc xml:space="preserve">Complete version of g_object_bind_property().
 
 Creates a binding between @source_property on @source and @target_property
@@ -4434,30 +3852,17 @@ g_object_bind_property_with_closures() instead.</doc>
             <doc xml:space="preserve">flags to pass to #GBinding</doc>
             <type name="BindingFlags" c:type="GBindingFlags"/>
           </parameter>
-          <parameter name="transform_to"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="notified">
+          <parameter name="transform_to" transfer-ownership="none" nullable="1" allow-none="1" scope="notified">
             <doc xml:space="preserve">the transformation function
     from the @source to the @target, or %NULL to use the default</doc>
             <type name="BindingTransformFunc" c:type="GBindingTransformFunc"/>
           </parameter>
-          <parameter name="transform_from"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="notified"
-                     closure="6"
-                     destroy="7">
+          <parameter name="transform_from" transfer-ownership="none" nullable="1" allow-none="1" scope="notified" closure="6" destroy="7">
             <doc xml:space="preserve">the transformation function
     from the @target to the @source, or %NULL to use the default</doc>
             <type name="BindingTransformFunc" c:type="GBindingTransformFunc"/>
           </parameter>
-          <parameter name="user_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">custom data to be passed to the transformation functions,
     or %NULL</doc>
             <type name="gpointer" c:type="gpointer"/>
@@ -4469,10 +3874,7 @@ g_object_bind_property_with_closures() instead.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="bind_property_with_closures"
-              c:identifier="g_object_bind_property_with_closures"
-              shadows="bind_property_full"
-              version="2.26">
+      <method name="bind_property_with_closures" c:identifier="g_object_bind_property_with_closures" shadows="bind_property_full" version="2.26">
         <doc xml:space="preserve">Creates a binding between @source_property on @source and @target_property
 on @target, allowing you to set the transformation functions to be used by
 the binding.
@@ -4519,9 +3921,7 @@ function pointers.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="connect"
-              c:identifier="g_object_connect"
-              introspectable="0">
+      <method name="connect" c:identifier="g_object_connect" introspectable="0">
         <doc xml:space="preserve">A convenience function to connect multiple signals at once.
 
 The signal specs expected by this function have the form
@@ -4566,9 +3966,7 @@ The signal specs expected by this function have the form
           </parameter>
         </parameters>
       </method>
-      <method name="disconnect"
-              c:identifier="g_object_disconnect"
-              introspectable="0">
+      <method name="disconnect" c:identifier="g_object_disconnect" introspectable="0">
         <doc xml:space="preserve">A convenience function to disconnect multiple signals at once.
 
 The signal specs expected by this function have the form
@@ -4595,10 +3993,7 @@ disconnects the signal named "signal_name".</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="dup_data"
-              c:identifier="g_object_dup_data"
-              version="2.34"
-              introspectable="0">
+      <method name="dup_data" c:identifier="g_object_dup_data" version="2.34" introspectable="0">
         <doc xml:space="preserve">This is a variant of g_object_get_data() which returns
 a 'duplicate' of the value. @dup_func defines the
 meaning of 'duplicate' in this context, it could e.g.
@@ -4629,27 +4024,17 @@ object.</doc>
             <doc xml:space="preserve">a string, naming the user data pointer</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
-          <parameter name="dup_func"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     closure="2">
+          <parameter name="dup_func" transfer-ownership="none" nullable="1" allow-none="1" closure="2">
             <doc xml:space="preserve">function to dup the value</doc>
             <type name="GLib.DuplicateFunc" c:type="GDuplicateFunc"/>
           </parameter>
-          <parameter name="user_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">passed as user_data to @dup_func</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="dup_qdata"
-              c:identifier="g_object_dup_qdata"
-              version="2.34"
-              introspectable="0">
+      <method name="dup_qdata" c:identifier="g_object_dup_qdata" version="2.34" introspectable="0">
         <doc xml:space="preserve">This is a variant of g_object_get_qdata() which returns
 a 'duplicate' of the value. @dup_func defines the
 meaning of 'duplicate' in this context, it could e.g.
@@ -4680,26 +4065,17 @@ object.</doc>
             <doc xml:space="preserve">a #GQuark, naming the user data pointer</doc>
             <type name="GLib.Quark" c:type="GQuark"/>
           </parameter>
-          <parameter name="dup_func"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     closure="2">
+          <parameter name="dup_func" transfer-ownership="none" nullable="1" allow-none="1" closure="2">
             <doc xml:space="preserve">function to dup the value</doc>
             <type name="GLib.DuplicateFunc" c:type="GDuplicateFunc"/>
           </parameter>
-          <parameter name="user_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">passed as user_data to @dup_func</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="force_floating"
-              c:identifier="g_object_force_floating"
-              version="2.10">
+      <method name="force_floating" c:identifier="g_object_force_floating" version="2.10">
         <doc xml:space="preserve">This function is intended for #GObject implementations to re-enforce
 a [floating][floating-ref] object reference. Doing this is seldom
 required: all #GInitiallyUnowneds are created with a floating reference
@@ -4841,9 +4217,7 @@ g_object_set_qdata().</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_valist"
-              c:identifier="g_object_get_valist"
-              introspectable="0">
+      <method name="get_valist" c:identifier="g_object_get_valist" introspectable="0">
         <doc xml:space="preserve">Gets properties of an object.
 
 In general, a copy is made of the property contents and the caller
@@ -4901,9 +4275,7 @@ properties are passed in.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="is_floating"
-              c:identifier="g_object_is_floating"
-              version="2.10">
+      <method name="is_floating" c:identifier="g_object_is_floating" version="2.10">
         <doc xml:space="preserve">Checks whether @object has a [floating][floating-ref] reference.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE if @object has a floating reference</doc>
@@ -4941,9 +4313,7 @@ called.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="notify_by_pspec"
-              c:identifier="g_object_notify_by_pspec"
-              version="2.26">
+      <method name="notify_by_pspec" c:identifier="g_object_notify_by_pspec" version="2.26">
         <doc xml:space="preserve">Emits a "notify" signal for the property specified by @pspec on @object.
 
 This function omits the property name lookup, hence it is faster than
@@ -5029,10 +4399,7 @@ adds a new normal reference increasing the reference count by one.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="remove_toggle_ref"
-              c:identifier="g_object_remove_toggle_ref"
-              version="2.8"
-              introspectable="0">
+      <method name="remove_toggle_ref" c:identifier="g_object_remove_toggle_ref" version="2.8" introspectable="0">
         <doc xml:space="preserve">Removes a reference added with g_object_add_toggle_ref(). The
 reference count of the object is decreased by one.</doc>
         <return-value transfer-ownership="none">
@@ -5049,18 +4416,13 @@ reference count of the object is decreased by one.</doc>
  the last reference.</doc>
             <type name="ToggleNotify" c:type="GToggleNotify"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">data to pass to @notify</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="remove_weak_pointer"
-              c:identifier="g_object_remove_weak_pointer"
-              introspectable="0">
+      <method name="remove_weak_pointer" c:identifier="g_object_remove_weak_pointer" introspectable="0">
         <doc xml:space="preserve">Removes a weak reference from @object that was previously added
 using g_object_add_weak_pointer(). The @weak_pointer_location has
 to match the one used with g_object_add_weak_pointer().</doc>
@@ -5072,19 +4434,14 @@ to match the one used with g_object_add_weak_pointer().</doc>
             <doc xml:space="preserve">The object that is weak referenced.</doc>
             <type name="Object" c:type="GObject*"/>
           </instance-parameter>
-          <parameter name="weak_pointer_location"
-                     direction="inout"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="weak_pointer_location" direction="inout" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">The memory address
    of a pointer.</doc>
             <type name="gpointer" c:type="gpointer*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="replace_data"
-              c:identifier="g_object_replace_data"
-              version="2.34">
+      <method name="replace_data" c:identifier="g_object_replace_data" version="2.34">
         <doc xml:space="preserve">Compares the user data for the key @key on @object with
 @oldval, and if they are the same, replaces @oldval with
 @newval.
@@ -5112,41 +4469,25 @@ should not destroy the object in the normal way.</doc>
             <doc xml:space="preserve">a string, naming the user data pointer</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
-          <parameter name="oldval"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="oldval" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the old value to compare against</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="newval"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="newval" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the new value</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="destroy"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="async">
+          <parameter name="destroy" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
             <doc xml:space="preserve">a destroy notify for the new value</doc>
             <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
           </parameter>
-          <parameter name="old_destroy"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="async">
+          <parameter name="old_destroy" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
             <doc xml:space="preserve">destroy notify for the existing value</doc>
             <type name="GLib.DestroyNotify" c:type="GDestroyNotify*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="replace_qdata"
-              c:identifier="g_object_replace_qdata"
-              version="2.34">
+      <method name="replace_qdata" c:identifier="g_object_replace_qdata" version="2.34">
         <doc xml:space="preserve">Compares the user data for the key @quark on @object with
 @oldval, and if they are the same, replaces @oldval with
 @newval.
@@ -5174,33 +4515,19 @@ should not destroy the object in the normal way.</doc>
             <doc xml:space="preserve">a #GQuark, naming the user data pointer</doc>
             <type name="GLib.Quark" c:type="GQuark"/>
           </parameter>
-          <parameter name="oldval"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="oldval" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the old value to compare against</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="newval"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="newval" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the new value</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="destroy"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="async">
+          <parameter name="destroy" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
             <doc xml:space="preserve">a destroy notify for the new value</doc>
             <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
           </parameter>
-          <parameter name="old_destroy"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="async">
+          <parameter name="old_destroy" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
             <doc xml:space="preserve">destroy notify for the existing value</doc>
             <type name="GLib.DestroyNotify" c:type="GDestroyNotify*"/>
           </parameter>
@@ -5264,18 +4591,13 @@ the old association will be destroyed.</doc>
             <doc xml:space="preserve">name of the key</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">data to associate with that key</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="set_data_full"
-              c:identifier="g_object_set_data_full"
-              introspectable="0">
+      <method name="set_data_full" c:identifier="g_object_set_data_full" introspectable="0">
         <doc xml:space="preserve">Like g_object_set_data() except it adds notification
 for when the association is destroyed, either by setting it
 to a different value or when the object is destroyed.
@@ -5293,10 +4615,7 @@ Note that the @destroy callback is not called if @data is %NULL.</doc>
             <doc xml:space="preserve">name of the key</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">data to associate with that key</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -5326,9 +4645,7 @@ Note that the @destroy callback is not called if @data is %NULL.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_qdata"
-              c:identifier="g_object_set_qdata"
-              introspectable="0">
+      <method name="set_qdata" c:identifier="g_object_set_qdata" introspectable="0">
         <doc xml:space="preserve">This sets an opaque, named pointer on an object.
 The name is specified through a #GQuark (retrived e.g. via
 g_quark_from_static_string()), and the pointer
@@ -5349,18 +4666,13 @@ removes the data stored.</doc>
             <doc xml:space="preserve">A #GQuark, naming the user data pointer</doc>
             <type name="GLib.Quark" c:type="GQuark"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">An opaque user data pointer</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="set_qdata_full"
-              c:identifier="g_object_set_qdata_full"
-              introspectable="0">
+      <method name="set_qdata_full" c:identifier="g_object_set_qdata_full" introspectable="0">
         <doc xml:space="preserve">This function works like g_object_set_qdata(), but in addition,
 a void (*destroy) (gpointer) function may be specified which is
 called with @data as argument when the @object is finalized, or
@@ -5378,10 +4690,7 @@ with the same @quark.</doc>
             <doc xml:space="preserve">A #GQuark, naming the user data pointer</doc>
             <type name="GLib.Quark" c:type="GQuark"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">An opaque user data pointer</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -5392,9 +4701,7 @@ with the same @quark.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_valist"
-              c:identifier="g_object_set_valist"
-              introspectable="0">
+      <method name="set_valist" c:identifier="g_object_set_valist" introspectable="0">
         <doc xml:space="preserve">Sets properties on an object.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -5415,10 +4722,7 @@ with the same @quark.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="setv"
-              c:identifier="g_object_setv"
-              version="2.54"
-              introspectable="0">
+      <method name="setv" c:identifier="g_object_setv" version="2.54" introspectable="0">
         <doc xml:space="preserve">Sets @n_properties properties for an @object.
 Properties to be set will be taken from @values. All properties must be
 valid. Warnings will be emitted and undefined behaviour may result if invalid
@@ -5580,9 +4884,7 @@ use this @object as closure data.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="weak_ref"
-              c:identifier="g_object_weak_ref"
-              introspectable="0">
+      <method name="weak_ref" c:identifier="g_object_weak_ref" introspectable="0">
         <doc xml:space="preserve">Adds a weak reference callback to an object. Weak references are
 used for notification when an object is finalized. They are called
 "weak references" because they allow you to safely hold a pointer
@@ -5605,18 +4907,13 @@ Use #GWeakRef if thread-safety is required.</doc>
             <doc xml:space="preserve">callback to invoke before the object is freed</doc>
             <type name="WeakNotify" c:type="GWeakNotify"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">extra data to pass to notify</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="weak_unref"
-              c:identifier="g_object_weak_unref"
-              introspectable="0">
+      <method name="weak_unref" c:identifier="g_object_weak_unref" introspectable="0">
         <doc xml:space="preserve">Removes a weak reference callback to an object.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -5630,10 +4927,7 @@ Use #GWeakRef if thread-safety is required.</doc>
             <doc xml:space="preserve">callback to search for</doc>
             <type name="WeakNotify" c:type="GWeakNotify"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">data to search for</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -5648,12 +4942,7 @@ Use #GWeakRef if thread-safety is required.</doc>
       <field name="qdata" readable="0" private="1">
         <type name="GLib.Data" c:type="GData*"/>
       </field>
-      <glib:signal name="notify"
-                   when="first"
-                   no-recurse="1"
-                   detailed="1"
-                   action="1"
-                   no-hooks="1">
+      <glib:signal name="notify" when="first" no-recurse="1" detailed="1" action="1" no-hooks="1">
         <doc xml:space="preserve">The notify signal is emitted on an object when one of its
 properties has been changed. Note that getting this signal
 doesn't guarantee that the value of the property has actually
@@ -5682,9 +4971,7 @@ detail strings for the notify signal.</doc>
         </parameters>
       </glib:signal>
     </class>
-    <record name="ObjectClass"
-            c:type="GObjectClass"
-            glib:is-gtype-struct-for="Object">
+    <record name="ObjectClass" c:type="GObjectClass" glib:is-gtype-struct-for="Object">
       <doc xml:space="preserve">The class structure for the GObject type.
 
 &lt;example&gt;
@@ -5734,8 +5021,7 @@ my_singleton_constructor (GType                  type,
               <type name="guint" c:type="guint"/>
             </parameter>
             <parameter name="construct_properties" transfer-ownership="none">
-              <type name="ObjectConstructParam"
-                    c:type="GObjectConstructParam*"/>
+              <type name="ObjectConstructParam" c:type="GObjectConstructParam*"/>
             </parameter>
           </parameters>
         </callback>
@@ -5878,9 +5164,7 @@ my_singleton_constructor (GType                  type,
           </parameter>
         </parameters>
       </method>
-      <method name="install_properties"
-              c:identifier="g_object_class_install_properties"
-              version="2.26">
+      <method name="install_properties" c:identifier="g_object_class_install_properties" version="2.26">
         <doc xml:space="preserve">Installs new properties from an array of #GParamSpecs.
 
 All properties should be installed during the class initializer.  It
@@ -5963,8 +5247,7 @@ my_object_set_foo (MyObject *self, gint foo)
           </parameter>
         </parameters>
       </method>
-      <method name="install_property"
-              c:identifier="g_object_class_install_property">
+      <method name="install_property" c:identifier="g_object_class_install_property">
         <doc xml:space="preserve">Installs a new property.
 
 All properties should be installed during the class initializer.  It
@@ -5993,8 +5276,7 @@ e.g. to change the range of allowed values or the default value.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="list_properties"
-              c:identifier="g_object_class_list_properties">
+      <method name="list_properties" c:identifier="g_object_class_list_properties">
         <doc xml:space="preserve">Get an array of #GParamSpec* for all properties of a class.</doc>
         <return-value transfer-ownership="container">
           <doc xml:space="preserve">an array of
@@ -6008,18 +5290,13 @@ e.g. to change the range of allowed values or the default value.</doc>
             <doc xml:space="preserve">a #GObjectClass</doc>
             <type name="ObjectClass" c:type="GObjectClass*"/>
           </instance-parameter>
-          <parameter name="n_properties"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="n_properties" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">return location for the length of the returned array</doc>
             <type name="guint" c:type="guint*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="override_property"
-              c:identifier="g_object_class_override_property"
-              version="2.4">
+      <method name="override_property" c:identifier="g_object_class_override_property" version="2.4">
         <doc xml:space="preserve">Registers @property_id as referring to a property with the name
 @name in a parent class or in an interface implemented by @oclass.
 This allows this class to "override" a property implementation in
@@ -6135,9 +5412,7 @@ a #GObjectClass.</doc>
       <doc xml:space="preserve">Mask containing the bits of #GParamSpec.flags which are reserved for GLib.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="PARAM_STATIC_STRINGS"
-              value="0"
-              c:type="G_PARAM_STATIC_STRINGS">
+    <constant name="PARAM_STATIC_STRINGS" value="0" c:type="G_PARAM_STATIC_STRINGS">
       <doc xml:space="preserve">#GParamFlags value alias for %G_PARAM_STATIC_NAME | %G_PARAM_STATIC_NICK | %G_PARAM_STATIC_BLURB.
 
 Since 2.13.0</doc>
@@ -6163,14 +5438,10 @@ can be configured. See also #G_PARAM_STATIC_STRINGS.</doc>
       <member name="construct" value="4" c:identifier="G_PARAM_CONSTRUCT">
         <doc xml:space="preserve">the parameter will be set upon object construction</doc>
       </member>
-      <member name="construct_only"
-              value="8"
-              c:identifier="G_PARAM_CONSTRUCT_ONLY">
+      <member name="construct_only" value="8" c:identifier="G_PARAM_CONSTRUCT_ONLY">
         <doc xml:space="preserve">the parameter can only be set upon object construction</doc>
       </member>
-      <member name="lax_validation"
-              value="16"
-              c:identifier="G_PARAM_LAX_VALIDATION">
+      <member name="lax_validation" value="16" c:identifier="G_PARAM_LAX_VALIDATION">
         <doc xml:space="preserve">upon parameter conversion (see g_param_value_convert())
  strict validation is not required</doc>
       </member>
@@ -6189,43 +5460,26 @@ can be configured. See also #G_PARAM_STATIC_STRINGS.</doc>
  unmmodified for the lifetime of the parameter.
  Since 2.8</doc>
       </member>
-      <member name="static_blurb"
-              value="128"
-              c:identifier="G_PARAM_STATIC_BLURB">
+      <member name="static_blurb" value="128" c:identifier="G_PARAM_STATIC_BLURB">
         <doc xml:space="preserve">the string used as blurb when constructing the
  parameter is guaranteed to remain valid and
  unmodified for the lifetime of the parameter.
  Since 2.8</doc>
       </member>
-      <member name="explicit_notify"
-              value="1073741824"
-              c:identifier="G_PARAM_EXPLICIT_NOTIFY">
+      <member name="explicit_notify" value="1073741824" c:identifier="G_PARAM_EXPLICIT_NOTIFY">
         <doc xml:space="preserve">calls to g_object_set_property() for this
   property will not automatically result in a "notify" signal being
   emitted: the implementation must call g_object_notify() themselves
   in case the property actually changes.  Since: 2.42.</doc>
       </member>
-      <member name="deprecated"
-              value="2147483648"
-              c:identifier="G_PARAM_DEPRECATED">
+      <member name="deprecated" value="2147483648" c:identifier="G_PARAM_DEPRECATED">
         <doc xml:space="preserve">the parameter is deprecated and will be removed
  in a future version. A warning will be generated if it is used
  while running with G_ENABLE_DIAGNOSTIC=1.
  Since 2.26</doc>
       </member>
     </bitfield>
-    <class name="ParamSpec"
-           c:symbol-prefix="param_spec"
-           c:type="GParamSpec"
-           abstract="1"
-           glib:type-name="GParam"
-           glib:get-type="intern"
-           glib:type-struct="ParamSpecClass"
-           glib:fundamental="1"
-           glib:ref-func="g_param_spec_ref_sink"
-           glib:unref-func="g_param_spec_uref"
-           glib:set-value-func="g_value_set_param"
-           glib:get-value-func="g_value_get_param">
+    <class name="ParamSpec" c:symbol-prefix="param_spec" c:type="GParamSpec" abstract="1" glib:type-name="GParam" glib:get-type="intern" glib:type-struct="ParamSpecClass" glib:fundamental="1" glib:ref-func="g_param_spec_ref_sink" glib:unref-func="g_param_spec_uref" glib:set-value-func="g_value_set_param" glib:get-value-func="g_value_get_param">
       <doc xml:space="preserve">#GParamSpec is an object structure that encapsulates the metadata
 required to specify parameters, such as e.g. #GObject properties.
 
@@ -6236,9 +5490,7 @@ Subsequent characters can be letters, numbers or a '-'.
 All other characters are replaced by a '-' during construction.
 The result of this replacement is called the canonical name of
 the parameter.</doc>
-      <function name="internal"
-                c:identifier="g_param_spec_internal"
-                introspectable="0">
+      <function name="internal" c:identifier="g_param_spec_internal" introspectable="0">
         <doc xml:space="preserve">Creates a new #GParamSpec instance.
 
 A property name consists of segments consisting of ASCII letters and
@@ -6348,9 +5600,7 @@ e.g. a tooltip. The @nick and @blurb should ideally be localized.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_default_value"
-              c:identifier="g_param_spec_get_default_value"
-              version="2.38">
+      <method name="get_default_value" c:identifier="g_param_spec_get_default_value" version="2.38">
         <doc xml:space="preserve">Gets the default value of @pspec as a pointer to a #GValue.
 
 The #GValue will remain value for the life of @pspec.</doc>
@@ -6381,9 +5631,7 @@ This allows for pointer-value comparisons.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name_quark"
-              c:identifier="g_param_spec_get_name_quark"
-              version="2.46">
+      <method name="get_name_quark" c:identifier="g_param_spec_get_name_quark" version="2.46">
         <doc xml:space="preserve">Gets the GQuark for the name.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the GQuark for @pspec-&gt;name.</doc>
@@ -6426,9 +5674,7 @@ This allows for pointer-value comparisons.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_redirect_target"
-              c:identifier="g_param_spec_get_redirect_target"
-              version="2.4">
+      <method name="get_redirect_target" c:identifier="g_param_spec_get_redirect_target" version="2.4">
         <doc xml:space="preserve">If the paramspec redirects operations to another paramspec,
 returns that paramspec. Redirect is used typically for
 providing a new implementation of a property in a derived
@@ -6461,10 +5707,7 @@ for an example of the use of this capability.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="ref_sink"
-              c:identifier="g_param_spec_ref_sink"
-              version="2.10"
-              introspectable="0">
+      <method name="ref_sink" c:identifier="g_param_spec_ref_sink" version="2.10" introspectable="0">
         <doc xml:space="preserve">Convenience function to ref and sink a #GParamSpec.</doc>
         <return-value>
           <doc xml:space="preserve">the #GParamSpec that was passed into this function</doc>
@@ -6496,18 +5739,13 @@ set, using %NULL as pointer essentially removes the data stored.</doc>
             <doc xml:space="preserve">a #GQuark, naming the user data pointer</doc>
             <type name="GLib.Quark" c:type="GQuark"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">an opaque user data pointer</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="set_qdata_full"
-              c:identifier="g_param_spec_set_qdata_full"
-              introspectable="0">
+      <method name="set_qdata_full" c:identifier="g_param_spec_set_qdata_full" introspectable="0">
         <doc xml:space="preserve">This function works like g_param_spec_set_qdata(), but in addition,
 a `void (*destroy) (gpointer)` function may be
 specified which is called with @data as argument when the @pspec is
@@ -6525,10 +5763,7 @@ g_param_spec_set_qdata() with the same @quark.</doc>
             <doc xml:space="preserve">a #GQuark, naming the user data pointer</doc>
             <type name="GLib.Quark" c:type="GQuark"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">an opaque user data pointer</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -6577,9 +5812,7 @@ required to update user data pointers with a destroy notifier.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="unref"
-              c:identifier="g_param_spec_unref"
-              introspectable="0">
+      <method name="unref" c:identifier="g_param_spec_unref" introspectable="0">
         <doc xml:space="preserve">Decrements the reference count of a @pspec.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -6627,13 +5860,7 @@ required to update user data pointers with a destroy notifier.</doc>
         <type name="guint" c:type="guint"/>
       </field>
     </class>
-    <class name="ParamSpecBoolean"
-           c:symbol-prefix="param_spec_boolean"
-           c:type="GParamSpecBoolean"
-           parent="ParamSpec"
-           glib:type-name="GParamBoolean"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecBoolean" c:symbol-prefix="param_spec_boolean" c:type="GParamSpecBoolean" parent="ParamSpec" glib:type-name="GParamBoolean" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for boolean properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -6644,26 +5871,14 @@ required to update user data pointers with a destroy notifier.</doc>
         <type name="gboolean" c:type="gboolean"/>
       </field>
     </class>
-    <class name="ParamSpecBoxed"
-           c:symbol-prefix="param_spec_boxed"
-           c:type="GParamSpecBoxed"
-           parent="ParamSpec"
-           glib:type-name="GParamBoxed"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecBoxed" c:symbol-prefix="param_spec_boxed" c:type="GParamSpecBoxed" parent="ParamSpec" glib:type-name="GParamBoxed" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for boxed properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
         <type name="ParamSpec" c:type="GParamSpec"/>
       </field>
     </class>
-    <class name="ParamSpecChar"
-           c:symbol-prefix="param_spec_char"
-           c:type="GParamSpecChar"
-           parent="ParamSpec"
-           glib:type-name="GParamChar"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecChar" c:symbol-prefix="param_spec_char" c:type="GParamSpecChar" parent="ParamSpec" glib:type-name="GParamChar" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for character properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -6682,9 +5897,7 @@ required to update user data pointers with a destroy notifier.</doc>
         <type name="gint8" c:type="gint8"/>
       </field>
     </class>
-    <record name="ParamSpecClass"
-            c:type="GParamSpecClass"
-            glib:is-gtype-struct-for="ParamSpec">
+    <record name="ParamSpecClass" c:type="GParamSpecClass" glib:is-gtype-struct-for="ParamSpec">
       <doc xml:space="preserve">The class structure for the GParamSpec type.
 Normally, GParamSpec classes are filled by
 g_param_type_register_static().</doc>
@@ -6762,13 +5975,7 @@ g_param_type_register_static().</doc>
         </array>
       </field>
     </record>
-    <class name="ParamSpecDouble"
-           c:symbol-prefix="param_spec_double"
-           c:type="GParamSpecDouble"
-           parent="ParamSpec"
-           glib:type-name="GParamDouble"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecDouble" c:symbol-prefix="param_spec_double" c:type="GParamSpecDouble" parent="ParamSpec" glib:type-name="GParamDouble" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for double properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -6792,13 +5999,7 @@ g_param_type_register_static().</doc>
         <type name="gdouble" c:type="gdouble"/>
       </field>
     </class>
-    <class name="ParamSpecEnum"
-           c:symbol-prefix="param_spec_enum"
-           c:type="GParamSpecEnum"
-           parent="ParamSpec"
-           glib:type-name="GParamEnum"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecEnum" c:symbol-prefix="param_spec_enum" c:type="GParamSpecEnum" parent="ParamSpec" glib:type-name="GParamEnum" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for enum
 properties.</doc>
       <field name="parent_instance">
@@ -6814,13 +6015,7 @@ properties.</doc>
         <type name="gint" c:type="gint"/>
       </field>
     </class>
-    <class name="ParamSpecFlags"
-           c:symbol-prefix="param_spec_flags"
-           c:type="GParamSpecFlags"
-           parent="ParamSpec"
-           glib:type-name="GParamFlags"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecFlags" c:symbol-prefix="param_spec_flags" c:type="GParamSpecFlags" parent="ParamSpec" glib:type-name="GParamFlags" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for flags
 properties.</doc>
       <field name="parent_instance">
@@ -6836,13 +6031,7 @@ properties.</doc>
         <type name="guint" c:type="guint"/>
       </field>
     </class>
-    <class name="ParamSpecFloat"
-           c:symbol-prefix="param_spec_float"
-           c:type="GParamSpecFloat"
-           parent="ParamSpec"
-           glib:type-name="GParamFloat"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecFloat" c:symbol-prefix="param_spec_float" c:type="GParamSpecFloat" parent="ParamSpec" glib:type-name="GParamFloat" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for float properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -6866,14 +6055,7 @@ properties.</doc>
         <type name="gfloat" c:type="gfloat"/>
       </field>
     </class>
-    <class name="ParamSpecGType"
-           c:symbol-prefix="param_spec_gtype"
-           c:type="GParamSpecGType"
-           version="2.10"
-           parent="ParamSpec"
-           glib:type-name="GParamGType"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecGType" c:symbol-prefix="param_spec_gtype" c:type="GParamSpecGType" version="2.10" parent="ParamSpec" glib:type-name="GParamGType" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for #GType properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -6884,13 +6066,7 @@ properties.</doc>
         <type name="GType" c:type="GType"/>
       </field>
     </class>
-    <class name="ParamSpecInt"
-           c:symbol-prefix="param_spec_int"
-           c:type="GParamSpecInt"
-           parent="ParamSpec"
-           glib:type-name="GParamInt"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecInt" c:symbol-prefix="param_spec_int" c:type="GParamSpecInt" parent="ParamSpec" glib:type-name="GParamInt" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for integer properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -6909,13 +6085,7 @@ properties.</doc>
         <type name="gint" c:type="gint"/>
       </field>
     </class>
-    <class name="ParamSpecInt64"
-           c:symbol-prefix="param_spec_int64"
-           c:type="GParamSpecInt64"
-           parent="ParamSpec"
-           glib:type-name="GParamInt64"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecInt64" c:symbol-prefix="param_spec_int64" c:type="GParamSpecInt64" parent="ParamSpec" glib:type-name="GParamInt64" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for 64bit integer properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -6934,13 +6104,7 @@ properties.</doc>
         <type name="gint64" c:type="gint64"/>
       </field>
     </class>
-    <class name="ParamSpecLong"
-           c:symbol-prefix="param_spec_long"
-           c:type="GParamSpecLong"
-           parent="ParamSpec"
-           glib:type-name="GParamLong"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecLong" c:symbol-prefix="param_spec_long" c:type="GParamSpecLong" parent="ParamSpec" glib:type-name="GParamLong" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for long integer properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -6959,27 +6123,14 @@ properties.</doc>
         <type name="glong" c:type="glong"/>
       </field>
     </class>
-    <class name="ParamSpecObject"
-           c:symbol-prefix="param_spec_object"
-           c:type="GParamSpecObject"
-           parent="ParamSpec"
-           glib:type-name="GParamObject"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecObject" c:symbol-prefix="param_spec_object" c:type="GParamSpecObject" parent="ParamSpec" glib:type-name="GParamObject" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for object properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
         <type name="ParamSpec" c:type="GParamSpec"/>
       </field>
     </class>
-    <class name="ParamSpecOverride"
-           c:symbol-prefix="param_spec_override"
-           c:type="GParamSpecOverride"
-           version="2.4"
-           parent="ParamSpec"
-           glib:type-name="GParamOverride"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecOverride" c:symbol-prefix="param_spec_override" c:type="GParamSpecOverride" version="2.4" parent="ParamSpec" glib:type-name="GParamOverride" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">This is a type of #GParamSpec type that simply redirects operations to
 another paramspec.  All operations other than getting or
 setting the value are redirected, including accessing the nick and
@@ -6995,13 +6146,7 @@ unless you are implementing a new base type similar to GObject.</doc>
         <type name="ParamSpec" c:type="GParamSpec*"/>
       </field>
     </class>
-    <class name="ParamSpecParam"
-           c:symbol-prefix="param_spec_param"
-           c:type="GParamSpecParam"
-           parent="ParamSpec"
-           glib:type-name="GParamParam"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecParam" c:symbol-prefix="param_spec_param" c:type="GParamSpecParam" parent="ParamSpec" glib:type-name="GParamParam" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for %G_TYPE_PARAM
 properties.</doc>
       <field name="parent_instance">
@@ -7009,13 +6154,7 @@ properties.</doc>
         <type name="ParamSpec" c:type="GParamSpec"/>
       </field>
     </class>
-    <class name="ParamSpecPointer"
-           c:symbol-prefix="param_spec_pointer"
-           c:type="GParamSpecPointer"
-           parent="ParamSpec"
-           glib:type-name="GParamPointer"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecPointer" c:symbol-prefix="param_spec_pointer" c:type="GParamSpecPointer" parent="ParamSpec" glib:type-name="GParamPointer" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for pointer properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -7067,10 +6206,7 @@ the pool.</doc>
             <doc xml:space="preserve">the owner to look for</doc>
             <type name="GType" c:type="GType"/>
           </parameter>
-          <parameter name="n_pspecs_p"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="n_pspecs_p" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">return location for the length of the returned array</doc>
             <type name="guint" c:type="guint*"/>
           </parameter>
@@ -7160,13 +6296,7 @@ deprecated, so you should always set @type_prefixing to %FALSE.</doc>
         </parameters>
       </function>
     </record>
-    <class name="ParamSpecString"
-           c:symbol-prefix="param_spec_string"
-           c:type="GParamSpecString"
-           parent="ParamSpec"
-           glib:type-name="GParamString"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecString" c:symbol-prefix="param_spec_string" c:type="GParamSpecString" parent="ParamSpec" glib:type-name="GParamString" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for string
 properties.</doc>
       <field name="parent_instance">
@@ -7291,13 +6421,7 @@ g_param_type_register_static().</doc>
         </callback>
       </field>
     </record>
-    <class name="ParamSpecUChar"
-           c:symbol-prefix="param_spec_uchar"
-           c:type="GParamSpecUChar"
-           parent="ParamSpec"
-           glib:type-name="GParamUChar"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecUChar" c:symbol-prefix="param_spec_uchar" c:type="GParamSpecUChar" parent="ParamSpec" glib:type-name="GParamUChar" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for unsigned character properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -7316,13 +6440,7 @@ g_param_type_register_static().</doc>
         <type name="guint8" c:type="guint8"/>
       </field>
     </class>
-    <class name="ParamSpecUInt"
-           c:symbol-prefix="param_spec_uint"
-           c:type="GParamSpecUInt"
-           parent="ParamSpec"
-           glib:type-name="GParamUInt"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecUInt" c:symbol-prefix="param_spec_uint" c:type="GParamSpecUInt" parent="ParamSpec" glib:type-name="GParamUInt" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for unsigned integer properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -7341,13 +6459,7 @@ g_param_type_register_static().</doc>
         <type name="guint" c:type="guint"/>
       </field>
     </class>
-    <class name="ParamSpecUInt64"
-           c:symbol-prefix="param_spec_uint64"
-           c:type="GParamSpecUInt64"
-           parent="ParamSpec"
-           glib:type-name="GParamUInt64"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecUInt64" c:symbol-prefix="param_spec_uint64" c:type="GParamSpecUInt64" parent="ParamSpec" glib:type-name="GParamUInt64" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for unsigned 64bit integer properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -7366,13 +6478,7 @@ g_param_type_register_static().</doc>
         <type name="guint64" c:type="guint64"/>
       </field>
     </class>
-    <class name="ParamSpecULong"
-           c:symbol-prefix="param_spec_ulong"
-           c:type="GParamSpecULong"
-           parent="ParamSpec"
-           glib:type-name="GParamULong"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecULong" c:symbol-prefix="param_spec_ulong" c:type="GParamSpecULong" parent="ParamSpec" glib:type-name="GParamULong" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for unsigned long integer properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -7391,13 +6497,7 @@ g_param_type_register_static().</doc>
         <type name="gulong" c:type="gulong"/>
       </field>
     </class>
-    <class name="ParamSpecUnichar"
-           c:symbol-prefix="param_spec_unichar"
-           c:type="GParamSpecUnichar"
-           parent="ParamSpec"
-           glib:type-name="GParamUnichar"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecUnichar" c:symbol-prefix="param_spec_unichar" c:type="GParamSpecUnichar" parent="ParamSpec" glib:type-name="GParamUnichar" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for unichar (unsigned integer) properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -7408,13 +6508,7 @@ g_param_type_register_static().</doc>
         <type name="gunichar" c:type="gunichar"/>
       </field>
     </class>
-    <class name="ParamSpecValueArray"
-           c:symbol-prefix="param_spec_value_array"
-           c:type="GParamSpecValueArray"
-           parent="ParamSpec"
-           glib:type-name="GParamValueArray"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecValueArray" c:symbol-prefix="param_spec_value_array" c:type="GParamSpecValueArray" parent="ParamSpec" glib:type-name="GParamValueArray" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for #GValueArray properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -7429,14 +6523,7 @@ g_param_type_register_static().</doc>
         <type name="guint" c:type="guint"/>
       </field>
     </class>
-    <class name="ParamSpecVariant"
-           c:symbol-prefix="param_spec_variant"
-           c:type="GParamSpecVariant"
-           version="2.26"
-           parent="ParamSpec"
-           glib:type-name="GParamVariant"
-           glib:get-type="intern"
-           glib:fundamental="1">
+    <class name="ParamSpecVariant" c:symbol-prefix="param_spec_variant" c:type="GParamSpecVariant" version="2.26" parent="ParamSpec" glib:type-name="GParamVariant" glib:get-type="intern" glib:fundamental="1">
       <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for #GVariant properties.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
@@ -7456,10 +6543,7 @@ g_param_type_register_static().</doc>
         </array>
       </field>
     </class>
-    <record name="Parameter"
-            c:type="GParameter"
-            deprecated="1"
-            deprecated-version="2.54">
+    <record name="Parameter" c:type="GParameter" deprecated="1" deprecated-version="2.54">
       <doc xml:space="preserve">The GParameter struct is an auxiliary structure used
 to hand parameter name/value pairs to g_object_newv().</doc>
       <doc-deprecated xml:space="preserve">This type is not introspectable.</doc-deprecated>
@@ -7472,9 +6556,7 @@ to hand parameter name/value pairs to g_object_newv().</doc>
         <type name="Value" c:type="GValue"/>
       </field>
     </record>
-    <constant name="SIGNAL_FLAGS_MASK"
-              value="511"
-              c:type="G_SIGNAL_FLAGS_MASK">
+    <constant name="SIGNAL_FLAGS_MASK" value="511" c:type="G_SIGNAL_FLAGS_MASK">
       <doc xml:space="preserve">A mask for all #GSignalFlags bits.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
@@ -7509,10 +6591,7 @@ value returned by the last callback.</doc>
           <doc xml:space="preserve">A #GValue holding the return value of the signal handler.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Callback data that was specified when creating the signal.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -7546,10 +6625,7 @@ You may not attach these to signals created with the #G_SIGNAL_NO_HOOKS flag.</d
             <type name="Value" c:type="GValue"/>
           </array>
         </parameter>
-        <parameter name="data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">user data associated with the hook.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -7588,9 +6664,7 @@ stages of a signal emission.</doc>
       <member name="no_hooks" value="64" c:identifier="G_SIGNAL_NO_HOOKS">
         <doc xml:space="preserve">No emissions hooks are supported for this signal.</doc>
       </member>
-      <member name="must_collect"
-              value="128"
-              c:identifier="G_SIGNAL_MUST_COLLECT">
+      <member name="must_collect" value="128" c:identifier="G_SIGNAL_MUST_COLLECT">
         <doc xml:space="preserve">Varargs signal emission will always collect the
   arguments, even if there are no signal handlers connected.  Since 2.30.</doc>
       </member>
@@ -7637,9 +6711,7 @@ match signals by.</doc>
       <member name="data" value="16" c:identifier="G_SIGNAL_MATCH_DATA">
         <doc xml:space="preserve">The closure data must be the same.</doc>
       </member>
-      <member name="unblocked"
-              value="32"
-              c:identifier="G_SIGNAL_MATCH_UNBLOCKED">
+      <member name="unblocked" value="32" c:identifier="G_SIGNAL_MATCH_UNBLOCKED">
         <doc xml:space="preserve">Only unblocked signals may matched.</doc>
       </member>
     </bitfield>
@@ -7684,54 +6756,38 @@ filled in by the g_signal_query() function.</doc>
         </array>
       </field>
     </record>
-    <constant name="TYPE_FLAG_RESERVED_ID_BIT"
-              value="1"
-              c:type="G_TYPE_FLAG_RESERVED_ID_BIT">
+    <constant name="TYPE_FLAG_RESERVED_ID_BIT" value="1" c:type="G_TYPE_FLAG_RESERVED_ID_BIT">
       <doc xml:space="preserve">A bit in the type number that's supposed to be left untouched.</doc>
       <type name="GLib.Type" c:type="GType"/>
     </constant>
-    <constant name="TYPE_FUNDAMENTAL_MAX"
-              value="255"
-              c:type="G_TYPE_FUNDAMENTAL_MAX">
+    <constant name="TYPE_FUNDAMENTAL_MAX" value="255" c:type="G_TYPE_FUNDAMENTAL_MAX">
       <doc xml:space="preserve">An integer constant that represents the number of identifiers reserved
 for types that are assigned at compile-time.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="TYPE_FUNDAMENTAL_SHIFT"
-              value="2"
-              c:type="G_TYPE_FUNDAMENTAL_SHIFT">
+    <constant name="TYPE_FUNDAMENTAL_SHIFT" value="2" c:type="G_TYPE_FUNDAMENTAL_SHIFT">
       <doc xml:space="preserve">Shift value used in converting numbers to type IDs.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="TYPE_RESERVED_BSE_FIRST"
-              value="32"
-              c:type="G_TYPE_RESERVED_BSE_FIRST">
+    <constant name="TYPE_RESERVED_BSE_FIRST" value="32" c:type="G_TYPE_RESERVED_BSE_FIRST">
       <doc xml:space="preserve">First fundamental type number to create a new fundamental type id with
 G_TYPE_MAKE_FUNDAMENTAL() reserved for BSE.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="TYPE_RESERVED_BSE_LAST"
-              value="48"
-              c:type="G_TYPE_RESERVED_BSE_LAST">
+    <constant name="TYPE_RESERVED_BSE_LAST" value="48" c:type="G_TYPE_RESERVED_BSE_LAST">
       <doc xml:space="preserve">Last fundamental type number reserved for BSE.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="TYPE_RESERVED_GLIB_FIRST"
-              value="22"
-              c:type="G_TYPE_RESERVED_GLIB_FIRST">
+    <constant name="TYPE_RESERVED_GLIB_FIRST" value="22" c:type="G_TYPE_RESERVED_GLIB_FIRST">
       <doc xml:space="preserve">First fundamental type number to create a new fundamental type id with
 G_TYPE_MAKE_FUNDAMENTAL() reserved for GLib.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="TYPE_RESERVED_GLIB_LAST"
-              value="31"
-              c:type="G_TYPE_RESERVED_GLIB_LAST">
+    <constant name="TYPE_RESERVED_GLIB_LAST" value="31" c:type="G_TYPE_RESERVED_GLIB_LAST">
       <doc xml:space="preserve">Last fundamental type number reserved for GLib.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="TYPE_RESERVED_USER_FIRST"
-              value="49"
-              c:type="G_TYPE_RESERVED_USER_FIRST">
+    <constant name="TYPE_RESERVED_USER_FIRST" value="49" c:type="G_TYPE_RESERVED_USER_FIRST">
       <doc xml:space="preserve">First available fundamental type number to create new fundamental
 type id with G_TYPE_MAKE_FUNDAMENTAL().</doc>
       <type name="gint" c:type="gint"/>
@@ -7743,10 +6799,7 @@ of a toggle reference changes. See g_object_add_toggle_ref().</doc>
         <type name="none" c:type="void"/>
       </return-value>
       <parameters>
-        <parameter name="data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Callback data passed to g_object_add_toggle_ref()</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -7791,9 +6844,7 @@ of a toggle reference changes. See g_object_add_toggle_ref().</doc>
       <field name="g_type" readable="0" private="1">
         <type name="GType" c:type="GType"/>
       </field>
-      <method name="add_private"
-              c:identifier="g_type_class_add_private"
-              version="2.4">
+      <method name="add_private" c:identifier="g_type_class_add_private" version="2.4">
         <doc xml:space="preserve">Registers a private structure for an instantiatable type.
 
 When an object is allocated, the private structures for
@@ -7871,10 +6922,7 @@ my_object_get_some_field (MyObject *my_object)
           </parameter>
         </parameters>
       </method>
-      <method name="get_instance_private_offset"
-              c:identifier="g_type_class_get_instance_private_offset"
-              version="2.38"
-              introspectable="0">
+      <method name="get_instance_private_offset" c:identifier="g_type_class_get_instance_private_offset" version="2.38" introspectable="0">
         <doc xml:space="preserve">Gets the offset of the private data for instances of @g_class.
 
 This is how many bytes you should add to the instance pointer of a
@@ -7944,9 +6992,7 @@ class pointer after g_type_class_unref() are invalid.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="unref_uncached"
-              c:identifier="g_type_class_unref_uncached"
-              introspectable="0">
+      <method name="unref_uncached" c:identifier="g_type_class_unref_uncached" introspectable="0">
         <doc xml:space="preserve">A variant of g_type_class_unref() for use in #GTypeClassCacheFunc
 implementations. It unreferences a class without consulting the chain
 of #GTypeClassCacheFuncs, avoiding the recursion which would occur
@@ -7961,16 +7007,12 @@ otherwise.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <function name="adjust_private_offset"
-                c:identifier="g_type_class_adjust_private_offset">
+      <function name="adjust_private_offset" c:identifier="g_type_class_adjust_private_offset">
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <parameter name="g_class"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="g_class" transfer-ownership="none" nullable="1" allow-none="1">
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
           <parameter name="private_size_or_offset" transfer-ownership="none">
@@ -7997,9 +7039,7 @@ referenced before).</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="peek_static"
-                c:identifier="g_type_class_peek_static"
-                version="2.4">
+      <function name="peek_static" c:identifier="g_type_class_peek_static" version="2.4">
         <doc xml:space="preserve">A more efficient version of g_type_class_peek() which works only for
 static types.</doc>
         <return-value transfer-ownership="none">
@@ -8048,10 +7088,7 @@ classes are routed through the same #GTypeClassCacheFunc chain.</doc>
         <type name="gboolean" c:type="gboolean"/>
       </return-value>
       <parameters>
-        <parameter name="cache_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="cache_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">data that was given to the g_type_add_class_cache_func() call</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -8062,10 +7099,7 @@ classes are routed through the same #GTypeClassCacheFunc chain.</doc>
         </parameter>
       </parameters>
     </callback>
-    <bitfield name="TypeDebugFlags"
-              deprecated="1"
-              deprecated-version="2.36"
-              c:type="GTypeDebugFlags">
+    <bitfield name="TypeDebugFlags" deprecated="1" deprecated-version="2.36" c:type="GTypeDebugFlags">
       <doc xml:space="preserve">These flags used to be passed to g_type_init_with_debug_flags() which
 is now deprecated.
 
@@ -8081,9 +7115,7 @@ environment variable.</doc>
       <member name="signals" value="2" c:identifier="G_TYPE_DEBUG_SIGNALS">
         <doc xml:space="preserve">Print messages about signal emissions</doc>
       </member>
-      <member name="instance_count"
-              value="4"
-              c:identifier="G_TYPE_DEBUG_INSTANCE_COUNT">
+      <member name="instance_count" value="4" c:identifier="G_TYPE_DEBUG_INSTANCE_COUNT">
         <doc xml:space="preserve">Keep a count of instances of each type</doc>
       </member>
       <member name="mask" value="7" c:identifier="G_TYPE_DEBUG_MASK">
@@ -8096,9 +7128,7 @@ environment variable.</doc>
         <doc xml:space="preserve">Indicates an abstract type. No instances can be
  created for an abstract type</doc>
       </member>
-      <member name="value_abstract"
-              value="32"
-              c:identifier="G_TYPE_FLAG_VALUE_ABSTRACT">
+      <member name="value_abstract" value="32" c:identifier="G_TYPE_FLAG_VALUE_ABSTRACT">
         <doc xml:space="preserve">Indicates an abstract value type, i.e. a type
  that introduces a value table, but can't be used for
  g_value_init()</doc>
@@ -8110,17 +7140,13 @@ fundamental type.</doc>
       <member name="classed" value="1" c:identifier="G_TYPE_FLAG_CLASSED">
         <doc xml:space="preserve">Indicates a classed type</doc>
       </member>
-      <member name="instantiatable"
-              value="2"
-              c:identifier="G_TYPE_FLAG_INSTANTIATABLE">
+      <member name="instantiatable" value="2" c:identifier="G_TYPE_FLAG_INSTANTIATABLE">
         <doc xml:space="preserve">Indicates an instantiable type (implies classed)</doc>
       </member>
       <member name="derivable" value="4" c:identifier="G_TYPE_FLAG_DERIVABLE">
         <doc xml:space="preserve">Indicates a flat derivable type</doc>
       </member>
-      <member name="deep_derivable"
-              value="8"
-              c:identifier="G_TYPE_FLAG_DEEP_DERIVABLE">
+      <member name="deep_derivable" value="8" c:identifier="G_TYPE_FLAG_DEEP_DERIVABLE">
         <doc xml:space="preserve">Indicates a deep derivable type (implies derivable)</doc>
       </member>
     </bitfield>
@@ -8237,8 +7263,7 @@ then possibly overriding some methods.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <function name="add_prerequisite"
-                c:identifier="g_type_interface_add_prerequisite">
+      <function name="add_prerequisite" c:identifier="g_type_interface_add_prerequisite">
         <doc xml:space="preserve">Adds @prerequisite_type to the list of prerequisites of @interface_type.
 This means that any type implementing @interface_type must also implement
 @prerequisite_type. Prerequisites can be thought of as an alternative to
@@ -8299,9 +7324,7 @@ passed in class conforms.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="prerequisites"
-                c:identifier="g_type_interface_prerequisites"
-                version="2.2">
+      <function name="prerequisites" c:identifier="g_type_interface_prerequisites" version="2.2">
         <doc xml:space="preserve">Returns the prerequisites of an interfaces type.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a
@@ -8316,12 +7339,7 @@ passed in class conforms.</doc>
             <doc xml:space="preserve">an interface type</doc>
             <type name="GType" c:type="GType"/>
           </parameter>
-          <parameter name="n_prerequisites"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="n_prerequisites" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to return the number
     of prerequisites, or %NULL</doc>
             <type name="guint" c:type="guint*"/>
@@ -8329,19 +7347,14 @@ passed in class conforms.</doc>
         </parameters>
       </function>
     </record>
-    <callback name="TypeInterfaceCheckFunc"
-              c:type="GTypeInterfaceCheckFunc"
-              version="2.4">
+    <callback name="TypeInterfaceCheckFunc" c:type="GTypeInterfaceCheckFunc" version="2.4">
       <doc xml:space="preserve">A callback called after an interface vtable is initialized.
 See g_type_add_interface_check().</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
       </return-value>
       <parameters>
-        <parameter name="check_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="check_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">data passed to g_type_add_interface_check()</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -8352,14 +7365,7 @@ See g_type_add_interface_check().</doc>
         </parameter>
       </parameters>
     </callback>
-    <class name="TypeModule"
-           c:symbol-prefix="type_module"
-           c:type="GTypeModule"
-           parent="Object"
-           abstract="1"
-           glib:type-name="GTypeModule"
-           glib:get-type="g_type_module_get_type"
-           glib:type-struct="TypeModuleClass">
+    <class name="TypeModule" c:symbol-prefix="type_module" c:type="GTypeModule" parent="Object" abstract="1" glib:type-name="GTypeModule" glib:get-type="g_type_module_get_type" glib:type-struct="TypeModuleClass">
       <doc xml:space="preserve">#GTypeModule provides a simple implementation of the #GTypePlugin
 interface. The model of #GTypeModule is a dynamically loaded module
 which implements some number of types and interface implementations.
@@ -8436,9 +7442,7 @@ not be unloaded.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="register_enum"
-              c:identifier="g_type_module_register_enum"
-              version="2.6">
+      <method name="register_enum" c:identifier="g_type_module_register_enum" version="2.6">
         <doc xml:space="preserve">Looks up or registers an enumeration that is implemented with a particular
 type plugin. If a type with name @type_name was previously registered,
 the #GType identifier for the type is returned, otherwise the type
@@ -8468,9 +7472,7 @@ not be unloaded.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="register_flags"
-              c:identifier="g_type_module_register_flags"
-              version="2.6">
+      <method name="register_flags" c:identifier="g_type_module_register_flags" version="2.6">
         <doc xml:space="preserve">Looks up or registers a flags type that is implemented with a particular
 type plugin. If a type with name @type_name was previously registered,
 the #GType identifier for the type is returned, otherwise the type
@@ -8609,9 +7611,7 @@ its prior value.</doc>
         <type name="utf8" c:type="gchar*"/>
       </field>
     </class>
-    <record name="TypeModuleClass"
-            c:type="GTypeModuleClass"
-            glib:is-gtype-struct-for="TypeModule">
+    <record name="TypeModuleClass" c:type="GTypeModuleClass" glib:is-gtype-struct-for="TypeModule">
       <doc xml:space="preserve">In order to implement dynamic loading of types based on #GTypeModule,
 the @load and @unload functions in #GTypeModuleClass must be implemented.</doc>
       <field name="parent_class">
@@ -8671,11 +7671,7 @@ the @load and @unload functions in #GTypeModuleClass must be implemented.</doc>
         </callback>
       </field>
     </record>
-    <interface name="TypePlugin"
-               c:symbol-prefix="type_plugin"
-               c:type="GTypePlugin"
-               glib:type-name="GTypePlugin"
-               glib:get-type="g_type_plugin_get_type">
+    <interface name="TypePlugin" c:symbol-prefix="type_plugin" c:type="GTypePlugin" glib:type-name="GTypePlugin" glib:get-type="g_type_plugin_get_type">
       <doc xml:space="preserve">The GObject type system supports dynamic loading of types.
 The #GTypePlugin interface is used to handle the lifecycle
 of dynamically loaded types. It goes as follows:
@@ -8723,8 +7719,7 @@ when the type is needed again.
 #GTypeModule is an implementation of #GTypePlugin that already
 implements most of this except for the actual module loading and
 unloading. It even handles multiple registered types per module.</doc>
-      <method name="complete_interface_info"
-              c:identifier="g_type_plugin_complete_interface_info">
+      <method name="complete_interface_info" c:identifier="g_type_plugin_complete_interface_info">
         <doc xml:space="preserve">Calls the @complete_interface_info function from the
 #GTypePluginClass of @plugin. There should be no need to use this
 function outside of the GObject type system itself.</doc>
@@ -8751,8 +7746,7 @@ function outside of the GObject type system itself.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="complete_type_info"
-              c:identifier="g_type_plugin_complete_type_info">
+      <method name="complete_type_info" c:identifier="g_type_plugin_complete_type_info">
         <doc xml:space="preserve">Calls the @complete_type_info function from the #GTypePluginClass of @plugin.
 There should be no need to use this function outside of the GObject
 type system itself.</doc>
@@ -8825,19 +7819,16 @@ the lifecycle of dynamically loaded types.</doc>
         <doc xml:space="preserve">Fills in the #GTypeInfo and
  #GTypeValueTable structs for the type. The structs are initialized
  with `memset(s, 0, sizeof (s))` before calling this function.</doc>
-        <type name="TypePluginCompleteTypeInfo"
-              c:type="GTypePluginCompleteTypeInfo"/>
+        <type name="TypePluginCompleteTypeInfo" c:type="GTypePluginCompleteTypeInfo"/>
       </field>
       <field name="complete_interface_info" writable="1">
         <doc xml:space="preserve">Fills in missing parts of the #GInterfaceInfo
  for the interface. The structs is initialized with
  `memset(s, 0, sizeof (s))` before calling this function.</doc>
-        <type name="TypePluginCompleteInterfaceInfo"
-              c:type="GTypePluginCompleteInterfaceInfo"/>
+        <type name="TypePluginCompleteInterfaceInfo" c:type="GTypePluginCompleteInterfaceInfo"/>
       </field>
     </record>
-    <callback name="TypePluginCompleteInterfaceInfo"
-              c:type="GTypePluginCompleteInterfaceInfo">
+    <callback name="TypePluginCompleteInterfaceInfo" c:type="GTypePluginCompleteInterfaceInfo">
       <doc xml:space="preserve">The type of the @complete_interface_info function of #GTypePluginClass.</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
@@ -8862,8 +7853,7 @@ the lifecycle of dynamically loaded types.</doc>
         </parameter>
       </parameters>
     </callback>
-    <callback name="TypePluginCompleteTypeInfo"
-              c:type="GTypePluginCompleteTypeInfo">
+    <callback name="TypePluginCompleteTypeInfo" c:type="GTypePluginCompleteTypeInfo">
       <doc xml:space="preserve">The type of the @complete_type_info function of #GTypePluginClass.</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
@@ -9049,9 +8039,7 @@ implementation, to serve as a container for values of a type.</doc>
           </parameters>
         </callback>
       </field>
-      <function name="peek"
-                c:identifier="g_type_value_table_peek"
-                introspectable="0">
+      <function name="peek" c:identifier="g_type_value_table_peek" introspectable="0">
         <doc xml:space="preserve">Returns the location of the #GTypeValueTable associated with @type.
 
 Note that this function should only be used from source code
@@ -9070,24 +8058,18 @@ that implements or has internal knowledge of the implementation of
         </parameters>
       </function>
     </record>
-    <constant name="VALUE_COLLECT_FORMAT_MAX_LENGTH"
-              value="8"
-              c:type="G_VALUE_COLLECT_FORMAT_MAX_LENGTH">
+    <constant name="VALUE_COLLECT_FORMAT_MAX_LENGTH" value="8" c:type="G_VALUE_COLLECT_FORMAT_MAX_LENGTH">
       <doc xml:space="preserve">The maximal number of #GTypeCValues which can be collected for a
 single #GValue.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="VALUE_NOCOPY_CONTENTS"
-              value="134217728"
-              c:type="G_VALUE_NOCOPY_CONTENTS">
+    <constant name="VALUE_NOCOPY_CONTENTS" value="134217728" c:type="G_VALUE_NOCOPY_CONTENTS">
       <doc xml:space="preserve">If passed to G_VALUE_COLLECT(), allocated data won't be copied
 but used verbatim. This does not affect ref-counted types like
 objects.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <callback name="VaClosureMarshal"
-              c:type="GVaClosureMarshal"
-              introspectable="0">
+    <callback name="VaClosureMarshal" c:type="GVaClosureMarshal" introspectable="0">
       <doc xml:space="preserve">This is the signature of va_list marshaller functions, an optional
 marshaller that can be used in some situations to avoid
 marshalling the signal argument into GValues.</doc>
@@ -9099,10 +8081,7 @@ marshalling the signal argument into GValues.</doc>
           <doc xml:space="preserve">the #GClosure to which the marshaller belongs</doc>
           <type name="Closure" c:type="GClosure*"/>
         </parameter>
-        <parameter name="return_value"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="return_value" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">a #GValue to store the return
  value. May be %NULL if the callback of @closure doesn't return a
  value.</doc>
@@ -9117,10 +8096,7 @@ marshalling the signal argument into GValues.</doc>
           <doc xml:space="preserve">va_list of arguments to be passed to the closure.</doc>
           <type name="va_list" c:type="va_list"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">additional data specified when
  registering the marshaller, see g_closure_set_marshal() and
  g_closure_set_meta_marshal()</doc>
@@ -9139,11 +8115,7 @@ marshalling the signal argument into GValues.</doc>
         </parameter>
       </parameters>
     </callback>
-    <record name="Value"
-            c:type="GValue"
-            glib:type-name="GValue"
-            glib:get-type="g_value_get_type"
-            c:symbol-prefix="value">
+    <record name="Value" c:type="GValue" glib:type-name="GValue" glib:get-type="g_value_get_type" c:symbol-prefix="value">
       <doc xml:space="preserve">An opaque structure used to hold different types of values.
 The data within the structure has protected scope: it is accessible only
 to functions within a #GTypeValueTable structure, or implementations of
@@ -9176,9 +8148,7 @@ only be accessed through the G_VALUE_TYPE() macro.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="dup_boxed"
-              c:identifier="g_value_dup_boxed"
-              introspectable="0">
+      <method name="dup_boxed" c:identifier="g_value_dup_boxed" introspectable="0">
         <doc xml:space="preserve">Get the contents of a %G_TYPE_BOXED derived #GValue.  Upon getting,
 the boxed value is duplicated and needs to be later freed with
 g_boxed_free(), e.g. like: g_boxed_free (G_VALUE_TYPE (@value),
@@ -9210,9 +8180,7 @@ its reference count. If the contents of the #GValue are %NULL, then
           </instance-parameter>
         </parameters>
       </method>
-      <method name="dup_param"
-              c:identifier="g_value_dup_param"
-              introspectable="0">
+      <method name="dup_param" c:identifier="g_value_dup_param" introspectable="0">
         <doc xml:space="preserve">Get the contents of a %G_TYPE_PARAM #GValue, increasing its
 reference count.</doc>
         <return-value>
@@ -9240,9 +8208,7 @@ reference count.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="dup_variant"
-              c:identifier="g_value_dup_variant"
-              version="2.26">
+      <method name="dup_variant" c:identifier="g_value_dup_variant" version="2.26">
         <doc xml:space="preserve">Get the contents of a variant #GValue, increasing its refcount.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">variant contents of @value, should be unrefed using
@@ -9296,10 +8262,7 @@ This is an internal function introduced mainly for C marshallers.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_char"
-              c:identifier="g_value_get_char"
-              deprecated="1"
-              deprecated-version="2.32">
+      <method name="get_char" c:identifier="g_value_get_char" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Do not use this function; it is broken on platforms where the %char
 type is unsigned, such as ARM and PowerPC.  See g_value_get_schar().
 
@@ -9537,9 +8500,7 @@ Get the contents of a %G_TYPE_CHAR #GValue.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_variant"
-              c:identifier="g_value_get_variant"
-              version="2.26">
+      <method name="get_variant" c:identifier="g_value_get_variant" version="2.26">
         <doc xml:space="preserve">Get the contents of a variant #GValue.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">variant contents of @value</doc>
@@ -9569,9 +8530,7 @@ Get the contents of a %G_TYPE_CHAR #GValue.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="init_from_instance"
-              c:identifier="g_value_init_from_instance"
-              version="2.42">
+      <method name="init_from_instance" c:identifier="g_value_init_from_instance" version="2.42">
         <doc xml:space="preserve">Initializes and sets @value from an instantiatable type via the
 value_table's collect_value() function.
 
@@ -9648,19 +8607,13 @@ This is an internal function introduced mainly for C marshallers.</doc>
             <doc xml:space="preserve">a valid #GValue of %G_TYPE_BOXED derived type</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="v_boxed"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="v_boxed" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">boxed value to be set</doc>
             <type name="gpointer" c:type="gconstpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="set_boxed_take_ownership"
-              c:identifier="g_value_set_boxed_take_ownership"
-              deprecated="1"
-              deprecated-version="2.4">
+      <method name="set_boxed_take_ownership" c:identifier="g_value_set_boxed_take_ownership" deprecated="1" deprecated-version="2.4">
         <doc xml:space="preserve">This is an internal function introduced mainly for C marshallers.</doc>
         <doc-deprecated xml:space="preserve">Use g_value_take_boxed() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -9671,19 +8624,13 @@ This is an internal function introduced mainly for C marshallers.</doc>
             <doc xml:space="preserve">a valid #GValue of %G_TYPE_BOXED derived type</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="v_boxed"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="v_boxed" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">duplicated unowned boxed value to be set</doc>
             <type name="gpointer" c:type="gconstpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="set_char"
-              c:identifier="g_value_set_char"
-              deprecated="1"
-              deprecated-version="2.32">
+      <method name="set_char" c:identifier="g_value_set_char" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Set the contents of a %G_TYPE_CHAR #GValue to @v_char.</doc>
         <doc-deprecated xml:space="preserve">This function's input type is broken, see g_value_set_schar()</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -9791,10 +8738,7 @@ value_table's collect_value() function.</doc>
             <doc xml:space="preserve">An initialized #GValue structure.</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="instance"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="instance" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the instance</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -9868,20 +8812,13 @@ the #GValue still exists).</doc>
             <doc xml:space="preserve">a valid #GValue of %G_TYPE_OBJECT derived type</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="v_object"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="v_object" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">object value to be set</doc>
             <type name="Object" c:type="gpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="set_object_take_ownership"
-              c:identifier="g_value_set_object_take_ownership"
-              introspectable="0"
-              deprecated="1"
-              deprecated-version="2.4">
+      <method name="set_object_take_ownership" c:identifier="g_value_set_object_take_ownership" introspectable="0" deprecated="1" deprecated-version="2.4">
         <doc xml:space="preserve">This is an internal function introduced mainly for C marshallers.</doc>
         <doc-deprecated xml:space="preserve">Use g_value_take_object() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -9892,10 +8829,7 @@ the #GValue still exists).</doc>
             <doc xml:space="preserve">a valid #GValue of %G_TYPE_OBJECT derived type</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="v_object"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="v_object" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">object value to be set</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -9911,20 +8845,13 @@ the #GValue still exists).</doc>
             <doc xml:space="preserve">a valid #GValue of type %G_TYPE_PARAM</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="param"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="param" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the #GParamSpec to be set</doc>
             <type name="ParamSpec" c:type="GParamSpec*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="set_param_take_ownership"
-              c:identifier="g_value_set_param_take_ownership"
-              introspectable="0"
-              deprecated="1"
-              deprecated-version="2.4">
+      <method name="set_param_take_ownership" c:identifier="g_value_set_param_take_ownership" introspectable="0" deprecated="1" deprecated-version="2.4">
         <doc xml:space="preserve">This is an internal function introduced mainly for C marshallers.</doc>
         <doc-deprecated xml:space="preserve">Use g_value_take_param() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -9935,10 +8862,7 @@ the #GValue still exists).</doc>
             <doc xml:space="preserve">a valid #GValue of type %G_TYPE_PARAM</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="param"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="param" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the #GParamSpec to be set</doc>
             <type name="ParamSpec" c:type="GParamSpec*"/>
           </parameter>
@@ -9954,10 +8878,7 @@ the #GValue still exists).</doc>
             <doc xml:space="preserve">a valid #GValue of %G_TYPE_POINTER</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="v_pointer"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="v_pointer" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">pointer value to be set</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -9991,17 +8912,13 @@ when setting the #GValue.</doc>
             <doc xml:space="preserve">a valid #GValue of %G_TYPE_BOXED derived type</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="v_boxed"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="v_boxed" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">static boxed value to be set</doc>
             <type name="gpointer" c:type="gconstpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="set_static_string"
-              c:identifier="g_value_set_static_string">
+      <method name="set_static_string" c:identifier="g_value_set_static_string">
         <doc xml:space="preserve">Set the contents of a %G_TYPE_STRING #GValue to @v_string.
 The string is assumed to be static, and is thus not duplicated
 when setting the #GValue.</doc>
@@ -10013,10 +8930,7 @@ when setting the #GValue.</doc>
             <doc xml:space="preserve">a valid #GValue of type %G_TYPE_STRING</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="v_string"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="v_string" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">static string to be set</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
@@ -10032,19 +8946,13 @@ when setting the #GValue.</doc>
             <doc xml:space="preserve">a valid #GValue of type %G_TYPE_STRING</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="v_string"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="v_string" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">caller-owned string to be duplicated for the #GValue</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="set_string_take_ownership"
-              c:identifier="g_value_set_string_take_ownership"
-              deprecated="1"
-              deprecated-version="2.4">
+      <method name="set_string_take_ownership" c:identifier="g_value_set_string_take_ownership" deprecated="1" deprecated-version="2.4">
         <doc xml:space="preserve">This is an internal function introduced mainly for C marshallers.</doc>
         <doc-deprecated xml:space="preserve">Use g_value_take_string() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -10055,10 +8963,7 @@ when setting the #GValue.</doc>
             <doc xml:space="preserve">a valid #GValue of type %G_TYPE_STRING</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="v_string"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="v_string" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">duplicated unowned string to be set</doc>
             <type name="utf8" c:type="gchar*"/>
           </parameter>
@@ -10128,9 +9033,7 @@ when setting the #GValue.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_variant"
-              c:identifier="g_value_set_variant"
-              version="2.26">
+      <method name="set_variant" c:identifier="g_value_set_variant" version="2.26">
         <doc xml:space="preserve">Set the contents of a variant #GValue to @variant.
 If the variant is floating, it is consumed.</doc>
         <return-value transfer-ownership="none">
@@ -10141,18 +9044,13 @@ If the variant is floating, it is consumed.</doc>
             <doc xml:space="preserve">a valid #GValue of type %G_TYPE_VARIANT</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="variant"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="variant" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GVariant, or %NULL</doc>
             <type name="GLib.Variant" c:type="GVariant*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="take_boxed"
-              c:identifier="g_value_take_boxed"
-              version="2.4">
+      <method name="take_boxed" c:identifier="g_value_take_boxed" version="2.4">
         <doc xml:space="preserve">Sets the contents of a %G_TYPE_BOXED derived #GValue to @v_boxed
 and takes over the ownership of the callers reference to @v_boxed;
 the caller doesn't have to unref it any more.</doc>
@@ -10164,19 +9062,13 @@ the caller doesn't have to unref it any more.</doc>
             <doc xml:space="preserve">a valid #GValue of %G_TYPE_BOXED derived type</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="v_boxed"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="v_boxed" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">duplicated unowned boxed value to be set</doc>
             <type name="gpointer" c:type="gconstpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="take_object"
-              c:identifier="g_value_take_object"
-              version="2.4"
-              introspectable="0">
+      <method name="take_object" c:identifier="g_value_take_object" version="2.4" introspectable="0">
         <doc xml:space="preserve">Sets the contents of a %G_TYPE_OBJECT derived #GValue to @v_object
 and takes over the ownership of the callers reference to @v_object;
 the caller doesn't have to unref it any more (i.e. the reference
@@ -10192,19 +9084,13 @@ g_value_set_object() instead.</doc>
             <doc xml:space="preserve">a valid #GValue of %G_TYPE_OBJECT derived type</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="v_object"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="v_object" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">object value to be set</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="take_param"
-              c:identifier="g_value_take_param"
-              version="2.4"
-              introspectable="0">
+      <method name="take_param" c:identifier="g_value_take_param" version="2.4" introspectable="0">
         <doc xml:space="preserve">Sets the contents of a %G_TYPE_PARAM #GValue to @param and takes
 over the ownership of the callers reference to @param; the caller
 doesn't have to unref it any more.</doc>
@@ -10216,18 +9102,13 @@ doesn't have to unref it any more.</doc>
             <doc xml:space="preserve">a valid #GValue of type %G_TYPE_PARAM</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="param"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="param" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the #GParamSpec to be set</doc>
             <type name="ParamSpec" c:type="GParamSpec*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="take_string"
-              c:identifier="g_value_take_string"
-              version="2.4">
+      <method name="take_string" c:identifier="g_value_take_string" version="2.4">
         <doc xml:space="preserve">Sets the contents of a %G_TYPE_STRING #GValue to @v_string.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -10237,18 +9118,13 @@ doesn't have to unref it any more.</doc>
             <doc xml:space="preserve">a valid #GValue of type %G_TYPE_STRING</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="v_string"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="v_string" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">string to take ownership of</doc>
             <type name="utf8" c:type="gchar*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="take_variant"
-              c:identifier="g_value_take_variant"
-              version="2.26">
+      <method name="take_variant" c:identifier="g_value_take_variant" version="2.26">
         <doc xml:space="preserve">Set the contents of a variant #GValue to @variant, and takes over
 the ownership of the caller's reference to @variant;
 the caller doesn't have to unref it any more (i.e. the reference
@@ -10269,10 +9145,7 @@ This is an internal function introduced mainly for C marshallers.</doc>
             <doc xml:space="preserve">a valid #GValue of type %G_TYPE_VARIANT</doc>
             <type name="Value" c:type="GValue*"/>
           </instance-parameter>
-          <parameter name="variant"
-                     transfer-ownership="full"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="variant" transfer-ownership="full" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GVariant, or %NULL</doc>
             <type name="GLib.Variant" c:type="GVariant*"/>
           </parameter>
@@ -10317,9 +9190,7 @@ structure.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <function name="register_transform_func"
-                c:identifier="g_value_register_transform_func"
-                introspectable="0">
+      <function name="register_transform_func" c:identifier="g_value_register_transform_func" introspectable="0">
         <doc xml:space="preserve">Registers a value transformation function for use in g_value_transform().
 A previously registered transformation function for @src_type and @dest_type
 will be replaced.</doc>
@@ -10360,8 +9231,7 @@ a #GValue of type @dest_type.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="type_transformable"
-                c:identifier="g_value_type_transformable">
+      <function name="type_transformable" c:identifier="g_value_type_transformable">
         <doc xml:space="preserve">Check whether g_value_transform() is able to transform values
 of type @src_type into values of type @dest_type. Note that for
 the types to be transformable, they must be compatible or a
@@ -10382,11 +9252,7 @@ transformation function must be registered.</doc>
         </parameters>
       </function>
     </record>
-    <record name="ValueArray"
-            c:type="GValueArray"
-            glib:type-name="GValueArray"
-            glib:get-type="g_value_array_get_type"
-            c:symbol-prefix="value_array">
+    <record name="ValueArray" c:type="GValueArray" glib:type-name="GValueArray" glib:get-type="g_value_array_get_type" c:symbol-prefix="value_array">
       <doc xml:space="preserve">A #GValueArray contains an array of #GValue elements.</doc>
       <field name="n_values" writable="1">
         <doc xml:space="preserve">number of values contained in the array</doc>
@@ -10399,10 +9265,7 @@ transformation function must be registered.</doc>
       <field name="n_prealloced" readable="0" private="1">
         <type name="guint" c:type="guint"/>
       </field>
-      <constructor name="new"
-                   c:identifier="g_value_array_new"
-                   deprecated="1"
-                   deprecated-version="2.32">
+      <constructor name="new" c:identifier="g_value_array_new" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Allocate and initialize a new #GValueArray, optionally preserve space
 for @n_prealloced elements. New arrays always contain 0 elements,
 regardless of the value of @n_prealloced.</doc>
@@ -10418,10 +9281,7 @@ regardless of the value of @n_prealloced.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <method name="append"
-              c:identifier="g_value_array_append"
-              deprecated="1"
-              deprecated-version="2.32">
+      <method name="append" c:identifier="g_value_array_append" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Insert a copy of @value as last element of @value_array. If @value is
 %NULL, an uninitialized value is appended.</doc>
         <doc-deprecated xml:space="preserve">Use #GArray and g_array_append_val() instead.</doc-deprecated>
@@ -10434,19 +9294,13 @@ regardless of the value of @n_prealloced.</doc>
             <doc xml:space="preserve">#GValueArray to add an element to</doc>
             <type name="ValueArray" c:type="GValueArray*"/>
           </instance-parameter>
-          <parameter name="value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">#GValue to copy into #GValueArray, or %NULL</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="copy"
-              c:identifier="g_value_array_copy"
-              deprecated="1"
-              deprecated-version="2.32">
+      <method name="copy" c:identifier="g_value_array_copy" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Construct an exact copy of a #GValueArray by duplicating all its
 contents.</doc>
         <doc-deprecated xml:space="preserve">Use #GArray and g_array_ref() instead.</doc-deprecated>
@@ -10461,10 +9315,7 @@ contents.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="free"
-              c:identifier="g_value_array_free"
-              deprecated="1"
-              deprecated-version="2.32">
+      <method name="free" c:identifier="g_value_array_free" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Free a #GValueArray including its contents.</doc>
         <doc-deprecated xml:space="preserve">Use #GArray and g_array_unref() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -10477,10 +9328,7 @@ contents.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_nth"
-              c:identifier="g_value_array_get_nth"
-              deprecated="1"
-              deprecated-version="2.32">
+      <method name="get_nth" c:identifier="g_value_array_get_nth" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Return a pointer to the value at @index_ containd in @value_array.</doc>
         <doc-deprecated xml:space="preserve">Use g_array_index() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -10498,10 +9346,7 @@ contents.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="insert"
-              c:identifier="g_value_array_insert"
-              deprecated="1"
-              deprecated-version="2.32">
+      <method name="insert" c:identifier="g_value_array_insert" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Insert a copy of @value at specified position into @value_array. If @value
 is %NULL, an uninitialized value is inserted.</doc>
         <doc-deprecated xml:space="preserve">Use #GArray and g_array_insert_val() instead.</doc-deprecated>
@@ -10518,19 +9363,13 @@ is %NULL, an uninitialized value is inserted.</doc>
             <doc xml:space="preserve">insertion position, must be &lt;= value_array-&gt;;n_values</doc>
             <type name="guint" c:type="guint"/>
           </parameter>
-          <parameter name="value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">#GValue to copy into #GValueArray, or %NULL</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="prepend"
-              c:identifier="g_value_array_prepend"
-              deprecated="1"
-              deprecated-version="2.32">
+      <method name="prepend" c:identifier="g_value_array_prepend" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Insert a copy of @value as first element of @value_array. If @value is
 %NULL, an uninitialized value is prepended.</doc>
         <doc-deprecated xml:space="preserve">Use #GArray and g_array_prepend_val() instead.</doc-deprecated>
@@ -10543,19 +9382,13 @@ is %NULL, an uninitialized value is inserted.</doc>
             <doc xml:space="preserve">#GValueArray to add an element to</doc>
             <type name="ValueArray" c:type="GValueArray*"/>
           </instance-parameter>
-          <parameter name="value"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">#GValue to copy into #GValueArray, or %NULL</doc>
             <type name="Value" c:type="const GValue*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="remove"
-              c:identifier="g_value_array_remove"
-              deprecated="1"
-              deprecated-version="2.32">
+      <method name="remove" c:identifier="g_value_array_remove" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Remove the value at position @index_ from @value_array.</doc>
         <doc-deprecated xml:space="preserve">Use #GArray and g_array_remove_index() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -10574,11 +9407,7 @@ is %NULL, an uninitialized value is inserted.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="sort"
-              c:identifier="g_value_array_sort"
-              shadowed-by="sort_with_data"
-              deprecated="1"
-              deprecated-version="2.32">
+      <method name="sort" c:identifier="g_value_array_sort" shadowed-by="sort_with_data" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Sort @value_array using @compare_func to compare the elements according to
 the semantics of #GCompareFunc.
 
@@ -10594,19 +9423,13 @@ C qsort() function.</doc>
             <doc xml:space="preserve">#GValueArray to sort</doc>
             <type name="ValueArray" c:type="GValueArray*"/>
           </instance-parameter>
-          <parameter name="compare_func"
-                     transfer-ownership="none"
-                     scope="call">
+          <parameter name="compare_func" transfer-ownership="none" scope="call">
             <doc xml:space="preserve">function to compare elements</doc>
             <type name="GLib.CompareFunc" c:type="GCompareFunc"/>
           </parameter>
         </parameters>
       </method>
-      <method name="sort_with_data"
-              c:identifier="g_value_array_sort_with_data"
-              shadows="sort"
-              deprecated="1"
-              deprecated-version="2.32">
+      <method name="sort_with_data" c:identifier="g_value_array_sort_with_data" shadows="sort" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Sort @value_array using @compare_func to compare the elements according
 to the semantics of #GCompareDataFunc.
 
@@ -10622,17 +9445,11 @@ C qsort() function.</doc>
             <doc xml:space="preserve">#GValueArray to sort</doc>
             <type name="ValueArray" c:type="GValueArray*"/>
           </instance-parameter>
-          <parameter name="compare_func"
-                     transfer-ownership="none"
-                     scope="call"
-                     closure="1">
+          <parameter name="compare_func" transfer-ownership="none" scope="call" closure="1">
             <doc xml:space="preserve">function to compare elements</doc>
             <type name="GLib.CompareDataFunc" c:type="GCompareDataFunc"/>
           </parameter>
-          <parameter name="user_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">extra data argument provided for @compare_func</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -10665,10 +9482,7 @@ with the object, apart from e.g. using its address as hash-index or the like.</d
         <type name="none" c:type="void"/>
       </return-value>
       <parameters>
-        <parameter name="data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">data that was provided when the weak reference was established</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -10704,10 +9518,7 @@ goes back to zero, at which point they too will be invalidated.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </field>
       </union>
-      <method name="clear"
-              c:identifier="g_weak_ref_clear"
-              version="2.32"
-              introspectable="0">
+      <method name="clear" c:identifier="g_weak_ref_clear" version="2.32" introspectable="0">
         <doc xml:space="preserve">Frees resources associated with a non-statically-allocated #GWeakRef.
 After this call, the #GWeakRef is left in an undefined state.
 
@@ -10717,20 +9528,14 @@ g_weak_ref_init() called on it.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="weak_ref"
-                              direction="inout"
-                              caller-allocates="0"
-                              transfer-ownership="full">
+          <instance-parameter name="weak_ref" direction="inout" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location of a weak reference, which
  may be empty</doc>
             <type name="WeakRef" c:type="GWeakRef*"/>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get"
-              c:identifier="g_weak_ref_get"
-              version="2.32"
-              introspectable="0">
+      <method name="get" c:identifier="g_weak_ref_get" version="2.32" introspectable="0">
         <doc xml:space="preserve">If @weak_ref is not empty, atomically acquire a strong
 reference to the object it points to, and return that reference.
 
@@ -10746,19 +9551,13 @@ by using g_object_unref().</doc>
           <type name="Object" c:type="gpointer"/>
         </return-value>
         <parameters>
-          <instance-parameter name="weak_ref"
-                              direction="inout"
-                              caller-allocates="0"
-                              transfer-ownership="full">
+          <instance-parameter name="weak_ref" direction="inout" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location of a weak reference to a #GObject</doc>
             <type name="WeakRef" c:type="GWeakRef*"/>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="init"
-              c:identifier="g_weak_ref_init"
-              version="2.32"
-              introspectable="0">
+      <method name="init" c:identifier="g_weak_ref_init" version="2.32" introspectable="0">
         <doc xml:space="preserve">Initialise a non-statically-allocated #GWeakRef.
 
 This function also calls g_weak_ref_set() with @object on the
@@ -10772,27 +9571,18 @@ properly initialised.  Just use g_weak_ref_set() directly.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="weak_ref"
-                              direction="inout"
-                              caller-allocates="0"
-                              transfer-ownership="full">
+          <instance-parameter name="weak_ref" direction="inout" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">uninitialized or empty location for a weak
    reference</doc>
             <type name="WeakRef" c:type="GWeakRef*"/>
           </instance-parameter>
-          <parameter name="object"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="object" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GObject or %NULL</doc>
             <type name="Object" c:type="gpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="set"
-              c:identifier="g_weak_ref_set"
-              version="2.32"
-              introspectable="0">
+      <method name="set" c:identifier="g_weak_ref_set" version="2.32" introspectable="0">
         <doc xml:space="preserve">Change the object to which @weak_ref points, or set it to
 %NULL.
 
@@ -10806,10 +9596,7 @@ function.</doc>
             <doc xml:space="preserve">location for a weak reference</doc>
             <type name="WeakRef" c:type="GWeakRef*"/>
           </instance-parameter>
-          <parameter name="object"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="object" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #GObject or %NULL</doc>
             <type name="Object" c:type="gpointer"/>
           </parameter>
@@ -10879,9 +9666,7 @@ function.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="boxed_type_register_static"
-              c:identifier="g_boxed_type_register_static"
-              introspectable="0">
+    <function name="boxed_type_register_static" c:identifier="g_boxed_type_register_static" introspectable="0">
       <doc xml:space="preserve">This function creates a new %G_TYPE_BOXED derived type id for a new
 boxed type with name @name. Boxed type handling functions have to be
 provided to copy and free opaque boxed structures of this type.</doc>
@@ -10904,9 +9689,7 @@ provided to copy and free opaque boxed structures of this type.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_BOOLEAN__BOXED_BOXED"
-              c:identifier="g_cclosure_marshal_BOOLEAN__BOXED_BOXED"
-              moved-to="CClosure.marshal_BOOLEAN__BOXED_BOXED">
+    <function name="cclosure_marshal_BOOLEAN__BOXED_BOXED" c:identifier="g_cclosure_marshal_BOOLEAN__BOXED_BOXED" moved-to="CClosure.marshal_BOOLEAN__BOXED_BOXED">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with handlers that
 take two boxed pointers as arguments and return a boolean.  If you
 have such a signal, you will probably also need to use an
@@ -10933,18 +9716,12 @@ accumulator, such as g_signal_accumulator_true_handled().</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -10952,9 +9729,7 @@ accumulator, such as g_signal_accumulator_true_handled().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_BOOLEAN__FLAGS"
-              c:identifier="g_cclosure_marshal_BOOLEAN__FLAGS"
-              moved-to="CClosure.marshal_BOOLEAN__FLAGS">
+    <function name="cclosure_marshal_BOOLEAN__FLAGS" c:identifier="g_cclosure_marshal_BOOLEAN__FLAGS" moved-to="CClosure.marshal_BOOLEAN__FLAGS">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with handlers that
 take a flags type as an argument and return a boolean.  If you have
 such a signal, you will probably also need to use an accumulator,
@@ -10981,18 +9756,12 @@ such as g_signal_accumulator_true_handled().</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11000,9 +9769,7 @@ such as g_signal_accumulator_true_handled().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_STRING__OBJECT_POINTER"
-              c:identifier="g_cclosure_marshal_STRING__OBJECT_POINTER"
-              moved-to="CClosure.marshal_STRING__OBJECT_POINTER">
+    <function name="cclosure_marshal_STRING__OBJECT_POINTER" c:identifier="g_cclosure_marshal_STRING__OBJECT_POINTER" moved-to="CClosure.marshal_STRING__OBJECT_POINTER">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with handlers that
 take a #GObject and a pointer and produce a string.  It is highly
 unlikely that your signal handler fits this description.</doc>
@@ -11028,18 +9795,12 @@ unlikely that your signal handler fits this description.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11047,9 +9808,7 @@ unlikely that your signal handler fits this description.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__BOOLEAN"
-              c:identifier="g_cclosure_marshal_VOID__BOOLEAN"
-              moved-to="CClosure.marshal_VOID__BOOLEAN">
+    <function name="cclosure_marshal_VOID__BOOLEAN" c:identifier="g_cclosure_marshal_VOID__BOOLEAN" moved-to="CClosure.marshal_VOID__BOOLEAN">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 boolean argument.</doc>
       <return-value transfer-ownership="none">
@@ -11074,18 +9833,12 @@ boolean argument.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11093,9 +9846,7 @@ boolean argument.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__BOXED"
-              c:identifier="g_cclosure_marshal_VOID__BOXED"
-              moved-to="CClosure.marshal_VOID__BOXED">
+    <function name="cclosure_marshal_VOID__BOXED" c:identifier="g_cclosure_marshal_VOID__BOXED" moved-to="CClosure.marshal_VOID__BOXED">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 argument which is any boxed pointer type.</doc>
       <return-value transfer-ownership="none">
@@ -11120,18 +9871,12 @@ argument which is any boxed pointer type.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11139,9 +9884,7 @@ argument which is any boxed pointer type.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__CHAR"
-              c:identifier="g_cclosure_marshal_VOID__CHAR"
-              moved-to="CClosure.marshal_VOID__CHAR">
+    <function name="cclosure_marshal_VOID__CHAR" c:identifier="g_cclosure_marshal_VOID__CHAR" moved-to="CClosure.marshal_VOID__CHAR">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 character argument.</doc>
       <return-value transfer-ownership="none">
@@ -11166,18 +9909,12 @@ character argument.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11185,9 +9922,7 @@ character argument.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__DOUBLE"
-              c:identifier="g_cclosure_marshal_VOID__DOUBLE"
-              moved-to="CClosure.marshal_VOID__DOUBLE">
+    <function name="cclosure_marshal_VOID__DOUBLE" c:identifier="g_cclosure_marshal_VOID__DOUBLE" moved-to="CClosure.marshal_VOID__DOUBLE">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with one
 double-precision floating point argument.</doc>
       <return-value transfer-ownership="none">
@@ -11212,18 +9947,12 @@ double-precision floating point argument.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11231,9 +9960,7 @@ double-precision floating point argument.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__ENUM"
-              c:identifier="g_cclosure_marshal_VOID__ENUM"
-              moved-to="CClosure.marshal_VOID__ENUM">
+    <function name="cclosure_marshal_VOID__ENUM" c:identifier="g_cclosure_marshal_VOID__ENUM" moved-to="CClosure.marshal_VOID__ENUM">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 argument with an enumerated type.</doc>
       <return-value transfer-ownership="none">
@@ -11258,18 +9985,12 @@ argument with an enumerated type.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11277,9 +9998,7 @@ argument with an enumerated type.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__FLAGS"
-              c:identifier="g_cclosure_marshal_VOID__FLAGS"
-              moved-to="CClosure.marshal_VOID__FLAGS">
+    <function name="cclosure_marshal_VOID__FLAGS" c:identifier="g_cclosure_marshal_VOID__FLAGS" moved-to="CClosure.marshal_VOID__FLAGS">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 argument with a flags types.</doc>
       <return-value transfer-ownership="none">
@@ -11304,18 +10023,12 @@ argument with a flags types.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11323,9 +10036,7 @@ argument with a flags types.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__FLOAT"
-              c:identifier="g_cclosure_marshal_VOID__FLOAT"
-              moved-to="CClosure.marshal_VOID__FLOAT">
+    <function name="cclosure_marshal_VOID__FLOAT" c:identifier="g_cclosure_marshal_VOID__FLOAT" moved-to="CClosure.marshal_VOID__FLOAT">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with one
 single-precision floating point argument.</doc>
       <return-value transfer-ownership="none">
@@ -11350,18 +10061,12 @@ single-precision floating point argument.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11369,9 +10074,7 @@ single-precision floating point argument.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__INT"
-              c:identifier="g_cclosure_marshal_VOID__INT"
-              moved-to="CClosure.marshal_VOID__INT">
+    <function name="cclosure_marshal_VOID__INT" c:identifier="g_cclosure_marshal_VOID__INT" moved-to="CClosure.marshal_VOID__INT">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 integer argument.</doc>
       <return-value transfer-ownership="none">
@@ -11396,18 +10099,12 @@ integer argument.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11415,9 +10112,7 @@ integer argument.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__LONG"
-              c:identifier="g_cclosure_marshal_VOID__LONG"
-              moved-to="CClosure.marshal_VOID__LONG">
+    <function name="cclosure_marshal_VOID__LONG" c:identifier="g_cclosure_marshal_VOID__LONG" moved-to="CClosure.marshal_VOID__LONG">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with with a single
 long integer argument.</doc>
       <return-value transfer-ownership="none">
@@ -11442,18 +10137,12 @@ long integer argument.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11461,9 +10150,7 @@ long integer argument.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__OBJECT"
-              c:identifier="g_cclosure_marshal_VOID__OBJECT"
-              moved-to="CClosure.marshal_VOID__OBJECT">
+    <function name="cclosure_marshal_VOID__OBJECT" c:identifier="g_cclosure_marshal_VOID__OBJECT" moved-to="CClosure.marshal_VOID__OBJECT">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 #GObject argument.</doc>
       <return-value transfer-ownership="none">
@@ -11488,18 +10175,12 @@ long integer argument.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11507,9 +10188,7 @@ long integer argument.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__PARAM"
-              c:identifier="g_cclosure_marshal_VOID__PARAM"
-              moved-to="CClosure.marshal_VOID__PARAM">
+    <function name="cclosure_marshal_VOID__PARAM" c:identifier="g_cclosure_marshal_VOID__PARAM" moved-to="CClosure.marshal_VOID__PARAM">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 argument of type #GParamSpec.</doc>
       <return-value transfer-ownership="none">
@@ -11534,18 +10213,12 @@ argument of type #GParamSpec.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11553,9 +10226,7 @@ argument of type #GParamSpec.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__POINTER"
-              c:identifier="g_cclosure_marshal_VOID__POINTER"
-              moved-to="CClosure.marshal_VOID__POINTER">
+    <function name="cclosure_marshal_VOID__POINTER" c:identifier="g_cclosure_marshal_VOID__POINTER" moved-to="CClosure.marshal_VOID__POINTER">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single raw
 pointer argument type.
 
@@ -11584,18 +10255,12 @@ g_cclosure_marshal_VOID__OBJECT().</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11603,9 +10268,7 @@ g_cclosure_marshal_VOID__OBJECT().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__STRING"
-              c:identifier="g_cclosure_marshal_VOID__STRING"
-              moved-to="CClosure.marshal_VOID__STRING">
+    <function name="cclosure_marshal_VOID__STRING" c:identifier="g_cclosure_marshal_VOID__STRING" moved-to="CClosure.marshal_VOID__STRING">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single string
 argument.</doc>
       <return-value transfer-ownership="none">
@@ -11630,18 +10293,12 @@ argument.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11649,9 +10306,7 @@ argument.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__UCHAR"
-              c:identifier="g_cclosure_marshal_VOID__UCHAR"
-              moved-to="CClosure.marshal_VOID__UCHAR">
+    <function name="cclosure_marshal_VOID__UCHAR" c:identifier="g_cclosure_marshal_VOID__UCHAR" moved-to="CClosure.marshal_VOID__UCHAR">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 unsigned character argument.</doc>
       <return-value transfer-ownership="none">
@@ -11676,18 +10331,12 @@ unsigned character argument.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11695,9 +10344,7 @@ unsigned character argument.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__UINT"
-              c:identifier="g_cclosure_marshal_VOID__UINT"
-              moved-to="CClosure.marshal_VOID__UINT">
+    <function name="cclosure_marshal_VOID__UINT" c:identifier="g_cclosure_marshal_VOID__UINT" moved-to="CClosure.marshal_VOID__UINT">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with with a single
 unsigned integer argument.</doc>
       <return-value transfer-ownership="none">
@@ -11722,18 +10369,12 @@ unsigned integer argument.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11741,9 +10382,7 @@ unsigned integer argument.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__UINT_POINTER"
-              c:identifier="g_cclosure_marshal_VOID__UINT_POINTER"
-              moved-to="CClosure.marshal_VOID__UINT_POINTER">
+    <function name="cclosure_marshal_VOID__UINT_POINTER" c:identifier="g_cclosure_marshal_VOID__UINT_POINTER" moved-to="CClosure.marshal_VOID__UINT_POINTER">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a unsigned int
 and a pointer as arguments.</doc>
       <return-value transfer-ownership="none">
@@ -11768,18 +10407,12 @@ and a pointer as arguments.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11787,9 +10420,7 @@ and a pointer as arguments.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__ULONG"
-              c:identifier="g_cclosure_marshal_VOID__ULONG"
-              moved-to="CClosure.marshal_VOID__ULONG">
+    <function name="cclosure_marshal_VOID__ULONG" c:identifier="g_cclosure_marshal_VOID__ULONG" moved-to="CClosure.marshal_VOID__ULONG">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 unsigned long integer argument.</doc>
       <return-value transfer-ownership="none">
@@ -11814,18 +10445,12 @@ unsigned long integer argument.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11833,9 +10458,7 @@ unsigned long integer argument.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__VARIANT"
-              c:identifier="g_cclosure_marshal_VOID__VARIANT"
-              moved-to="CClosure.marshal_VOID__VARIANT">
+    <function name="cclosure_marshal_VOID__VARIANT" c:identifier="g_cclosure_marshal_VOID__VARIANT" moved-to="CClosure.marshal_VOID__VARIANT">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with a single
 #GVariant argument.</doc>
       <return-value transfer-ownership="none">
@@ -11860,18 +10483,12 @@ unsigned long integer argument.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11879,9 +10496,7 @@ unsigned long integer argument.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_VOID__VOID"
-              c:identifier="g_cclosure_marshal_VOID__VOID"
-              moved-to="CClosure.marshal_VOID__VOID">
+    <function name="cclosure_marshal_VOID__VOID" c:identifier="g_cclosure_marshal_VOID__VOID" moved-to="CClosure.marshal_VOID__VOID">
       <doc xml:space="preserve">A #GClosureMarshal function for use with signals with no arguments.</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
@@ -11905,18 +10520,12 @@ unsigned long integer argument.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11924,10 +10533,7 @@ unsigned long integer argument.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_marshal_generic"
-              c:identifier="g_cclosure_marshal_generic"
-              moved-to="CClosure.marshal_generic"
-              version="2.30">
+    <function name="cclosure_marshal_generic" c:identifier="g_cclosure_marshal_generic" moved-to="CClosure.marshal_generic" version="2.30">
       <doc xml:space="preserve">A generic marshaller function implemented via
 [libffi](http://sourceware.org/libffi/).
 
@@ -11955,18 +10561,12 @@ but used automatically by GLib when specifying a %NULL marshaller.</doc>
   on which to invoke the callback of closure.</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="invocation_hint"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="invocation_hint" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The invocation hint given as the last argument to
   g_closure_invoke().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="marshal_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="marshal_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Additional data specified when registering the
   marshaller, see g_closure_set_marshal() and
   g_closure_set_meta_marshal()</doc>
@@ -11974,10 +10574,7 @@ but used automatically by GLib when specifying a %NULL marshaller.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_new"
-              c:identifier="g_cclosure_new"
-              moved-to="CClosure.new"
-              introspectable="0">
+    <function name="cclosure_new" c:identifier="g_cclosure_new" moved-to="CClosure.new" introspectable="0">
       <doc xml:space="preserve">Creates a new closure which invokes @callback_func with @user_data as
 the last parameter.</doc>
       <return-value transfer-ownership="full">
@@ -11985,19 +10582,11 @@ the last parameter.</doc>
         <type name="Closure" c:type="GClosure*"/>
       </return-value>
       <parameters>
-        <parameter name="callback_func"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1"
-                   closure="1">
+        <parameter name="callback_func" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
           <doc xml:space="preserve">the function to invoke</doc>
           <type name="Callback" c:type="GCallback"/>
         </parameter>
-        <parameter name="user_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1"
-                   closure="0">
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="0">
           <doc xml:space="preserve">user data to pass to @callback_func</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -12007,10 +10596,7 @@ the last parameter.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_new_object"
-              c:identifier="g_cclosure_new_object"
-              moved-to="CClosure.new_object"
-              introspectable="0">
+    <function name="cclosure_new_object" c:identifier="g_cclosure_new_object" moved-to="CClosure.new_object" introspectable="0">
       <doc xml:space="preserve">A variant of g_cclosure_new() which uses @object as @user_data and
 calls g_object_watch_closure() on @object and the created
 closure. This function is useful when you have a callback closely
@@ -12031,10 +10617,7 @@ after the object is is freed.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_new_object_swap"
-              c:identifier="g_cclosure_new_object_swap"
-              moved-to="CClosure.new_object_swap"
-              introspectable="0">
+    <function name="cclosure_new_object_swap" c:identifier="g_cclosure_new_object_swap" moved-to="CClosure.new_object_swap" introspectable="0">
       <doc xml:space="preserve">A variant of g_cclosure_new_swap() which uses @object as @user_data
 and calls g_object_watch_closure() on @object and the created
 closure. This function is useful when you have a callback closely
@@ -12055,10 +10638,7 @@ after the object is is freed.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="cclosure_new_swap"
-              c:identifier="g_cclosure_new_swap"
-              moved-to="CClosure.new_swap"
-              introspectable="0">
+    <function name="cclosure_new_swap" c:identifier="g_cclosure_new_swap" moved-to="CClosure.new_swap" introspectable="0">
       <doc xml:space="preserve">Creates a new closure which invokes @callback_func with @user_data as
 the first parameter.</doc>
       <return-value transfer-ownership="full">
@@ -12066,19 +10646,11 @@ the first parameter.</doc>
         <type name="Closure" c:type="GClosure*"/>
       </return-value>
       <parameters>
-        <parameter name="callback_func"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1"
-                   closure="1">
+        <parameter name="callback_func" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
           <doc xml:space="preserve">the function to invoke</doc>
           <type name="Callback" c:type="GCallback"/>
         </parameter>
-        <parameter name="user_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1"
-                   closure="0">
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="0">
           <doc xml:space="preserve">user data to pass to @callback_func</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -12088,10 +10660,7 @@ the first parameter.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="clear_object"
-              c:identifier="g_clear_object"
-              version="2.28"
-              introspectable="0">
+    <function name="clear_object" c:identifier="g_clear_object" version="2.28" introspectable="0">
       <doc xml:space="preserve">Clears a reference to a #GObject.
 
 @object_ptr must not be %NULL.
@@ -12112,8 +10681,7 @@ pointer casts.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="enum_complete_type_info"
-              c:identifier="g_enum_complete_type_info">
+    <function name="enum_complete_type_info" c:identifier="g_enum_complete_type_info">
       <doc xml:space="preserve">This function is meant to be called from the `complete_type_info`
 function of a #GTypePlugin implementation, as in the following
 example:
@@ -12142,10 +10710,7 @@ my_enum_complete_type_info (GTypePlugin     *plugin,
           <doc xml:space="preserve">the type identifier of the type being completed</doc>
           <type name="GType" c:type="GType"/>
         </parameter>
-        <parameter name="info"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="info" direction="out" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">the #GTypeInfo struct to be filled in</doc>
           <type name="TypeInfo" c:type="GTypeInfo*"/>
         </parameter>
@@ -12175,8 +10740,7 @@ my_enum_complete_type_info (GTypePlugin     *plugin,
         </parameter>
       </parameters>
     </function>
-    <function name="enum_get_value_by_name"
-              c:identifier="g_enum_get_value_by_name">
+    <function name="enum_get_value_by_name" c:identifier="g_enum_get_value_by_name">
       <doc xml:space="preserve">Looks up a #GEnumValue by name.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the #GEnumValue with name @name,
@@ -12195,8 +10759,7 @@ my_enum_complete_type_info (GTypePlugin     *plugin,
         </parameter>
       </parameters>
     </function>
-    <function name="enum_get_value_by_nick"
-              c:identifier="g_enum_get_value_by_nick">
+    <function name="enum_get_value_by_nick" c:identifier="g_enum_get_value_by_nick">
       <doc xml:space="preserve">Looks up a #GEnumValue by nickname.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the #GEnumValue with nickname @nick,
@@ -12215,8 +10778,7 @@ my_enum_complete_type_info (GTypePlugin     *plugin,
         </parameter>
       </parameters>
     </function>
-    <function name="enum_register_static"
-              c:identifier="g_enum_register_static">
+    <function name="enum_register_static" c:identifier="g_enum_register_static">
       <doc xml:space="preserve">Registers a new static enumeration type with the name @name.
 
 It is normally more convenient to let [glib-mkenums][glib-mkenums],
@@ -12240,10 +10802,8 @@ definition  than to write one yourself using g_enum_register_static().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="enum_to_string"
-              c:identifier="g_enum_to_string"
-              version="2.54">
-      <doc xml:space="preserve">Pretty-prints @value in the form of the enum’s name.
+    <function name="enum_to_string" c:identifier="g_enum_to_string" version="2.54">
+      <doc xml:space="preserve">Pretty-prints @value in the form of the enum&#x2019;s name.
 
 This is intended to be used for debugging purposes. The format of the output
 may change in the future.</doc>
@@ -12262,8 +10822,7 @@ may change in the future.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="flags_complete_type_info"
-              c:identifier="g_flags_complete_type_info">
+    <function name="flags_complete_type_info" c:identifier="g_flags_complete_type_info">
       <doc xml:space="preserve">This function is meant to be called from the complete_type_info()
 function of a #GTypePlugin implementation, see the example for
 g_enum_complete_type_info() above.</doc>
@@ -12275,10 +10834,7 @@ g_enum_complete_type_info() above.</doc>
           <doc xml:space="preserve">the type identifier of the type being completed</doc>
           <type name="GType" c:type="GType"/>
         </parameter>
-        <parameter name="info"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="info" direction="out" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">the #GTypeInfo struct to be filled in</doc>
           <type name="TypeInfo" c:type="GTypeInfo*"/>
         </parameter>
@@ -12290,8 +10846,7 @@ g_enum_complete_type_info() above.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="flags_get_first_value"
-              c:identifier="g_flags_get_first_value">
+    <function name="flags_get_first_value" c:identifier="g_flags_get_first_value">
       <doc xml:space="preserve">Returns the first #GFlagsValue which is set in @value.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the first #GFlagsValue which is set in
@@ -12309,8 +10864,7 @@ g_enum_complete_type_info() above.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="flags_get_value_by_name"
-              c:identifier="g_flags_get_value_by_name">
+    <function name="flags_get_value_by_name" c:identifier="g_flags_get_value_by_name">
       <doc xml:space="preserve">Looks up a #GFlagsValue by name.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the #GFlagsValue with name @name,
@@ -12328,8 +10882,7 @@ g_enum_complete_type_info() above.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="flags_get_value_by_nick"
-              c:identifier="g_flags_get_value_by_nick">
+    <function name="flags_get_value_by_nick" c:identifier="g_flags_get_value_by_nick">
       <doc xml:space="preserve">Looks up a #GFlagsValue by nickname.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the #GFlagsValue with nickname @nick,
@@ -12347,8 +10900,7 @@ g_enum_complete_type_info() above.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="flags_register_static"
-              c:identifier="g_flags_register_static">
+    <function name="flags_register_static" c:identifier="g_flags_register_static">
       <doc xml:space="preserve">Registers a new static flags type with the name @name.
 
 It is normally more convenient to let [glib-mkenums][glib-mkenums]
@@ -12371,9 +10923,7 @@ definition than to write one yourself using g_flags_register_static().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="flags_to_string"
-              c:identifier="g_flags_to_string"
-              version="2.54">
+    <function name="flags_to_string" c:identifier="g_flags_to_string" version="2.54">
       <doc xml:space="preserve">Pretty-prints @value in the form of the flag names separated by ` | ` and
 sorted. Any extra bits will be shown at the end as a hexadecimal number.
 
@@ -12654,9 +11204,7 @@ See g_param_spec_internal() for details on property names.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="param_spec_gtype"
-              c:identifier="g_param_spec_gtype"
-              version="2.10">
+    <function name="param_spec_gtype" c:identifier="g_param_spec_gtype" version="2.10">
       <doc xml:space="preserve">Creates a new #GParamSpecGType instance specifying a
 %G_TYPE_GTYPE property.
 
@@ -12838,10 +11386,7 @@ See g_param_spec_internal() for details on property names.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="param_spec_override"
-              c:identifier="g_param_spec_override"
-              version="2.4"
-              introspectable="0">
+    <function name="param_spec_override" c:identifier="g_param_spec_override" version="2.4" introspectable="0">
       <doc xml:space="preserve">Creates a new property of type #GParamSpecOverride. This is used
 to direct operations to another paramspec, and will not be directly
 useful unless you are implementing a new base type similar to GObject.</doc>
@@ -12921,9 +11466,7 @@ See g_param_spec_internal() for details on property names.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="param_spec_pool_new"
-              c:identifier="g_param_spec_pool_new"
-              moved-to="ParamSpecPool.new">
+    <function name="param_spec_pool_new" c:identifier="g_param_spec_pool_new" moved-to="ParamSpecPool.new">
       <doc xml:space="preserve">Creates a new #GParamSpecPool.
 
 If @type_prefixing is %TRUE, lookups in the newly created pool will
@@ -12962,10 +11505,7 @@ See g_param_spec_internal() for details on property names.</doc>
           <doc xml:space="preserve">description of the property specified</doc>
           <type name="utf8" c:type="const gchar*"/>
         </parameter>
-        <parameter name="default_value"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="default_value" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">default value for the property specified</doc>
           <type name="utf8" c:type="const gchar*"/>
         </parameter>
@@ -13164,9 +11704,7 @@ See g_param_spec_internal() for details on property names.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="param_spec_value_array"
-              c:identifier="g_param_spec_value_array"
-              introspectable="0">
+    <function name="param_spec_value_array" c:identifier="g_param_spec_value_array" introspectable="0">
       <doc xml:space="preserve">Creates a new #GParamSpecValueArray instance specifying a
 %G_TYPE_VALUE_ARRAY property. %G_TYPE_VALUE_ARRAY is a
 %G_TYPE_BOXED type, as such, #GValue structures for this property
@@ -13201,9 +11739,7 @@ See g_param_spec_internal() for details on property names.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="param_spec_variant"
-              c:identifier="g_param_spec_variant"
-              version="2.26">
+    <function name="param_spec_variant" c:identifier="g_param_spec_variant" version="2.26">
       <doc xml:space="preserve">Creates a new #GParamSpecVariant instance specifying a #GVariant
 property.
 
@@ -13231,10 +11767,7 @@ See g_param_spec_internal() for details on property names.</doc>
           <doc xml:space="preserve">a #GVariantType</doc>
           <type name="GLib.VariantType" c:type="const GVariantType*"/>
         </parameter>
-        <parameter name="default_value"
-                   transfer-ownership="full"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="default_value" transfer-ownership="full" nullable="1" allow-none="1">
           <doc xml:space="preserve">a #GVariant of type @type to
                 use as the default value, or %NULL</doc>
           <type name="GLib.Variant" c:type="GVariant*"/>
@@ -13245,8 +11778,7 @@ See g_param_spec_internal() for details on property names.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="param_type_register_static"
-              c:identifier="g_param_type_register_static">
+    <function name="param_type_register_static" c:identifier="g_param_type_register_static">
       <doc xml:space="preserve">Registers @name as the name of a new static type derived from
 #G_TYPE_PARAM. The type system uses the information contained in
 the #GParamSpecTypeInfo structure pointed to by @info to manage the
@@ -13299,8 +11831,7 @@ without modifications</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="param_value_defaults"
-              c:identifier="g_param_value_defaults">
+    <function name="param_value_defaults" c:identifier="g_param_value_defaults">
       <doc xml:space="preserve">Checks whether @value contains the default value as specified in @pspec.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">whether @value contains the canonical default for this @pspec</doc>
@@ -13317,8 +11848,7 @@ without modifications</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="param_value_set_default"
-              c:identifier="g_param_value_set_default">
+    <function name="param_value_set_default" c:identifier="g_param_value_set_default">
       <doc xml:space="preserve">Sets @value to its default value as specified in @pspec.</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
@@ -13334,8 +11864,7 @@ without modifications</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="param_value_validate"
-              c:identifier="g_param_value_validate">
+    <function name="param_value_validate" c:identifier="g_param_value_validate">
       <doc xml:space="preserve">Ensures that the contents of @value comply with the specifications
 set out by @pspec. For example, a #GParamSpecInt might require
 that integers stored in @value may not be smaller than -42 and not be
@@ -13380,8 +11909,7 @@ respectively.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="pointer_type_register_static"
-              c:identifier="g_pointer_type_register_static">
+    <function name="pointer_type_register_static" c:identifier="g_pointer_type_register_static">
       <doc xml:space="preserve">Creates a new %G_TYPE_POINTER derived type id for a new
 pointer type with name @name.</doc>
       <return-value transfer-ownership="none">
@@ -13395,9 +11923,7 @@ pointer type with name @name.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_accumulator_first_wins"
-              c:identifier="g_signal_accumulator_first_wins"
-              version="2.28">
+    <function name="signal_accumulator_first_wins" c:identifier="g_signal_accumulator_first_wins" version="2.28">
       <doc xml:space="preserve">A predefined #GSignalAccumulator for signals intended to be used as a
 hook for application code to provide a particular value.  Usually
 only one such value is desired and multiple handlers for the same
@@ -13425,18 +11951,13 @@ any further handlers (ie: the first handler "wins").</doc>
           <doc xml:space="preserve">standard #GSignalAccumulator parameter</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="dummy"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="dummy" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">standard #GSignalAccumulator parameter</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_accumulator_true_handled"
-              c:identifier="g_signal_accumulator_true_handled"
-              version="2.4">
+    <function name="signal_accumulator_true_handled" c:identifier="g_signal_accumulator_true_handled" version="2.4">
       <doc xml:space="preserve">A predefined #GSignalAccumulator for signals that return a
 boolean values. The behavior that this accumulator gives is
 that a return of %TRUE stops the signal emission: no further
@@ -13461,17 +11982,13 @@ handling is needed.</doc>
           <doc xml:space="preserve">standard #GSignalAccumulator parameter</doc>
           <type name="Value" c:type="const GValue*"/>
         </parameter>
-        <parameter name="dummy"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="dummy" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">standard #GSignalAccumulator parameter</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_add_emission_hook"
-              c:identifier="g_signal_add_emission_hook">
+    <function name="signal_add_emission_hook" c:identifier="g_signal_add_emission_hook">
       <doc xml:space="preserve">Adds an emission hook for a signal, which will get called for any emission
 of that signal, independent of the instance. This is possible only
 for signals which don't have #G_SIGNAL_NO_HOOKS flag set.</doc>
@@ -13488,18 +12005,11 @@ for signals which don't have #G_SIGNAL_NO_HOOKS flag set.</doc>
           <doc xml:space="preserve">the detail on which to call the hook.</doc>
           <type name="GLib.Quark" c:type="GQuark"/>
         </parameter>
-        <parameter name="hook_func"
-                   transfer-ownership="none"
-                   scope="notified"
-                   closure="3"
-                   destroy="4">
+        <parameter name="hook_func" transfer-ownership="none" scope="notified" closure="3" destroy="4">
           <doc xml:space="preserve">a #GSignalEmissionHook function.</doc>
           <type name="SignalEmissionHook" c:type="GSignalEmissionHook"/>
         </parameter>
-        <parameter name="hook_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="hook_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">user data for @hook_func.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -13509,8 +12019,7 @@ for signals which don't have #G_SIGNAL_NO_HOOKS flag set.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_chain_from_overridden"
-              c:identifier="g_signal_chain_from_overridden">
+    <function name="signal_chain_from_overridden" c:identifier="g_signal_chain_from_overridden">
       <doc xml:space="preserve">Calls the original class closure of a signal. This function should only
 be called from an overridden class closure; see
 g_signal_override_class_closure() and
@@ -13533,10 +12042,7 @@ g_signal_override_class_handler().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_chain_from_overridden_handler"
-              c:identifier="g_signal_chain_from_overridden_handler"
-              version="2.18"
-              introspectable="0">
+    <function name="signal_chain_from_overridden_handler" c:identifier="g_signal_chain_from_overridden_handler" version="2.18" introspectable="0">
       <doc xml:space="preserve">Calls the original class closure of a signal. This function should
 only be called from an overridden class closure; see
 g_signal_override_class_closure() and
@@ -13558,8 +12064,7 @@ g_signal_override_class_handler().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_connect_closure"
-              c:identifier="g_signal_connect_closure">
+    <function name="signal_connect_closure" c:identifier="g_signal_connect_closure">
       <doc xml:space="preserve">Connects a closure to a signal for a particular object.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the handler ID (always greater than 0 for successful connections)</doc>
@@ -13585,8 +12090,7 @@ g_signal_override_class_handler().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_connect_closure_by_id"
-              c:identifier="g_signal_connect_closure_by_id">
+    <function name="signal_connect_closure_by_id" c:identifier="g_signal_connect_closure_by_id">
       <doc xml:space="preserve">Connects a closure to a signal for a particular object.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the handler ID (always greater than 0 for successful connections)</doc>
@@ -13616,9 +12120,7 @@ g_signal_override_class_handler().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_connect_data"
-              c:identifier="g_signal_connect_data"
-              introspectable="0">
+    <function name="signal_connect_data" c:identifier="g_signal_connect_data" introspectable="0">
       <doc xml:space="preserve">Connects a #GCallback function to a signal for a particular object. Similar
 to g_signal_connect(), but allows to provide a #GClosureNotify for the data
 which will be called when the signal handler is disconnected and no longer
@@ -13641,10 +12143,7 @@ used. Specify @connect_flags if you need `..._after()` or
           <doc xml:space="preserve">the #GCallback to connect.</doc>
           <type name="Callback" c:type="GCallback"/>
         </parameter>
-        <parameter name="data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">data to pass to @c_handler calls.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -13658,9 +12157,7 @@ used. Specify @connect_flags if you need `..._after()` or
         </parameter>
       </parameters>
     </function>
-    <function name="signal_connect_object"
-              c:identifier="g_signal_connect_object"
-              introspectable="0">
+    <function name="signal_connect_object" c:identifier="g_signal_connect_object" introspectable="0">
       <doc xml:space="preserve">This is similar to g_signal_connect_data(), but uses a closure which
 ensures that the @gobject stays alive during the call to @c_handler
 by temporarily adding a reference count to @gobject.
@@ -13686,10 +12183,7 @@ is not safe).</doc>
           <doc xml:space="preserve">the #GCallback to connect.</doc>
           <type name="Callback" c:type="GCallback"/>
         </parameter>
-        <parameter name="gobject"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="gobject" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">the object to pass as data
    to @c_handler.</doc>
           <type name="Object" c:type="gpointer"/>
@@ -13700,9 +12194,7 @@ is not safe).</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_emit"
-              c:identifier="g_signal_emit"
-              introspectable="0">
+    <function name="signal_emit" c:identifier="g_signal_emit" introspectable="0">
       <doc xml:space="preserve">Emits a signal.
 
 Note that g_signal_emit() resets the return value to the default
@@ -13731,9 +12223,7 @@ if no handlers are connected, in contrast to g_signal_emitv().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_emit_by_name"
-              c:identifier="g_signal_emit_by_name"
-              introspectable="0">
+    <function name="signal_emit_by_name" c:identifier="g_signal_emit_by_name" introspectable="0">
       <doc xml:space="preserve">Emits a signal.
 
 Note that g_signal_emit_by_name() resets the return value to the default
@@ -13758,9 +12248,7 @@ if no handlers are connected, in contrast to g_signal_emitv().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_emit_valist"
-              c:identifier="g_signal_emit_valist"
-              introspectable="0">
+    <function name="signal_emit_valist" c:identifier="g_signal_emit_valist" introspectable="0">
       <doc xml:space="preserve">Emits a signal.
 
 Note that g_signal_emit_valist() resets the return value to the default
@@ -13815,10 +12303,7 @@ connected, in contrast to g_signal_emit() and g_signal_emit_valist().</doc>
           <doc xml:space="preserve">the detail</doc>
           <type name="GLib.Quark" c:type="GQuark"/>
         </parameter>
-        <parameter name="return_value"
-                   direction="inout"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="return_value" direction="inout" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">Location to
 store the return value of the signal emission. This must be provided if the
 specified signal returns a value, but may be ignored otherwise.</doc>
@@ -13826,8 +12311,7 @@ specified signal returns a value, but may be ignored otherwise.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_get_invocation_hint"
-              c:identifier="g_signal_get_invocation_hint">
+    <function name="signal_get_invocation_hint" c:identifier="g_signal_get_invocation_hint">
       <doc xml:space="preserve">Returns the invocation hint of the innermost signal emission of instance.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the invocation hint of the innermost signal  emission.</doc>
@@ -13840,8 +12324,7 @@ specified signal returns a value, but may be ignored otherwise.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_handler_block"
-              c:identifier="g_signal_handler_block">
+    <function name="signal_handler_block" c:identifier="g_signal_handler_block">
       <doc xml:space="preserve">Blocks a handler of an instance so it will not be called during any
 signal emissions unless it is unblocked again. Thus "blocking" a
 signal handler means to temporarily deactive it, a signal handler
@@ -13864,8 +12347,7 @@ signal of @instance.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_handler_disconnect"
-              c:identifier="g_signal_handler_disconnect">
+    <function name="signal_handler_disconnect" c:identifier="g_signal_handler_disconnect">
       <doc xml:space="preserve">Disconnects a handler from an instance so it will not be called during
 any future or currently ongoing emissions of the signal it has been
 connected to. The @handler_id becomes invalid and may be reused.
@@ -13914,31 +12396,21 @@ If no handler was found, 0 is returned.</doc>
           <doc xml:space="preserve">Signal detail the handler has to be connected to.</doc>
           <type name="GLib.Quark" c:type="GQuark"/>
         </parameter>
-        <parameter name="closure"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="closure" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The closure the handler will invoke.</doc>
           <type name="Closure" c:type="GClosure*"/>
         </parameter>
-        <parameter name="func"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="func" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The C closure callback of the handler (useless for non-C closures).</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The closure data of the handler's closure.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_handler_is_connected"
-              c:identifier="g_signal_handler_is_connected">
+    <function name="signal_handler_is_connected" c:identifier="g_signal_handler_is_connected">
       <doc xml:space="preserve">Returns whether @handler_id is the ID of a handler connected to @instance.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">whether @handler_id identifies a handler connected to @instance.</doc>
@@ -13955,8 +12427,7 @@ If no handler was found, 0 is returned.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_handler_unblock"
-              c:identifier="g_signal_handler_unblock">
+    <function name="signal_handler_unblock" c:identifier="g_signal_handler_unblock">
       <doc xml:space="preserve">Undoes the effect of a previous g_signal_handler_block() call.  A
 blocked handler is skipped during signal emissions and will not be
 invoked, unblocking it (for exactly the amount of times it has been
@@ -13984,8 +12455,7 @@ connected to a signal of @instance and is currently blocked.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_handlers_block_matched"
-              c:identifier="g_signal_handlers_block_matched">
+    <function name="signal_handlers_block_matched" c:identifier="g_signal_handlers_block_matched">
       <doc xml:space="preserve">Blocks all handlers on an instance that match a certain selection criteria.
 The criteria mask is passed as an OR-ed combination of #GSignalMatchType
 flags, and the criteria values are passed as arguments.
@@ -14015,31 +12485,21 @@ otherwise.</doc>
           <doc xml:space="preserve">Signal detail the handlers have to be connected to.</doc>
           <type name="GLib.Quark" c:type="GQuark"/>
         </parameter>
-        <parameter name="closure"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="closure" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The closure the handlers will invoke.</doc>
           <type name="Closure" c:type="GClosure*"/>
         </parameter>
-        <parameter name="func"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="func" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The C closure callback of the handlers (useless for non-C closures).</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The closure data of the handlers' closures.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_handlers_destroy"
-              c:identifier="g_signal_handlers_destroy">
+    <function name="signal_handlers_destroy" c:identifier="g_signal_handlers_destroy">
       <doc xml:space="preserve">Destroy all signal handlers of a type instance. This function is
 an implementation detail of the #GObject dispose implementation,
 and should not be used outside of the type system.</doc>
@@ -14053,8 +12513,7 @@ and should not be used outside of the type system.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_handlers_disconnect_matched"
-              c:identifier="g_signal_handlers_disconnect_matched">
+    <function name="signal_handlers_disconnect_matched" c:identifier="g_signal_handlers_disconnect_matched">
       <doc xml:space="preserve">Disconnects all handlers on an instance that match a certain
 selection criteria. The criteria mask is passed as an OR-ed
 combination of #GSignalMatchType flags, and the criteria values are
@@ -14085,31 +12544,21 @@ disconnected handlers otherwise.</doc>
           <doc xml:space="preserve">Signal detail the handlers have to be connected to.</doc>
           <type name="GLib.Quark" c:type="GQuark"/>
         </parameter>
-        <parameter name="closure"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="closure" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The closure the handlers will invoke.</doc>
           <type name="Closure" c:type="GClosure*"/>
         </parameter>
-        <parameter name="func"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="func" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The C closure callback of the handlers (useless for non-C closures).</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The closure data of the handlers' closures.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_handlers_unblock_matched"
-              c:identifier="g_signal_handlers_unblock_matched">
+    <function name="signal_handlers_unblock_matched" c:identifier="g_signal_handlers_unblock_matched">
       <doc xml:space="preserve">Unblocks all handlers on an instance that match a certain selection
 criteria. The criteria mask is passed as an OR-ed combination of
 #GSignalMatchType flags, and the criteria values are passed as arguments.
@@ -14140,31 +12589,21 @@ not currently blocked.</doc>
           <doc xml:space="preserve">Signal detail the handlers have to be connected to.</doc>
           <type name="GLib.Quark" c:type="GQuark"/>
         </parameter>
-        <parameter name="closure"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="closure" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The closure the handlers will invoke.</doc>
           <type name="Closure" c:type="GClosure*"/>
         </parameter>
-        <parameter name="func"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="func" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The C closure callback of the handlers (useless for non-C closures).</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The closure data of the handlers' closures.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_has_handler_pending"
-              c:identifier="g_signal_has_handler_pending">
+    <function name="signal_has_handler_pending" c:identifier="g_signal_has_handler_pending">
       <doc xml:space="preserve">Returns whether there are any handlers connected to @instance for the
 given signal id and detail.
 
@@ -14220,10 +12659,7 @@ g_signal_query().</doc>
           <doc xml:space="preserve">Instance or interface type.</doc>
           <type name="GType" c:type="GType"/>
         </parameter>
-        <parameter name="n_ids"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="n_ids" direction="out" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">Location to store the number of signal ids for @itype.</doc>
           <type name="guint" c:type="guint*"/>
         </parameter>
@@ -14314,17 +12750,11 @@ the marshaller for this signal.</doc>
           <doc xml:space="preserve">the accumulator for this signal; may be %NULL.</doc>
           <type name="SignalAccumulator" c:type="GSignalAccumulator"/>
         </parameter>
-        <parameter name="accu_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="accu_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">user data for the @accumulator.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="c_marshaller"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="c_marshaller" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">the function to translate arrays of parameter
  values to signal emissions into C language callback invocations or %NULL.</doc>
           <type name="SignalCMarshaller" c:type="GSignalCMarshaller"/>
@@ -14344,10 +12774,7 @@ the marshaller for this signal.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_new_class_handler"
-              c:identifier="g_signal_new_class_handler"
-              version="2.18"
-              introspectable="0">
+    <function name="signal_new_class_handler" c:identifier="g_signal_new_class_handler" version="2.18" introspectable="0">
       <doc xml:space="preserve">Creates a new signal. (This is usually done in the class initializer.)
 
 This is a variant of g_signal_new() that takes a C callback instead
@@ -14394,17 +12821,11 @@ the marshaller for this signal.</doc>
           <doc xml:space="preserve">the accumulator for this signal; may be %NULL.</doc>
           <type name="SignalAccumulator" c:type="GSignalAccumulator"/>
         </parameter>
-        <parameter name="accu_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="accu_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">user data for the @accumulator.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="c_marshaller"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="c_marshaller" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">the function to translate arrays of parameter
  values to signal emissions into C language callback invocations or %NULL.</doc>
           <type name="SignalCMarshaller" c:type="GSignalCMarshaller"/>
@@ -14424,9 +12845,7 @@ the marshaller for this signal.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_new_valist"
-              c:identifier="g_signal_new_valist"
-              introspectable="0">
+    <function name="signal_new_valist" c:identifier="g_signal_new_valist" introspectable="0">
       <doc xml:space="preserve">Creates a new signal. (This is usually done in the class initializer.)
 
 See g_signal_new() for details on allowed signal names.
@@ -14461,17 +12880,11 @@ the marshaller for this signal.</doc>
           <doc xml:space="preserve">the accumulator for this signal; may be %NULL.</doc>
           <type name="SignalAccumulator" c:type="GSignalAccumulator"/>
         </parameter>
-        <parameter name="accu_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="accu_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">user data for the @accumulator.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="c_marshaller"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="c_marshaller" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">the function to translate arrays of parameter
  values to signal emissions into C language callback invocations or %NULL.</doc>
           <type name="SignalCMarshaller" c:type="GSignalCMarshaller"/>
@@ -14491,9 +12904,7 @@ the marshaller for this signal.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_newv"
-              c:identifier="g_signal_newv"
-              introspectable="0">
+    <function name="signal_newv" c:identifier="g_signal_newv" introspectable="0">
       <doc xml:space="preserve">Creates a new signal. (This is usually done in the class initializer.)
 
 See g_signal_new() for details on allowed signal names.
@@ -14520,33 +12931,20 @@ the marshaller for this signal.</doc>
     %G_SIGNAL_RUN_FIRST or %G_SIGNAL_RUN_LAST</doc>
           <type name="SignalFlags" c:type="GSignalFlags"/>
         </parameter>
-        <parameter name="class_closure"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="class_closure" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">The closure to invoke on signal emission;
     may be %NULL</doc>
           <type name="Closure" c:type="GClosure*"/>
         </parameter>
-        <parameter name="accumulator"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1"
-                   closure="5">
+        <parameter name="accumulator" transfer-ownership="none" nullable="1" allow-none="1" closure="5">
           <doc xml:space="preserve">the accumulator for this signal; may be %NULL</doc>
           <type name="SignalAccumulator" c:type="GSignalAccumulator"/>
         </parameter>
-        <parameter name="accu_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="accu_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">user data for the @accumulator</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
-        <parameter name="c_marshaller"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="c_marshaller" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">the function to translate arrays of
     parameter values to signal emissions into C language callback
     invocations or %NULL</doc>
@@ -14570,8 +12968,7 @@ the marshaller for this signal.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_override_class_closure"
-              c:identifier="g_signal_override_class_closure">
+    <function name="signal_override_class_closure" c:identifier="g_signal_override_class_closure">
       <doc xml:space="preserve">Overrides the class closure (i.e. the default handler) for the given signal
 for emissions on instances of @instance_type. @instance_type must be derived
 from the type to which the signal belongs.
@@ -14598,10 +12995,7 @@ parent class closure from inside the overridden one.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_override_class_handler"
-              c:identifier="g_signal_override_class_handler"
-              version="2.18"
-              introspectable="0">
+    <function name="signal_override_class_handler" c:identifier="g_signal_override_class_handler" version="2.18" introspectable="0">
       <doc xml:space="preserve">Overrides the class closure (i.e. the default handler) for the
 given signal for emissions on instances of @instance_type with
 callback @class_handler. @instance_type must be derived from the
@@ -14645,17 +13039,11 @@ and @detail quark.</doc>
           <doc xml:space="preserve">The interface/instance type that introduced "signal-name".</doc>
           <type name="GType" c:type="GType"/>
         </parameter>
-        <parameter name="signal_id_p"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="signal_id_p" direction="out" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">Location to store the signal id.</doc>
           <type name="guint" c:type="guint*"/>
         </parameter>
-        <parameter name="detail_p"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="detail_p" direction="out" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">Location to store the detail quark.</doc>
           <type name="GLib.Quark" c:type="GQuark*"/>
         </parameter>
@@ -14680,18 +13068,14 @@ be considered constant and have to be left untouched.</doc>
           <doc xml:space="preserve">The signal id of the signal to query information for.</doc>
           <type name="guint" c:type="guint"/>
         </parameter>
-        <parameter name="query"
-                   direction="out"
-                   caller-allocates="1"
-                   transfer-ownership="none">
+        <parameter name="query" direction="out" caller-allocates="1" transfer-ownership="none">
           <doc xml:space="preserve">A user provided structure that is
  filled in with constant values upon success.</doc>
           <type name="SignalQuery" c:type="GSignalQuery*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_remove_emission_hook"
-              c:identifier="g_signal_remove_emission_hook">
+    <function name="signal_remove_emission_hook" c:identifier="g_signal_remove_emission_hook">
       <doc xml:space="preserve">Deletes an emission hook.</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
@@ -14708,9 +13092,7 @@ be considered constant and have to be left untouched.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_set_va_marshaller"
-              c:identifier="g_signal_set_va_marshaller"
-              version="2.32">
+    <function name="signal_set_va_marshaller" c:identifier="g_signal_set_va_marshaller" version="2.32">
       <doc xml:space="preserve">Change the #GSignalCVaMarshaller used for a given signal.  This is a
 specialised form of the marshaller that can often be used for the
 common case of a single connected signal handler and avoids the
@@ -14733,8 +13115,7 @@ overhead of #GValue.  Its use is optional.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_stop_emission"
-              c:identifier="g_signal_stop_emission">
+    <function name="signal_stop_emission" c:identifier="g_signal_stop_emission">
       <doc xml:space="preserve">Stops a signal's current emission.
 
 This will prevent the default method from running, if the signal was
@@ -14760,8 +13141,7 @@ Prints a warning if used on a signal which isn't being emitted.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_stop_emission_by_name"
-              c:identifier="g_signal_stop_emission_by_name">
+    <function name="signal_stop_emission_by_name" c:identifier="g_signal_stop_emission_by_name">
       <doc xml:space="preserve">Stops a signal's current emission.
 
 This is just like g_signal_stop_emission() except it will look up the
@@ -14780,8 +13160,7 @@ signal id for you.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="signal_type_cclosure_new"
-              c:identifier="g_signal_type_cclosure_new">
+    <function name="signal_type_cclosure_new" c:identifier="g_signal_type_cclosure_new">
       <doc xml:space="preserve">Creates a new closure which invokes the function found at the offset
 @struct_offset in the class structure of the interface or classed type
 identified by @itype.</doc>
@@ -14821,8 +13200,7 @@ filled in with pointers to appropriate functions.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="source_set_dummy_callback"
-              c:identifier="g_source_set_dummy_callback">
+    <function name="source_set_dummy_callback" c:identifier="g_source_set_dummy_callback">
       <doc xml:space="preserve">Sets a dummy callback for @source. The callback will do nothing, and
 if the source expects a #gboolean return value, it will return %TRUE.
 (If the source expects any other type of return value, it will return
@@ -14843,8 +13221,7 @@ functions.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="strdup_value_contents"
-              c:identifier="g_strdup_value_contents">
+    <function name="strdup_value_contents" c:identifier="g_strdup_value_contents">
       <doc xml:space="preserve">Return a newly allocated string, which describes the contents of a
 #GValue.  The main purpose of this function is to describe #GValue
 contents for debugging output, the way in which the contents are
@@ -14860,9 +13237,7 @@ described may change between different GLib versions.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_add_class_cache_func"
-              c:identifier="g_type_add_class_cache_func"
-              introspectable="0">
+    <function name="type_add_class_cache_func" c:identifier="g_type_add_class_cache_func" introspectable="0">
       <doc xml:space="preserve">Adds a #GTypeClassCacheFunc to be called before the reference count of a
 class goes from one to zero. This can be used to prevent premature class
 destruction. All installed #GTypeClassCacheFunc functions will be chained
@@ -14874,10 +13249,7 @@ chain.</doc>
         <type name="none" c:type="void"/>
       </return-value>
       <parameters>
-        <parameter name="cache_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="cache_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">data to be passed to @cache_func</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -14887,9 +13259,7 @@ chain.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_add_class_private"
-              c:identifier="g_type_add_class_private"
-              version="2.24">
+    <function name="type_add_class_private" c:identifier="g_type_add_class_private" version="2.24">
       <doc xml:space="preserve">Registers a private class structure for a classed type;
 when the class is allocated, the private structures for
 the class and all of its parent types are allocated
@@ -14914,8 +13284,7 @@ G_TYPE_CLASS_GET_PRIVATE() macro.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_add_instance_private"
-              c:identifier="g_type_add_instance_private">
+    <function name="type_add_instance_private" c:identifier="g_type_add_instance_private">
       <return-value transfer-ownership="none">
         <type name="gint" c:type="gint"/>
       </return-value>
@@ -14928,10 +13297,7 @@ G_TYPE_CLASS_GET_PRIVATE() macro.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_add_interface_check"
-              c:identifier="g_type_add_interface_check"
-              version="2.4"
-              introspectable="0">
+    <function name="type_add_interface_check" c:identifier="g_type_add_interface_check" version="2.4" introspectable="0">
       <doc xml:space="preserve">Adds a function to be called after an interface vtable is
 initialized for any class (i.e. after the @interface_init
 member of #GInterfaceInfo has been called).
@@ -14945,23 +13311,18 @@ interfaces.</doc>
         <type name="none" c:type="void"/>
       </return-value>
       <parameters>
-        <parameter name="check_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="check_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">data to pass to @check_func</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
         <parameter name="check_func" transfer-ownership="none">
           <doc xml:space="preserve">function to be called after each interface
     is initialized</doc>
-          <type name="TypeInterfaceCheckFunc"
-                c:type="GTypeInterfaceCheckFunc"/>
+          <type name="TypeInterfaceCheckFunc" c:type="GTypeInterfaceCheckFunc"/>
         </parameter>
       </parameters>
     </function>
-    <function name="type_add_interface_dynamic"
-              c:identifier="g_type_add_interface_dynamic">
+    <function name="type_add_interface_dynamic" c:identifier="g_type_add_interface_dynamic">
       <doc xml:space="preserve">Adds the dynamic @interface_type to @instantiable_type. The information
 contained in the #GTypePlugin structure pointed to by @plugin
 is used to manage the relationship.</doc>
@@ -14983,8 +13344,7 @@ is used to manage the relationship.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_add_interface_static"
-              c:identifier="g_type_add_interface_static">
+    <function name="type_add_interface_static" c:identifier="g_type_add_interface_static">
       <doc xml:space="preserve">Adds the static @interface_type to @instantiable_type.
 The information contained in the #GInterfaceInfo structure
 pointed to by @info is used to manage the relationship.</doc>
@@ -15007,9 +13367,7 @@ pointed to by @info is used to manage the relationship.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_check_class_cast"
-              c:identifier="g_type_check_class_cast"
-              introspectable="0">
+    <function name="type_check_class_cast" c:identifier="g_type_check_class_cast" introspectable="0">
       <return-value>
         <type name="TypeClass" c:type="GTypeClass*"/>
       </return-value>
@@ -15022,8 +13380,7 @@ pointed to by @info is used to manage the relationship.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_check_class_is_a"
-              c:identifier="g_type_check_class_is_a">
+    <function name="type_check_class_is_a" c:identifier="g_type_check_class_is_a">
       <return-value transfer-ownership="none">
         <type name="gboolean" c:type="gboolean"/>
       </return-value>
@@ -15050,9 +13407,7 @@ G_TYPE_CHECK_INSTANCE() macro.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_check_instance_cast"
-              c:identifier="g_type_check_instance_cast"
-              introspectable="0">
+    <function name="type_check_instance_cast" c:identifier="g_type_check_instance_cast" introspectable="0">
       <return-value>
         <type name="TypeInstance" c:type="GTypeInstance*"/>
       </return-value>
@@ -15065,8 +13420,7 @@ G_TYPE_CHECK_INSTANCE() macro.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_check_instance_is_a"
-              c:identifier="g_type_check_instance_is_a">
+    <function name="type_check_instance_is_a" c:identifier="g_type_check_instance_is_a">
       <return-value transfer-ownership="none">
         <type name="gboolean" c:type="gboolean"/>
       </return-value>
@@ -15079,8 +13433,7 @@ G_TYPE_CHECK_INSTANCE() macro.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_check_instance_is_fundamentally_a"
-              c:identifier="g_type_check_instance_is_fundamentally_a">
+    <function name="type_check_instance_is_fundamentally_a" c:identifier="g_type_check_instance_is_fundamentally_a">
       <return-value transfer-ownership="none">
         <type name="gboolean" c:type="gboolean"/>
       </return-value>
@@ -15093,8 +13446,7 @@ G_TYPE_CHECK_INSTANCE() macro.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_check_is_value_type"
-              c:identifier="g_type_check_is_value_type">
+    <function name="type_check_is_value_type" c:identifier="g_type_check_is_value_type">
       <return-value transfer-ownership="none">
         <type name="gboolean" c:type="gboolean"/>
       </return-value>
@@ -15114,8 +13466,7 @@ G_TYPE_CHECK_INSTANCE() macro.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_check_value_holds"
-              c:identifier="g_type_check_value_holds">
+    <function name="type_check_value_holds" c:identifier="g_type_check_value_holds">
       <return-value transfer-ownership="none">
         <type name="gboolean" c:type="gboolean"/>
       </return-value>
@@ -15143,29 +13494,19 @@ the child types of @type.</doc>
           <doc xml:space="preserve">the parent type</doc>
           <type name="GType" c:type="GType"/>
         </parameter>
-        <parameter name="n_children"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full"
-                   optional="1"
-                   allow-none="1">
+        <parameter name="n_children" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
           <doc xml:space="preserve">location to store the length of
     the returned array, or %NULL</doc>
           <type name="guint" c:type="guint*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="type_class_adjust_private_offset"
-              c:identifier="g_type_class_adjust_private_offset"
-              moved-to="TypeClass.adjust_private_offset">
+    <function name="type_class_adjust_private_offset" c:identifier="g_type_class_adjust_private_offset" moved-to="TypeClass.adjust_private_offset">
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
       </return-value>
       <parameters>
-        <parameter name="g_class"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="g_class" transfer-ownership="none" nullable="1" allow-none="1">
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
         <parameter name="private_size_or_offset" transfer-ownership="none">
@@ -15173,9 +13514,7 @@ the child types of @type.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_class_peek"
-              c:identifier="g_type_class_peek"
-              moved-to="TypeClass.peek">
+    <function name="type_class_peek" c:identifier="g_type_class_peek" moved-to="TypeClass.peek">
       <doc xml:space="preserve">This function is essentially the same as g_type_class_ref(),
 except that the classes reference count isn't incremented.
 As a consequence, this function may return %NULL if the class
@@ -15194,10 +13533,7 @@ referenced before).</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_class_peek_static"
-              c:identifier="g_type_class_peek_static"
-              moved-to="TypeClass.peek_static"
-              version="2.4">
+    <function name="type_class_peek_static" c:identifier="g_type_class_peek_static" moved-to="TypeClass.peek_static" version="2.4">
       <doc xml:space="preserve">A more efficient version of g_type_class_peek() which works only for
 static types.</doc>
       <return-value transfer-ownership="none">
@@ -15213,9 +13549,7 @@ static types.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_class_ref"
-              c:identifier="g_type_class_ref"
-              moved-to="TypeClass.ref">
+    <function name="type_class_ref" c:identifier="g_type_class_ref" moved-to="TypeClass.ref">
       <doc xml:space="preserve">Increments the reference count of the class structure belonging to
 @type. This function will demand-create the class if it doesn't
 exist already.</doc>
@@ -15231,9 +13565,7 @@ exist already.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_create_instance"
-              c:identifier="g_type_create_instance"
-              introspectable="0">
+    <function name="type_create_instance" c:identifier="g_type_create_instance" introspectable="0">
       <doc xml:space="preserve">Creates and initializes an instance of @type if @type is valid and
 can be instantiated. The type system only performs basic allocation
 and structure setups for instances: actual instance creation should
@@ -15262,9 +13594,7 @@ function, but g_object_new() instead.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_default_interface_peek"
-              c:identifier="g_type_default_interface_peek"
-              version="2.4">
+    <function name="type_default_interface_peek" c:identifier="g_type_default_interface_peek" version="2.4">
       <doc xml:space="preserve">If the interface type @g_type is currently in use, returns its
 default interface vtable.</doc>
       <return-value transfer-ownership="none">
@@ -15280,9 +13610,7 @@ default interface vtable.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_default_interface_ref"
-              c:identifier="g_type_default_interface_ref"
-              version="2.4">
+    <function name="type_default_interface_ref" c:identifier="g_type_default_interface_ref" version="2.4">
       <doc xml:space="preserve">Increments the reference count for the interface type @g_type,
 and returns the default interface vtable for the type.
 
@@ -15306,9 +13634,7 @@ have been installed.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_default_interface_unref"
-              c:identifier="g_type_default_interface_unref"
-              version="2.4">
+    <function name="type_default_interface_unref" c:identifier="g_type_default_interface_unref" version="2.4">
       <doc xml:space="preserve">Decrements the reference count for the type corresponding to the
 interface default vtable @g_iface. If the type is dynamic, then
 when no one is using the interface and all references have
@@ -15408,8 +13734,7 @@ Use G_TYPE_FUNDAMENTAL() instead.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_fundamental_next"
-              c:identifier="g_type_fundamental_next">
+    <function name="type_fundamental_next" c:identifier="g_type_fundamental_next">
       <doc xml:space="preserve">Returns the next free fundamental type id which can be used to
 register a new fundamental type with g_type_register_fundamental().
 The returned type ID represents the highest currently registered
@@ -15420,9 +13745,7 @@ fundamental type identifier.</doc>
         <type name="GType" c:type="GType"/>
       </return-value>
     </function>
-    <function name="type_get_instance_count"
-              c:identifier="g_type_get_instance_count"
-              version="2.44">
+    <function name="type_get_instance_count" c:identifier="g_type_get_instance_count" version="2.44">
       <doc xml:space="preserve">Returns the number of instances allocated of the particular type;
 this is only available if GLib is built with debugging support and
 the instance_count debug flag is set (by setting the GOBJECT_DEBUG
@@ -15475,9 +13798,7 @@ be retrieved from a subtype using g_type_get_qdata().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_get_type_registration_serial"
-              c:identifier="g_type_get_type_registration_serial"
-              version="2.36">
+    <function name="type_get_type_registration_serial" c:identifier="g_type_get_type_registration_serial" version="2.36">
       <doc xml:space="preserve">Returns an opaque serial number that represents the state of the set
 of registered types. Any time a type is registered this serial changes,
 which means you can cache information based on type lookups (such as
@@ -15488,10 +13809,7 @@ time by comparing the current serial with the one at the type lookup.</doc>
         <type name="guint" c:type="guint"/>
       </return-value>
     </function>
-    <function name="type_init"
-              c:identifier="g_type_init"
-              deprecated="1"
-              deprecated-version="2.36">
+    <function name="type_init" c:identifier="g_type_init" deprecated="1" deprecated-version="2.36">
       <doc xml:space="preserve">This function used to initialise the type system.  Since GLib 2.36,
 the type system is initialised automatically and this function does
 nothing.</doc>
@@ -15500,10 +13818,7 @@ nothing.</doc>
         <type name="none" c:type="void"/>
       </return-value>
     </function>
-    <function name="type_init_with_debug_flags"
-              c:identifier="g_type_init_with_debug_flags"
-              deprecated="1"
-              deprecated-version="2.36">
+    <function name="type_init_with_debug_flags" c:identifier="g_type_init_with_debug_flags" deprecated="1" deprecated-version="2.36">
       <doc xml:space="preserve">This function used to initialise the type system with debugging
 flags.  Since GLib 2.36, the type system is initialised automatically
 and this function does nothing.
@@ -15522,9 +13837,7 @@ environment variable.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_interface_add_prerequisite"
-              c:identifier="g_type_interface_add_prerequisite"
-              moved-to="TypeInterface.add_prerequisite">
+    <function name="type_interface_add_prerequisite" c:identifier="g_type_interface_add_prerequisite" moved-to="TypeInterface.add_prerequisite">
       <doc xml:space="preserve">Adds @prerequisite_type to the list of prerequisites of @interface_type.
 This means that any type implementing @interface_type must also implement
 @prerequisite_type. Prerequisites can be thought of as an alternative to
@@ -15544,9 +13857,7 @@ at most one instantiatable prerequisite type.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_interface_get_plugin"
-              c:identifier="g_type_interface_get_plugin"
-              moved-to="TypeInterface.get_plugin">
+    <function name="type_interface_get_plugin" c:identifier="g_type_interface_get_plugin" moved-to="TypeInterface.get_plugin">
       <doc xml:space="preserve">Returns the #GTypePlugin structure for the dynamic interface
 @interface_type which has been added to @instance_type, or %NULL
 if @interface_type has not been added to @instance_type or does
@@ -15567,9 +13878,7 @@ not have a #GTypePlugin structure. See g_type_add_interface_dynamic().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_interface_peek"
-              c:identifier="g_type_interface_peek"
-              moved-to="TypeInterface.peek">
+    <function name="type_interface_peek" c:identifier="g_type_interface_peek" moved-to="TypeInterface.peek">
       <doc xml:space="preserve">Returns the #GTypeInterface structure of an interface to which the
 passed in class conforms.</doc>
       <return-value transfer-ownership="none">
@@ -15589,10 +13898,7 @@ passed in class conforms.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_interface_prerequisites"
-              c:identifier="g_type_interface_prerequisites"
-              moved-to="TypeInterface.prerequisites"
-              version="2.2">
+    <function name="type_interface_prerequisites" c:identifier="g_type_interface_prerequisites" moved-to="TypeInterface.prerequisites" version="2.2">
       <doc xml:space="preserve">Returns the prerequisites of an interfaces type.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">a
@@ -15607,12 +13913,7 @@ passed in class conforms.</doc>
           <doc xml:space="preserve">an interface type</doc>
           <type name="GType" c:type="GType"/>
         </parameter>
-        <parameter name="n_prerequisites"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full"
-                   optional="1"
-                   allow-none="1">
+        <parameter name="n_prerequisites" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
           <doc xml:space="preserve">location to return the number
     of prerequisites, or %NULL</doc>
           <type name="guint" c:type="guint*"/>
@@ -15634,12 +13935,7 @@ the interface types that @type conforms to.</doc>
           <doc xml:space="preserve">the type to list interface types for</doc>
           <type name="GType" c:type="GType"/>
         </parameter>
-        <parameter name="n_interfaces"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full"
-                   optional="1"
-                   allow-none="1">
+        <parameter name="n_interfaces" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
           <doc xml:space="preserve">location to store the length of
     the returned array, or %NULL</doc>
           <type name="guint" c:type="guint*"/>
@@ -15683,8 +13979,7 @@ not be passed in and will most likely lead to a crash.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_name_from_class"
-              c:identifier="g_type_name_from_class">
+    <function name="type_name_from_class" c:identifier="g_type_name_from_class">
       <return-value transfer-ownership="none">
         <type name="utf8" c:type="const gchar*"/>
       </return-value>
@@ -15694,8 +13989,7 @@ not be passed in and will most likely lead to a crash.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_name_from_instance"
-              c:identifier="g_type_name_from_instance">
+    <function name="type_name_from_instance" c:identifier="g_type_name_from_instance">
       <return-value transfer-ownership="none">
         <type name="utf8" c:type="const gchar*"/>
       </return-value>
@@ -15770,18 +14064,14 @@ left untouched.</doc>
           <doc xml:space="preserve">#GType of a static, classed type</doc>
           <type name="GType" c:type="GType"/>
         </parameter>
-        <parameter name="query"
-                   direction="out"
-                   caller-allocates="1"
-                   transfer-ownership="none">
+        <parameter name="query" direction="out" caller-allocates="1" transfer-ownership="none">
           <doc xml:space="preserve">a user provided structure that is
     filled in with constant values upon success</doc>
           <type name="TypeQuery" c:type="GTypeQuery*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="type_register_dynamic"
-              c:identifier="g_type_register_dynamic">
+    <function name="type_register_dynamic" c:identifier="g_type_register_dynamic">
       <doc xml:space="preserve">Registers @type_name as the name of a new dynamic type derived from
 @parent_type.  The type system uses the information contained in the
 #GTypePlugin structure pointed to by @plugin to manage the type and its
@@ -15810,8 +14100,7 @@ instances (if not abstract).  The value of @flags determines the nature
         </parameter>
       </parameters>
     </function>
-    <function name="type_register_fundamental"
-              c:identifier="g_type_register_fundamental">
+    <function name="type_register_fundamental" c:identifier="g_type_register_fundamental">
       <doc xml:space="preserve">Registers @type_id as the predefined identifier and @type_name as the
 name of a fundamental type. If @type_id is already registered, or a
 type named @type_name is already registered, the behaviour is undefined.
@@ -15838,8 +14127,7 @@ additional characteristics of the fundamental type.</doc>
         </parameter>
         <parameter name="finfo" transfer-ownership="none">
           <doc xml:space="preserve">#GTypeFundamentalInfo structure for this type</doc>
-          <type name="TypeFundamentalInfo"
-                c:type="const GTypeFundamentalInfo*"/>
+          <type name="TypeFundamentalInfo" c:type="const GTypeFundamentalInfo*"/>
         </parameter>
         <parameter name="flags" transfer-ownership="none">
           <doc xml:space="preserve">bitwise combination of #GTypeFlags values</doc>
@@ -15847,8 +14135,7 @@ additional characteristics of the fundamental type.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_register_static"
-              c:identifier="g_type_register_static">
+    <function name="type_register_static" c:identifier="g_type_register_static">
       <doc xml:space="preserve">Registers @type_name as the name of a new static type derived from
 @parent_type. The type system uses the information contained in the
 #GTypeInfo structure pointed to by @info to manage the type and its
@@ -15877,10 +14164,7 @@ instances (if not abstract). The value of @flags determines the nature
         </parameter>
       </parameters>
     </function>
-    <function name="type_register_static_simple"
-              c:identifier="g_type_register_static_simple"
-              version="2.12"
-              introspectable="0">
+    <function name="type_register_static_simple" c:identifier="g_type_register_static_simple" version="2.12" introspectable="0">
       <doc xml:space="preserve">Registers @type_name as the name of a new static type derived from
 @parent_type.  The value of @flags determines the nature (e.g.
 abstract or not) of the type. It works by filling a #GTypeInfo
@@ -15920,9 +14204,7 @@ struct and calling g_type_register_static().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_remove_class_cache_func"
-              c:identifier="g_type_remove_class_cache_func"
-              introspectable="0">
+    <function name="type_remove_class_cache_func" c:identifier="g_type_remove_class_cache_func" introspectable="0">
       <doc xml:space="preserve">Removes a previously installed #GTypeClassCacheFunc. The cache
 maintained by @cache_func has to be empty when calling
 g_type_remove_class_cache_func() to avoid leaks.</doc>
@@ -15930,10 +14212,7 @@ g_type_remove_class_cache_func() to avoid leaks.</doc>
         <type name="none" c:type="void"/>
       </return-value>
       <parameters>
-        <parameter name="cache_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="cache_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">data that was given when adding @cache_func</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -15943,27 +14222,20 @@ g_type_remove_class_cache_func() to avoid leaks.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_remove_interface_check"
-              c:identifier="g_type_remove_interface_check"
-              version="2.4"
-              introspectable="0">
+    <function name="type_remove_interface_check" c:identifier="g_type_remove_interface_check" version="2.4" introspectable="0">
       <doc xml:space="preserve">Removes an interface check function added with
 g_type_add_interface_check().</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
       </return-value>
       <parameters>
-        <parameter name="check_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="check_data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">callback data passed to g_type_add_interface_check()</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
         <parameter name="check_func" transfer-ownership="none">
           <doc xml:space="preserve">callback function passed to g_type_add_interface_check()</doc>
-          <type name="TypeInterfaceCheckFunc"
-                c:type="GTypeInterfaceCheckFunc"/>
+          <type name="TypeInterfaceCheckFunc" c:type="GTypeInterfaceCheckFunc"/>
         </parameter>
       </parameters>
     </function>
@@ -15981,10 +14253,7 @@ g_type_add_interface_check().</doc>
           <doc xml:space="preserve">a #GQuark id to identify the data</doc>
           <type name="GLib.Quark" c:type="GQuark"/>
         </parameter>
-        <parameter name="data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">the data</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -16003,10 +14272,7 @@ g_type_add_interface_check().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="type_value_table_peek"
-              c:identifier="g_type_value_table_peek"
-              moved-to="TypeValueTable.peek"
-              introspectable="0">
+    <function name="type_value_table_peek" c:identifier="g_type_value_table_peek" moved-to="TypeValueTable.peek" introspectable="0">
       <doc xml:space="preserve">Returns the location of the #GTypeValueTable associated with @type.
 
 Note that this function should only be used from source code
@@ -16024,10 +14290,7 @@ that implements or has internal knowledge of the implementation of
         </parameter>
       </parameters>
     </function>
-    <function name="value_register_transform_func"
-              c:identifier="g_value_register_transform_func"
-              moved-to="Value.register_transform_func"
-              introspectable="0">
+    <function name="value_register_transform_func" c:identifier="g_value_register_transform_func" moved-to="Value.register_transform_func" introspectable="0">
       <doc xml:space="preserve">Registers a value transformation function for use in g_value_transform().
 A previously registered transformation function for @src_type and @dest_type
 will be replaced.</doc>
@@ -16050,9 +14313,7 @@ will be replaced.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="value_type_compatible"
-              c:identifier="g_value_type_compatible"
-              moved-to="Value.type_compatible">
+    <function name="value_type_compatible" c:identifier="g_value_type_compatible" moved-to="Value.type_compatible">
       <doc xml:space="preserve">Returns whether a #GValue of type @src_type can be copied into
 a #GValue of type @dest_type.</doc>
       <return-value transfer-ownership="none">
@@ -16070,9 +14331,7 @@ a #GValue of type @dest_type.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="value_type_transformable"
-              c:identifier="g_value_type_transformable"
-              moved-to="Value.type_transformable">
+    <function name="value_type_transformable" c:identifier="g_value_type_transformable" moved-to="Value.type_transformable">
       <doc xml:space="preserve">Check whether g_value_transform() is able to transform values
 of type @src_type into values of type @dest_type. Note that for
 the types to be transformable, they must be compatible or a

--- a/GdkPixbuf-2.0.gir
+++ b/GdkPixbuf-2.0.gir
@@ -7,7 +7,7 @@ and/or use gtk-doc annotations.  -->
   <include name="Gio" version="2.0"/>
   <package name="gdk-pixbuf-2.0"/>
   <c:include name="gdk-pixbuf/gdk-pixbuf.h"/>
-  <namespace name="GdkPixbuf" version="2.0" shared-library="libgdk_pixbuf-2.0.so.0" c:identifier-prefixes="Gdk" c:symbol-prefixes="gdk">
+  <c:include name="gdk-pixbuf/gdk-pixdata.h"/><namespace name="GdkPixbuf" version="2.0" shared-library="libgdk_pixbuf-2.0.so.0" c:identifier-prefixes="Gdk" c:symbol-prefixes="gdk">
     <enumeration name="Colorspace" glib:type-name="GdkColorspace" glib:get-type="gdk_colorspace_get_type" c:type="GdkColorspace">
       <doc xml:space="preserve">This enumeration defines the color spaces that are supported by
 the gdk-pixbuf library.  Currently only RGB is supported.</doc>

--- a/GdkPixbuf-2.0.gir
+++ b/GdkPixbuf-2.0.gir
@@ -2,36 +2,20 @@
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
-<repository version="1.2"
-            xmlns="http://www.gtk.org/introspection/core/1.0"
-            xmlns:c="http://www.gtk.org/introspection/c/1.0"
-            xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+<repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0" version="1.2">
   <include name="GModule" version="2.0"/>
   <include name="Gio" version="2.0"/>
   <package name="gdk-pixbuf-2.0"/>
   <c:include name="gdk-pixbuf/gdk-pixbuf.h"/>
-  <namespace name="GdkPixbuf"
-             version="2.0"
-             shared-library="libgdk_pixbuf-2.0.so.0"
-             c:identifier-prefixes="Gdk"
-             c:symbol-prefixes="gdk">
-    <enumeration name="Colorspace"
-                 glib:type-name="GdkColorspace"
-                 glib:get-type="gdk_colorspace_get_type"
-                 c:type="GdkColorspace">
+  <namespace name="GdkPixbuf" version="2.0" shared-library="libgdk_pixbuf-2.0.so.0" c:identifier-prefixes="Gdk" c:symbol-prefixes="gdk">
+    <enumeration name="Colorspace" glib:type-name="GdkColorspace" glib:get-type="gdk_colorspace_get_type" c:type="GdkColorspace">
       <doc xml:space="preserve">This enumeration defines the color spaces that are supported by
 the gdk-pixbuf library.  Currently only RGB is supported.</doc>
-      <member name="rgb"
-              value="0"
-              c:identifier="GDK_COLORSPACE_RGB"
-              glib:nick="rgb">
+      <member name="rgb" value="0" c:identifier="GDK_COLORSPACE_RGB" glib:nick="rgb">
         <doc xml:space="preserve">Indicates a red/green/blue additive color space.</doc>
       </member>
     </enumeration>
-    <enumeration name="InterpType"
-                 glib:type-name="GdkInterpType"
-                 glib:get-type="gdk_interp_type_get_type"
-                 c:type="GdkInterpType">
+    <enumeration name="InterpType" glib:type-name="GdkInterpType" glib:get-type="gdk_interp_type_get_type" c:type="GdkInterpType">
       <doc xml:space="preserve">This enumeration describes the different interpolation modes that
  can be used with the scaling functions. @GDK_INTERP_NEAREST is
  the fastest scaling method, but has horrible quality when
@@ -42,38 +26,26 @@ the gdk-pixbuf library.  Currently only RGB is supported.</doc>
 	Cubic filtering is missing from the list; hyperbolic
 	interpolation is just as fast and results in higher quality.
  &lt;/note&gt;</doc>
-      <member name="nearest"
-              value="0"
-              c:identifier="GDK_INTERP_NEAREST"
-              glib:nick="nearest">
+      <member name="nearest" value="0" c:identifier="GDK_INTERP_NEAREST" glib:nick="nearest">
         <doc xml:space="preserve">Nearest neighbor sampling; this is the fastest
  and lowest quality mode. Quality is normally unacceptable when scaling
  down, but may be OK when scaling up.</doc>
       </member>
-      <member name="tiles"
-              value="1"
-              c:identifier="GDK_INTERP_TILES"
-              glib:nick="tiles">
+      <member name="tiles" value="1" c:identifier="GDK_INTERP_TILES" glib:nick="tiles">
         <doc xml:space="preserve">This is an accurate simulation of the PostScript
  image operator without any interpolation enabled.  Each pixel is
  rendered as a tiny parallelogram of solid color, the edges of which
  are implemented with antialiasing.  It resembles nearest neighbor for
  enlargement, and bilinear for reduction.</doc>
       </member>
-      <member name="bilinear"
-              value="2"
-              c:identifier="GDK_INTERP_BILINEAR"
-              glib:nick="bilinear">
+      <member name="bilinear" value="2" c:identifier="GDK_INTERP_BILINEAR" glib:nick="bilinear">
         <doc xml:space="preserve">Best quality/speed balance; use this mode by
  default. Bilinear interpolation.  For enlargement, it is
  equivalent to point-sampling the ideal bilinear-interpolated image.
  For reduction, it is equivalent to laying down small tiles and
  integrating over the coverage area.</doc>
       </member>
-      <member name="hyper"
-              value="3"
-              c:identifier="GDK_INTERP_HYPER"
-              glib:nick="hyper">
+      <member name="hyper" value="3" c:identifier="GDK_INTERP_HYPER" glib:nick="hyper">
         <doc xml:space="preserve">This is the slowest and highest quality
  reconstruction function. It is derived from the hyperbolic filters in
  Wolberg's "Digital Image Warping", and is formally defined as the
@@ -81,14 +53,10 @@ the gdk-pixbuf library.  Currently only RGB is supported.</doc>
  image (the filter is designed to be idempotent for 1:1 pixel mapping).</doc>
       </member>
     </enumeration>
-    <constant name="PIXBUF_FEATURES_H"
-              value="1"
-              c:type="GDK_PIXBUF_FEATURES_H">
+    <constant name="PIXBUF_FEATURES_H" value="1" c:type="GDK_PIXBUF_FEATURES_H">
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="PIXBUF_MAGIC_NUMBER"
-              value="1197763408"
-              c:type="GDK_PIXBUF_MAGIC_NUMBER">
+    <constant name="PIXBUF_MAGIC_NUMBER" value="1197763408" c:type="GDK_PIXBUF_MAGIC_NUMBER">
       <doc xml:space="preserve">Magic number for #GdkPixdata structures.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
@@ -107,26 +75,17 @@ the gdk-pixbuf library.  Currently only RGB is supported.</doc>
 "0.8.2" for example.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="PIXBUF_VERSION"
-              value="2.36.11"
-              c:type="GDK_PIXBUF_VERSION">
+    <constant name="PIXBUF_VERSION" value="2.36.11" c:type="GDK_PIXBUF_VERSION">
       <doc xml:space="preserve">Contains the full version of the gdk-pixbuf header as a string.
 This is the version being compiled against; contrast with
 #gdk_pixbuf_version.</doc>
       <type name="utf8" c:type="gchar*"/>
     </constant>
-    <constant name="PIXDATA_HEADER_LENGTH"
-              value="24"
-              c:type="GDK_PIXDATA_HEADER_LENGTH">
+    <constant name="PIXDATA_HEADER_LENGTH" value="24" c:type="GDK_PIXDATA_HEADER_LENGTH">
       <doc xml:space="preserve">The length of a #GdkPixdata structure without the @pixel_data pointer.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <class name="Pixbuf"
-           c:symbol-prefix="pixbuf"
-           c:type="GdkPixbuf"
-           parent="GObject.Object"
-           glib:type-name="GdkPixbuf"
-           glib:get-type="gdk_pixbuf_get_type">
+    <class name="Pixbuf" c:symbol-prefix="pixbuf" c:type="GdkPixbuf" parent="GObject.Object" glib:type-name="GdkPixbuf" glib:get-type="gdk_pixbuf_get_type">
       <doc xml:space="preserve">This is the main structure in the gdk-pixbuf library.  It is
 used to represent images.  It contains information about the
 image's pixel data, its color space, bits per sample, width and
@@ -166,9 +125,7 @@ you will have to fill it completely yourself.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_bytes"
-                   c:identifier="gdk_pixbuf_new_from_bytes"
-                   version="2.32">
+      <constructor name="new_from_bytes" c:identifier="gdk_pixbuf_new_from_bytes" version="2.32">
         <doc xml:space="preserve">Creates a new #GdkPixbuf out of in-memory readonly image data.
 Currently only RGB images with 8 bits per sample are supported.
 This is the #GBytes variant of gdk_pixbuf_new_from_data().</doc>
@@ -207,8 +164,7 @@ This is the #GBytes variant of gdk_pixbuf_new_from_data().</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_data"
-                   c:identifier="gdk_pixbuf_new_from_data">
+      <constructor name="new_from_data" c:identifier="gdk_pixbuf_new_from_data">
         <doc xml:space="preserve">Creates a new #GdkPixbuf out of in-memory image data.  Currently only RGB
 images with 8 bits per sample are supported.
 
@@ -254,28 +210,18 @@ See also gdk_pixbuf_new_from_bytes().</doc>
             <doc xml:space="preserve">Distance in bytes between row starts</doc>
             <type name="gint" c:type="int"/>
           </parameter>
-          <parameter name="destroy_fn"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="async"
-                     closure="8">
+          <parameter name="destroy_fn" transfer-ownership="none" nullable="1" allow-none="1" scope="async" closure="8">
             <doc xml:space="preserve">Function used to free the data when the pixbuf's reference count
 drops to zero, or %NULL if the data should not be freed</doc>
             <type name="PixbufDestroyNotify" c:type="GdkPixbufDestroyNotify"/>
           </parameter>
-          <parameter name="destroy_fn_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="destroy_fn_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Closure data to pass to the destroy notification function</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_file"
-                   c:identifier="gdk_pixbuf_new_from_file"
-                   throws="1">
+      <constructor name="new_from_file" c:identifier="gdk_pixbuf_new_from_file" throws="1">
         <doc xml:space="preserve">Creates a new pixbuf by loading an image from a file.  The file format is
 detected automatically. If %NULL is returned, then @error will be set.
 Possible errors are in the #GDK_PIXBUF_ERROR and #G_FILE_ERROR domains.</doc>
@@ -293,10 +239,7 @@ allocate the image buffer, or the image file contained invalid data.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_file_at_scale"
-                   c:identifier="gdk_pixbuf_new_from_file_at_scale"
-                   version="2.6"
-                   throws="1">
+      <constructor name="new_from_file_at_scale" c:identifier="gdk_pixbuf_new_from_file_at_scale" version="2.6" throws="1">
         <doc xml:space="preserve">Creates a new pixbuf by loading an image from a file.  The file format is
 detected automatically. If %NULL is returned, then @error will be set.
 Possible errors are in the #GDK_PIXBUF_ERROR and #G_FILE_ERROR domains.
@@ -335,10 +278,7 @@ allocate the image buffer, or the image file contained invalid data.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_file_at_size"
-                   c:identifier="gdk_pixbuf_new_from_file_at_size"
-                   version="2.4"
-                   throws="1">
+      <constructor name="new_from_file_at_size" c:identifier="gdk_pixbuf_new_from_file_at_size" version="2.4" throws="1">
         <doc xml:space="preserve">Creates a new pixbuf by loading an image from a file.
 The file format is detected automatically. If %NULL is returned, then
 @error will be set. Possible errors are in the #GDK_PIXBUF_ERROR and
@@ -372,11 +312,7 @@ invalid data.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_inline"
-                   c:identifier="gdk_pixbuf_new_from_inline"
-                   deprecated="1"
-                   deprecated-version="2.32"
-                   throws="1">
+      <constructor name="new_from_inline" c:identifier="gdk_pixbuf_new_from_inline" deprecated="1" deprecated-version="2.32" throws="1">
         <doc xml:space="preserve">Create a #GdkPixbuf from a flat representation that is suitable for
 storing as inline data in a program. This is useful if you want to
 ship a program with images, but don't want to depend on any
@@ -433,10 +369,7 @@ addition.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_resource"
-                   c:identifier="gdk_pixbuf_new_from_resource"
-                   version="2.26"
-                   throws="1">
+      <constructor name="new_from_resource" c:identifier="gdk_pixbuf_new_from_resource" version="2.26" throws="1">
         <doc xml:space="preserve">Creates a new pixbuf by loading an image from an resource.
 
 The file format is detected automatically. If %NULL is returned, then
@@ -455,10 +388,7 @@ the stream contained invalid data, or the operation was cancelled.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_resource_at_scale"
-                   c:identifier="gdk_pixbuf_new_from_resource_at_scale"
-                   version="2.26"
-                   throws="1">
+      <constructor name="new_from_resource_at_scale" c:identifier="gdk_pixbuf_new_from_resource_at_scale" version="2.26" throws="1">
         <doc xml:space="preserve">Creates a new pixbuf by loading an image from an resource.
 
 The file format is detected automatically. If %NULL is returned, then
@@ -498,10 +428,7 @@ the stream contained invalid data, or the operation was cancelled.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_stream"
-                   c:identifier="gdk_pixbuf_new_from_stream"
-                   version="2.14"
-                   throws="1">
+      <constructor name="new_from_stream" c:identifier="gdk_pixbuf_new_from_stream" version="2.14" throws="1">
         <doc xml:space="preserve">Creates a new pixbuf by loading an image from an input stream.
 
 The file format is detected automatically. If %NULL is returned, then
@@ -523,19 +450,13 @@ the stream contained invalid data, or the operation was cancelled.</doc>
             <doc xml:space="preserve">a #GInputStream to load the pixbuf from</doc>
             <type name="Gio.InputStream" c:type="GInputStream*"/>
           </parameter>
-          <parameter name="cancellable"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">optional #GCancellable object, %NULL to ignore</doc>
             <type name="Gio.Cancellable" c:type="GCancellable*"/>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_stream_at_scale"
-                   c:identifier="gdk_pixbuf_new_from_stream_at_scale"
-                   version="2.14"
-                   throws="1">
+      <constructor name="new_from_stream_at_scale" c:identifier="gdk_pixbuf_new_from_stream_at_scale" version="2.14" throws="1">
         <doc xml:space="preserve">Creates a new pixbuf by loading an image from an input stream.
 
 The file format is detected automatically. If %NULL is returned, then
@@ -581,19 +502,13 @@ the stream contained invalid data, or the operation was cancelled.</doc>
             <doc xml:space="preserve">%TRUE to preserve the image's aspect ratio</doc>
             <type name="gboolean" c:type="gboolean"/>
           </parameter>
-          <parameter name="cancellable"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">optional #GCancellable object, %NULL to ignore</doc>
             <type name="Gio.Cancellable" c:type="GCancellable*"/>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_stream_finish"
-                   c:identifier="gdk_pixbuf_new_from_stream_finish"
-                   version="2.24"
-                   throws="1">
+      <constructor name="new_from_stream_finish" c:identifier="gdk_pixbuf_new_from_stream_finish" version="2.24" throws="1">
         <doc xml:space="preserve">Finishes an asynchronous pixbuf creation operation started with
 gdk_pixbuf_new_from_stream_async().</doc>
         <return-value transfer-ownership="full">
@@ -608,8 +523,7 @@ object with g_object_unref().</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_xpm_data"
-                   c:identifier="gdk_pixbuf_new_from_xpm_data">
+      <constructor name="new_from_xpm_data" c:identifier="gdk_pixbuf_new_from_xpm_data">
         <doc xml:space="preserve">Creates a new pixbuf by parsing XPM data in memory.  This data is commonly
 the result of including an XPM file into a program's C source.</doc>
         <return-value transfer-ownership="full">
@@ -625,9 +539,7 @@ the result of including an XPM file into a program's C source.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <function name="calculate_rowstride"
-                c:identifier="gdk_pixbuf_calculate_rowstride"
-                version="2.36.8">
+      <function name="calculate_rowstride" c:identifier="gdk_pixbuf_calculate_rowstride" version="2.36.8">
         <doc xml:space="preserve">Calculates the rowstride that an image created with those values would
 have. This is useful for front-ends and backends that want to sanity
 check image values without needing to create them.</doc>
@@ -658,11 +570,7 @@ check image values without needing to create them.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="from_pixdata"
-                c:identifier="gdk_pixbuf_from_pixdata"
-                deprecated="1"
-                deprecated-version="2.32"
-                throws="1">
+      <function name="from_pixdata" c:identifier="gdk_pixbuf_from_pixdata" deprecated="1" deprecated-version="2.32" throws="1">
         <doc xml:space="preserve">Converts a #GdkPixdata to a #GdkPixbuf. If @copy_pixels is %TRUE or
 if the pixel data is run-length-encoded, the pixel data is copied into
 newly-allocated memory; otherwise it is reused.</doc>
@@ -683,9 +591,7 @@ newly-allocated memory; otherwise it is reused.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="get_file_info"
-                c:identifier="gdk_pixbuf_get_file_info"
-                version="2.4">
+      <function name="get_file_info" c:identifier="gdk_pixbuf_get_file_info" version="2.4">
         <doc xml:space="preserve">Parses an image file far enough to determine its format and size.</doc>
         <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">A #GdkPixbufFormat describing
@@ -699,31 +605,19 @@ newly-allocated memory; otherwise it is reused.</doc>
             <doc xml:space="preserve">The name of the file to identify.</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
-          <parameter name="width"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="width" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">Return location for the width of the
     image, or %NULL</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
-          <parameter name="height"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="height" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">Return location for the height of the
     image, or %NULL</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
         </parameters>
       </function>
-      <function name="get_file_info_async"
-                c:identifier="gdk_pixbuf_get_file_info_async"
-                version="2.32">
+      <function name="get_file_info_async" c:identifier="gdk_pixbuf_get_file_info_async" version="2.32">
         <doc xml:space="preserve">Asynchronously parses an image file far enough to determine its
 format and size.
 
@@ -741,35 +635,21 @@ get the result of the operation.</doc>
             <doc xml:space="preserve">The name of the file to identify</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
-          <parameter name="cancellable"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">optional #GCancellable object, %NULL to ignore</doc>
             <type name="Gio.Cancellable" c:type="GCancellable*"/>
           </parameter>
-          <parameter name="callback"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="async"
-                     closure="3">
+          <parameter name="callback" transfer-ownership="none" nullable="1" allow-none="1" scope="async" closure="3">
             <doc xml:space="preserve">a #GAsyncReadyCallback to call when the file info is available</doc>
             <type name="Gio.AsyncReadyCallback" c:type="GAsyncReadyCallback"/>
           </parameter>
-          <parameter name="user_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the data to pass to the callback function</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </function>
-      <function name="get_file_info_finish"
-                c:identifier="gdk_pixbuf_get_file_info_finish"
-                version="2.32"
-                throws="1">
+      <function name="get_file_info_finish" c:identifier="gdk_pixbuf_get_file_info_finish" version="2.32" throws="1">
         <doc xml:space="preserve">Finishes an asynchronous pixbuf parsing operation started with
 gdk_pixbuf_get_file_info_async().</doc>
         <return-value transfer-ownership="none">
@@ -784,25 +664,17 @@ gdk_pixbuf_get_file_info_async().</doc>
             <doc xml:space="preserve">a #GAsyncResult</doc>
             <type name="Gio.AsyncResult" c:type="GAsyncResult*"/>
           </parameter>
-          <parameter name="width"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="width" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">Return location for the width of the image, or %NULL</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
-          <parameter name="height"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="height" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">Return location for the height of the image, or %NULL</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
         </parameters>
       </function>
-      <function name="get_formats"
-                c:identifier="gdk_pixbuf_get_formats"
-                version="2.2">
+      <function name="get_formats" c:identifier="gdk_pixbuf_get_formats" version="2.2">
         <doc xml:space="preserve">Obtains the available information about the image formats supported
 by GdkPixbuf.</doc>
         <return-value transfer-ownership="container">
@@ -815,9 +687,7 @@ owned by #GdkPixbuf and should not be freed.</doc>
           </type>
         </return-value>
       </function>
-      <function name="new_from_stream_async"
-                c:identifier="gdk_pixbuf_new_from_stream_async"
-                version="2.24">
+      <function name="new_from_stream_async" c:identifier="gdk_pixbuf_new_from_stream_async" version="2.24">
         <doc xml:space="preserve">Creates a new pixbuf by asynchronously loading an image from an input stream.
 
 For more details see gdk_pixbuf_new_from_stream(), which is the synchronous
@@ -833,34 +703,21 @@ You can then call gdk_pixbuf_new_from_stream_finish() to get the result of the o
             <doc xml:space="preserve">a #GInputStream from which to load the pixbuf</doc>
             <type name="Gio.InputStream" c:type="GInputStream*"/>
           </parameter>
-          <parameter name="cancellable"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">optional #GCancellable object, %NULL to ignore</doc>
             <type name="Gio.Cancellable" c:type="GCancellable*"/>
           </parameter>
-          <parameter name="callback"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="async"
-                     closure="3">
+          <parameter name="callback" transfer-ownership="none" nullable="1" allow-none="1" scope="async" closure="3">
             <doc xml:space="preserve">a #GAsyncReadyCallback to call when the pixbuf is loaded</doc>
             <type name="Gio.AsyncReadyCallback" c:type="GAsyncReadyCallback"/>
           </parameter>
-          <parameter name="user_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the data to pass to the callback function</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </function>
-      <function name="new_from_stream_at_scale_async"
-                c:identifier="gdk_pixbuf_new_from_stream_at_scale_async"
-                version="2.24">
+      <function name="new_from_stream_at_scale_async" c:identifier="gdk_pixbuf_new_from_stream_at_scale_async" version="2.24">
         <doc xml:space="preserve">Creates a new pixbuf by asynchronously loading an image from an input stream.
 
 For more details see gdk_pixbuf_new_from_stream_at_scale(), which is the synchronous
@@ -888,35 +745,21 @@ You can then call gdk_pixbuf_new_from_stream_finish() to get the result of the o
             <doc xml:space="preserve">%TRUE to preserve the image's aspect ratio</doc>
             <type name="gboolean" c:type="gboolean"/>
           </parameter>
-          <parameter name="cancellable"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">optional #GCancellable object, %NULL to ignore</doc>
             <type name="Gio.Cancellable" c:type="GCancellable*"/>
           </parameter>
-          <parameter name="callback"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="async"
-                     closure="6">
+          <parameter name="callback" transfer-ownership="none" nullable="1" allow-none="1" scope="async" closure="6">
             <doc xml:space="preserve">a #GAsyncReadyCallback to call when the pixbuf is loaded</doc>
             <type name="Gio.AsyncReadyCallback" c:type="GAsyncReadyCallback"/>
           </parameter>
-          <parameter name="user_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the data to pass to the callback function</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </function>
-      <function name="save_to_stream_finish"
-                c:identifier="gdk_pixbuf_save_to_stream_finish"
-                version="2.24"
-                throws="1">
+      <function name="save_to_stream_finish" c:identifier="gdk_pixbuf_save_to_stream_finish" version="2.24" throws="1">
         <doc xml:space="preserve">Finishes an asynchronous pixbuf save operation started with
 gdk_pixbuf_save_to_stream_async().</doc>
         <return-value transfer-ownership="none">
@@ -967,9 +810,7 @@ is %FALSE, then the (@r, @g, @b) arguments will be ignored.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="apply_embedded_orientation"
-              c:identifier="gdk_pixbuf_apply_embedded_orientation"
-              version="2.12">
+      <method name="apply_embedded_orientation" c:identifier="gdk_pixbuf_apply_embedded_orientation" version="2.12">
         <doc xml:space="preserve">Takes an existing pixbuf and checks for the presence of an
 associated "orientation" option, which may be provided by the
 jpeg loader (which reads the exif orientation tag) or the
@@ -1145,8 +986,7 @@ function suitable for many tasks.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="composite_color_simple"
-              c:identifier="gdk_pixbuf_composite_color_simple">
+      <method name="composite_color_simple" c:identifier="gdk_pixbuf_composite_color_simple">
         <doc xml:space="preserve">Creates a new #GdkPixbuf by scaling @src to @dest_width x
 @dest_height and alpha blending the result with a checkboard of colors
 @color1 and @color2.</doc>
@@ -1251,9 +1091,7 @@ Therefore, you can not use this function to scroll a pixbuf.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="copy_options"
-              c:identifier="gdk_pixbuf_copy_options"
-              version="2.36">
+      <method name="copy_options" c:identifier="gdk_pixbuf_copy_options" version="2.36">
         <doc xml:space="preserve">Copy the key/value pair options attached to a #GdkPixbuf to another.
 This is useful to keep original metadata after having manipulated
 a file. However be careful to remove metadata which you've already
@@ -1311,8 +1149,7 @@ if not enough memory could be allocated for it.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_bits_per_sample"
-              c:identifier="gdk_pixbuf_get_bits_per_sample">
+      <method name="get_bits_per_sample" c:identifier="gdk_pixbuf_get_bits_per_sample">
         <doc xml:space="preserve">Queries the number of bits per color sample in a pixbuf.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">Number of bits per color sample.</doc>
@@ -1325,9 +1162,7 @@ if not enough memory could be allocated for it.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_byte_length"
-              c:identifier="gdk_pixbuf_get_byte_length"
-              version="2.26">
+      <method name="get_byte_length" c:identifier="gdk_pixbuf_get_byte_length" version="2.26">
         <doc xml:space="preserve">Returns the length of the pixel data, in bytes.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">The length of the pixel data.</doc>
@@ -1424,9 +1259,7 @@ string that should not be freed or %NULL if @key was not found.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_options"
-              c:identifier="gdk_pixbuf_get_options"
-              version="2.32">
+      <method name="get_options" c:identifier="gdk_pixbuf_get_options" version="2.32">
         <doc xml:space="preserve">Returns a #GHashTable with a list of all the options that may have been
 attached to the @pixbuf when it was loaded, or that may have been
 attached by another function using gdk_pixbuf_set_option().
@@ -1446,9 +1279,7 @@ See gdk_pixbuf_get_option() for more details.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_pixels"
-              c:identifier="gdk_pixbuf_get_pixels"
-              shadowed-by="get_pixels_with_length">
+      <method name="get_pixels" c:identifier="gdk_pixbuf_get_pixels" shadowed-by="get_pixels_with_length">
         <doc xml:space="preserve">Queries a pointer to the pixel data of a pixbuf.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A pointer to the pixbuf's pixel data.
@@ -1468,10 +1299,7 @@ pixbuf was created from read-only data.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_pixels_with_length"
-              c:identifier="gdk_pixbuf_get_pixels_with_length"
-              shadows="get_pixels"
-              version="2.26">
+      <method name="get_pixels_with_length" c:identifier="gdk_pixbuf_get_pixels_with_length" shadows="get_pixels" version="2.26">
         <doc xml:space="preserve">Queries a pointer to the pixel data of a pixbuf.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A pointer to the pixbuf's
@@ -1489,10 +1317,7 @@ pixbuf was created from read-only data.</doc>
             <doc xml:space="preserve">A pixbuf.</doc>
             <type name="Pixbuf" c:type="const GdkPixbuf*"/>
           </instance-parameter>
-          <parameter name="length"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="length" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">The length of the binary data.</doc>
             <type name="guint" c:type="guint*"/>
           </parameter>
@@ -1561,9 +1386,7 @@ to be mutable.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="read_pixel_bytes"
-              c:identifier="gdk_pixbuf_read_pixel_bytes"
-              version="2.32">
+      <method name="read_pixel_bytes" c:identifier="gdk_pixbuf_read_pixel_bytes" version="2.32">
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A new reference to a read-only copy of
 the pixel data.  Note that for mutable pixbufs, this function will
@@ -1578,9 +1401,7 @@ returned #GBytes.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="read_pixels"
-              c:identifier="gdk_pixbuf_read_pixels"
-              version="2.32">
+      <method name="read_pixels" c:identifier="gdk_pixbuf_read_pixels" version="2.32">
         <doc xml:space="preserve">Returns a read-only pointer to the raw pixel data; must not be
 modified.  This function allows skipping the implicit copy that
 must be made if gdk_pixbuf_get_pixels() is called on a read-only
@@ -1595,11 +1416,7 @@ pixbuf.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="ref"
-              c:identifier="gdk_pixbuf_ref"
-              introspectable="0"
-              deprecated="1"
-              deprecated-version="2.0">
+      <method name="ref" c:identifier="gdk_pixbuf_ref" introspectable="0" deprecated="1" deprecated-version="2.0">
         <doc xml:space="preserve">Adds a reference to a pixbuf.</doc>
         <doc-deprecated xml:space="preserve">Use g_object_ref().</doc-deprecated>
         <return-value>
@@ -1613,9 +1430,7 @@ pixbuf.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="remove_option"
-              c:identifier="gdk_pixbuf_remove_option"
-              version="2.36">
+      <method name="remove_option" c:identifier="gdk_pixbuf_remove_option" version="2.36">
         <doc xml:space="preserve">Remove the key/value pair option attached to a #GdkPixbuf.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE if an option was removed, %FALSE if not.</doc>
@@ -1632,9 +1447,7 @@ pixbuf.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="rotate_simple"
-              c:identifier="gdk_pixbuf_rotate_simple"
-              version="2.6">
+      <method name="rotate_simple" c:identifier="gdk_pixbuf_rotate_simple" version="2.6">
         <doc xml:space="preserve">Rotates a pixbuf by a multiple of 90 degrees, and returns the
 result in a new pixbuf.
 
@@ -1655,8 +1468,7 @@ if not enough memory could be allocated for it.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="saturate_and_pixelate"
-              c:identifier="gdk_pixbuf_saturate_and_pixelate">
+      <method name="saturate_and_pixelate" c:identifier="gdk_pixbuf_saturate_and_pixelate">
         <doc xml:space="preserve">Modifies saturation and optionally pixelates @src, placing the result in
 @dest. @src and @dest may be the same pixbuf with no ill effects.  If
 @saturation is 1.0 then saturation is not changed. If it's less than 1.0,
@@ -1768,10 +1580,7 @@ it produces a CUR instead of an ICO.</doc>
             <doc xml:space="preserve">name of file format.</doc>
             <type name="utf8" c:type="const char*"/>
           </parameter>
-          <parameter name="error"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="error" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">return location for error, or %NULL</doc>
             <type name="GLib.Error" c:type="GError**"/>
           </parameter>
@@ -1781,10 +1590,7 @@ it produces a CUR instead of an ICO.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="save_to_buffer"
-              c:identifier="gdk_pixbuf_save_to_buffer"
-              version="2.4"
-              introspectable="0">
+      <method name="save_to_buffer" c:identifier="gdk_pixbuf_save_to_buffer" version="2.4" introspectable="0">
         <doc xml:space="preserve">Saves pixbuf to a new buffer in format @type, which is currently "jpeg",
 "png", "tiff", "ico" or "bmp".  This is a convenience function that uses
 gdk_pixbuf_save_to_callback() to do the real work. Note that the buffer
@@ -1803,20 +1609,14 @@ See gdk_pixbuf_save() for more details.</doc>
             <doc xml:space="preserve">a #GdkPixbuf.</doc>
             <type name="Pixbuf" c:type="GdkPixbuf*"/>
           </instance-parameter>
-          <parameter name="buffer"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="buffer" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to receive a pointer
   to the new buffer.</doc>
             <array length="1" zero-terminated="0" c:type="gchar**">
               <type name="guint8"/>
             </array>
           </parameter>
-          <parameter name="buffer_size"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="buffer_size" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to receive the size of the new buffer.</doc>
             <type name="gsize" c:type="gsize*"/>
           </parameter>
@@ -1824,10 +1624,7 @@ See gdk_pixbuf_save() for more details.</doc>
             <doc xml:space="preserve">name of file format.</doc>
             <type name="utf8" c:type="const char*"/>
           </parameter>
-          <parameter name="error"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="error" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">return location for error, or %NULL</doc>
             <type name="GLib.Error" c:type="GError**"/>
           </parameter>
@@ -1837,10 +1634,7 @@ See gdk_pixbuf_save() for more details.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="save_to_bufferv"
-              c:identifier="gdk_pixbuf_save_to_bufferv"
-              version="2.4"
-              throws="1">
+      <method name="save_to_bufferv" c:identifier="gdk_pixbuf_save_to_bufferv" version="2.4" throws="1">
         <doc xml:space="preserve">Saves pixbuf to a new buffer in format @type, which is currently "jpeg",
 "tiff", "png", "ico" or "bmp".  See gdk_pixbuf_save_to_buffer()
 for more details.</doc>
@@ -1853,20 +1647,14 @@ for more details.</doc>
             <doc xml:space="preserve">a #GdkPixbuf.</doc>
             <type name="Pixbuf" c:type="GdkPixbuf*"/>
           </instance-parameter>
-          <parameter name="buffer"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="buffer" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">
   location to receive a pointer to the new buffer.</doc>
             <array length="1" zero-terminated="0" c:type="gchar**">
               <type name="guint8"/>
             </array>
           </parameter>
-          <parameter name="buffer_size"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="buffer_size" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to receive the size of the new buffer.</doc>
             <type name="gsize" c:type="gsize*"/>
           </parameter>
@@ -1888,10 +1676,7 @@ for more details.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="save_to_callback"
-              c:identifier="gdk_pixbuf_save_to_callback"
-              version="2.4"
-              introspectable="0">
+      <method name="save_to_callback" c:identifier="gdk_pixbuf_save_to_callback" version="2.4" introspectable="0">
         <doc xml:space="preserve">Saves pixbuf in format @type by feeding the produced data to a
 callback. Can be used when you want to store the image to something
 other than a file, such as an in-memory buffer or a socket.
@@ -1909,18 +1694,12 @@ See gdk_pixbuf_save() for more details.</doc>
             <doc xml:space="preserve">a #GdkPixbuf.</doc>
             <type name="Pixbuf" c:type="GdkPixbuf*"/>
           </instance-parameter>
-          <parameter name="save_func"
-                     transfer-ownership="none"
-                     scope="call"
-                     closure="1">
+          <parameter name="save_func" transfer-ownership="none" scope="call" closure="1">
             <doc xml:space="preserve">a function that is called to save each block of data that
   the save routine generates.</doc>
             <type name="PixbufSaveFunc" c:type="GdkPixbufSaveFunc"/>
           </parameter>
-          <parameter name="user_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">user data to pass to the save function.</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -1928,10 +1707,7 @@ See gdk_pixbuf_save() for more details.</doc>
             <doc xml:space="preserve">name of file format.</doc>
             <type name="utf8" c:type="const char*"/>
           </parameter>
-          <parameter name="error"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="error" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">return location for error, or %NULL</doc>
             <type name="GLib.Error" c:type="GError**"/>
           </parameter>
@@ -1941,10 +1717,7 @@ See gdk_pixbuf_save() for more details.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="save_to_callbackv"
-              c:identifier="gdk_pixbuf_save_to_callbackv"
-              version="2.4"
-              throws="1">
+      <method name="save_to_callbackv" c:identifier="gdk_pixbuf_save_to_callbackv" version="2.4" throws="1">
         <doc xml:space="preserve">Saves pixbuf to a callback in format @type, which is currently "jpeg",
 "png", "tiff", "ico" or "bmp".  If @error is set, %FALSE will be returned. See
 gdk_pixbuf_save_to_callback () for more details.</doc>
@@ -1957,18 +1730,12 @@ gdk_pixbuf_save_to_callback () for more details.</doc>
             <doc xml:space="preserve">a #GdkPixbuf.</doc>
             <type name="Pixbuf" c:type="GdkPixbuf*"/>
           </instance-parameter>
-          <parameter name="save_func"
-                     transfer-ownership="none"
-                     scope="call"
-                     closure="1">
+          <parameter name="save_func" transfer-ownership="none" scope="call" closure="1">
             <doc xml:space="preserve">a function that is called to save each block of data that
   the save routine generates.</doc>
             <type name="PixbufSaveFunc" c:type="GdkPixbufSaveFunc"/>
           </parameter>
-          <parameter name="user_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">user data to pass to the save function.</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -1990,10 +1757,7 @@ gdk_pixbuf_save_to_callback () for more details.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="save_to_stream"
-              c:identifier="gdk_pixbuf_save_to_stream"
-              version="2.14"
-              introspectable="0">
+      <method name="save_to_stream" c:identifier="gdk_pixbuf_save_to_stream" version="2.14" introspectable="0">
         <doc xml:space="preserve">Saves @pixbuf to an output stream.
 
 Supported file formats are currently "jpeg", "tiff", "png", "ico" or
@@ -2023,17 +1787,11 @@ The stream is not closed.</doc>
             <doc xml:space="preserve">name of file format</doc>
             <type name="utf8" c:type="const char*"/>
           </parameter>
-          <parameter name="cancellable"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">optional #GCancellable object, %NULL to ignore</doc>
             <type name="Gio.Cancellable" c:type="GCancellable*"/>
           </parameter>
-          <parameter name="error"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="error" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">return location for error, or %NULL</doc>
             <type name="GLib.Error" c:type="GError**"/>
           </parameter>
@@ -2043,10 +1801,7 @@ The stream is not closed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="save_to_stream_async"
-              c:identifier="gdk_pixbuf_save_to_stream_async"
-              version="2.24"
-              introspectable="0">
+      <method name="save_to_stream_async" c:identifier="gdk_pixbuf_save_to_stream_async" version="2.24" introspectable="0">
         <doc xml:space="preserve">Saves @pixbuf to an output stream asynchronously.
 
 For more details see gdk_pixbuf_save_to_stream(), which is the synchronous
@@ -2070,26 +1825,15 @@ You can then call gdk_pixbuf_save_to_stream_finish() to get the result of the op
             <doc xml:space="preserve">name of file format</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
-          <parameter name="cancellable"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">optional #GCancellable object, %NULL to ignore</doc>
             <type name="Gio.Cancellable" c:type="GCancellable*"/>
           </parameter>
-          <parameter name="callback"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="async"
-                     closure="4">
+          <parameter name="callback" transfer-ownership="none" nullable="1" allow-none="1" scope="async" closure="4">
             <doc xml:space="preserve">a #GAsyncReadyCallback to call when the pixbuf is saved</doc>
             <type name="Gio.AsyncReadyCallback" c:type="GAsyncReadyCallback"/>
           </parameter>
-          <parameter name="user_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the data to pass to the callback function</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -2099,10 +1843,7 @@ You can then call gdk_pixbuf_save_to_stream_finish() to get the result of the op
           </parameter>
         </parameters>
       </method>
-      <method name="save_to_streamv"
-              c:identifier="gdk_pixbuf_save_to_streamv"
-              version="2.36"
-              throws="1">
+      <method name="save_to_streamv" c:identifier="gdk_pixbuf_save_to_streamv" version="2.36" throws="1">
         <doc xml:space="preserve">Saves @pixbuf to an output stream.
 
 Supported file formats are currently "jpeg", "tiff", "png", "ico" or
@@ -2137,18 +1878,13 @@ Supported file formats are currently "jpeg", "tiff", "png", "ico" or
               <type name="utf8" c:type="char*"/>
             </array>
           </parameter>
-          <parameter name="cancellable"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">optional #GCancellable object, %NULL to ignore</doc>
             <type name="Gio.Cancellable" c:type="GCancellable*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="save_to_streamv_async"
-              c:identifier="gdk_pixbuf_save_to_streamv_async"
-              version="2.36">
+      <method name="save_to_streamv_async" c:identifier="gdk_pixbuf_save_to_streamv_async" version="2.36">
         <doc xml:space="preserve">Saves @pixbuf to an output stream asynchronously.
 
 For more details see gdk_pixbuf_save_to_streamv(), which is the synchronous
@@ -2184,26 +1920,15 @@ You can then call gdk_pixbuf_save_to_stream_finish() to get the result of the op
               <type name="utf8" c:type="gchar*"/>
             </array>
           </parameter>
-          <parameter name="cancellable"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">optional #GCancellable object, %NULL to ignore</doc>
             <type name="Gio.Cancellable" c:type="GCancellable*"/>
           </parameter>
-          <parameter name="callback"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="async"
-                     closure="6">
+          <parameter name="callback" transfer-ownership="none" nullable="1" allow-none="1" scope="async" closure="6">
             <doc xml:space="preserve">a #GAsyncReadyCallback to call when the pixbuf is saved</doc>
             <type name="Gio.AsyncReadyCallback" c:type="GAsyncReadyCallback"/>
           </parameter>
-          <parameter name="user_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the data to pass to the callback function</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -2348,9 +2073,7 @@ allocated for it.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_option"
-              c:identifier="gdk_pixbuf_set_option"
-              version="2.2">
+      <method name="set_option" c:identifier="gdk_pixbuf_set_option" version="2.2">
         <doc xml:space="preserve">Attaches a key/value pair as an option to a #GdkPixbuf. If @key already
 exists in the list of options attached to @pixbuf, the new value is
 ignored and %FALSE is returned.</doc>
@@ -2373,11 +2096,7 @@ ignored and %FALSE is returned.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="unref"
-              c:identifier="gdk_pixbuf_unref"
-              introspectable="0"
-              deprecated="1"
-              deprecated-version="2.0">
+      <method name="unref" c:identifier="gdk_pixbuf_unref" introspectable="0" deprecated="1" deprecated-version="2.0">
         <doc xml:space="preserve">Removes a reference from a pixbuf.</doc>
         <doc-deprecated xml:space="preserve">Use g_object_unref().</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -2390,72 +2109,42 @@ ignored and %FALSE is returned.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <property name="bits-per-sample"
-                writable="1"
-                construct-only="1"
-                transfer-ownership="none">
+      <property name="bits-per-sample" writable="1" construct-only="1" transfer-ownership="none">
         <doc xml:space="preserve">The number of bits per sample.
 Currently only 8 bit per sample are supported.</doc>
         <type name="gint" c:type="gint"/>
       </property>
-      <property name="colorspace"
-                writable="1"
-                construct-only="1"
-                transfer-ownership="none">
+      <property name="colorspace" writable="1" construct-only="1" transfer-ownership="none">
         <type name="Colorspace"/>
       </property>
-      <property name="has-alpha"
-                writable="1"
-                construct-only="1"
-                transfer-ownership="none">
+      <property name="has-alpha" writable="1" construct-only="1" transfer-ownership="none">
         <type name="gboolean" c:type="gboolean"/>
       </property>
-      <property name="height"
-                writable="1"
-                construct-only="1"
-                transfer-ownership="none">
+      <property name="height" writable="1" construct-only="1" transfer-ownership="none">
         <type name="gint" c:type="gint"/>
       </property>
-      <property name="n-channels"
-                writable="1"
-                construct-only="1"
-                transfer-ownership="none">
+      <property name="n-channels" writable="1" construct-only="1" transfer-ownership="none">
         <doc xml:space="preserve">The number of samples per pixel.
 Currently, only 3 or 4 samples per pixel are supported.</doc>
         <type name="gint" c:type="gint"/>
       </property>
-      <property name="pixel-bytes"
-                writable="1"
-                construct-only="1"
-                transfer-ownership="none">
+      <property name="pixel-bytes" writable="1" construct-only="1" transfer-ownership="none">
         <type name="GLib.Bytes"/>
       </property>
-      <property name="pixels"
-                writable="1"
-                construct-only="1"
-                transfer-ownership="none">
+      <property name="pixels" writable="1" construct-only="1" transfer-ownership="none">
         <type name="gpointer" c:type="gpointer"/>
       </property>
-      <property name="rowstride"
-                writable="1"
-                construct-only="1"
-                transfer-ownership="none">
+      <property name="rowstride" writable="1" construct-only="1" transfer-ownership="none">
         <doc xml:space="preserve">The number of bytes between the start of a row and
 the start of the next row. This number must (obviously)
 be at least as large as the width of the pixbuf.</doc>
         <type name="gint" c:type="gint"/>
       </property>
-      <property name="width"
-                writable="1"
-                construct-only="1"
-                transfer-ownership="none">
+      <property name="width" writable="1" construct-only="1" transfer-ownership="none">
         <type name="gint" c:type="gint"/>
       </property>
     </class>
-    <enumeration name="PixbufAlphaMode"
-                 glib:type-name="GdkPixbufAlphaMode"
-                 glib:get-type="gdk_pixbuf_alpha_mode_get_type"
-                 c:type="GdkPixbufAlphaMode">
+    <enumeration name="PixbufAlphaMode" glib:type-name="GdkPixbufAlphaMode" glib:get-type="gdk_pixbuf_alpha_mode_get_type" c:type="GdkPixbufAlphaMode">
       <doc xml:space="preserve">These values can be passed to
 gdk_pixbuf_xlib_render_to_drawable_alpha() to control how the alpha
 channel of an image should be handled.  This function can create a
@@ -2464,33 +2153,20 @@ the image.  In the future, when the X Window System gets an alpha
 channel extension, it will be possible to do full alpha
 compositing onto arbitrary drawables.  For now both cases fall
 back to a bilevel clipping mask.</doc>
-      <member name="bilevel"
-              value="0"
-              c:identifier="GDK_PIXBUF_ALPHA_BILEVEL"
-              glib:nick="bilevel">
+      <member name="bilevel" value="0" c:identifier="GDK_PIXBUF_ALPHA_BILEVEL" glib:nick="bilevel">
         <doc xml:space="preserve">A bilevel clipping mask (black and white)
  will be created and used to draw the image.  Pixels below 0.5 opacity
  will be considered fully transparent, and all others will be
  considered fully opaque.</doc>
       </member>
-      <member name="full"
-              value="1"
-              c:identifier="GDK_PIXBUF_ALPHA_FULL"
-              glib:nick="full">
+      <member name="full" value="1" c:identifier="GDK_PIXBUF_ALPHA_FULL" glib:nick="full">
         <doc xml:space="preserve">For now falls back to #GDK_PIXBUF_ALPHA_BILEVEL.
  In the future it will do full alpha compositing.</doc>
       </member>
     </enumeration>
-    <class name="PixbufAnimation"
-           c:symbol-prefix="pixbuf_animation"
-           c:type="GdkPixbufAnimation"
-           parent="GObject.Object"
-           glib:type-name="GdkPixbufAnimation"
-           glib:get-type="gdk_pixbuf_animation_get_type">
+    <class name="PixbufAnimation" c:symbol-prefix="pixbuf_animation" c:type="GdkPixbufAnimation" parent="GObject.Object" glib:type-name="GdkPixbufAnimation" glib:get-type="gdk_pixbuf_animation_get_type">
       <doc xml:space="preserve">An opaque struct representing an animation.</doc>
-      <constructor name="new_from_file"
-                   c:identifier="gdk_pixbuf_animation_new_from_file"
-                   throws="1">
+      <constructor name="new_from_file" c:identifier="gdk_pixbuf_animation_new_from_file" throws="1">
         <doc xml:space="preserve">Creates a new animation by loading it from a file. The file format is
 detected automatically. If the file's format does not support multi-frame
 images, then an animation with a single frame will be created. Possible errors
@@ -2509,10 +2185,7 @@ allocate the image buffer, or the image file contained invalid data.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_resource"
-                   c:identifier="gdk_pixbuf_animation_new_from_resource"
-                   version="2.28"
-                   throws="1">
+      <constructor name="new_from_resource" c:identifier="gdk_pixbuf_animation_new_from_resource" version="2.28" throws="1">
         <doc xml:space="preserve">Creates a new pixbuf animation by loading an image from an resource.
 
 The file format is detected automatically. If %NULL is returned, then
@@ -2531,10 +2204,7 @@ the stream contained invalid data, or the operation was cancelled.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_stream"
-                   c:identifier="gdk_pixbuf_animation_new_from_stream"
-                   version="2.28"
-                   throws="1">
+      <constructor name="new_from_stream" c:identifier="gdk_pixbuf_animation_new_from_stream" version="2.28" throws="1">
         <doc xml:space="preserve">Creates a new animation by loading it from an input stream.
 
 The file format is detected automatically. If %NULL is returned, then
@@ -2556,19 +2226,13 @@ the stream contained invalid data, or the operation was cancelled.</doc>
             <doc xml:space="preserve">a #GInputStream to load the pixbuf from</doc>
             <type name="Gio.InputStream" c:type="GInputStream*"/>
           </parameter>
-          <parameter name="cancellable"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">optional #GCancellable object, %NULL to ignore</doc>
             <type name="Gio.Cancellable" c:type="GCancellable*"/>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_from_stream_finish"
-                   c:identifier="gdk_pixbuf_animation_new_from_stream_finish"
-                   version="2.28"
-                   throws="1">
+      <constructor name="new_from_stream_finish" c:identifier="gdk_pixbuf_animation_new_from_stream_finish" version="2.28" throws="1">
         <doc xml:space="preserve">Finishes an asynchronous pixbuf animation creation operation started with
 gdk_pixbuf_animation_new_from_stream_async().</doc>
         <return-value transfer-ownership="full">
@@ -2583,9 +2247,7 @@ object with g_object_unref().</doc>
           </parameter>
         </parameters>
       </constructor>
-      <function name="new_from_stream_async"
-                c:identifier="gdk_pixbuf_animation_new_from_stream_async"
-                version="2.28">
+      <function name="new_from_stream_async" c:identifier="gdk_pixbuf_animation_new_from_stream_async" version="2.28">
         <doc xml:space="preserve">Creates a new animation by asynchronously loading an image from an input stream.
 
 For more details see gdk_pixbuf_new_from_stream(), which is the synchronous
@@ -2602,26 +2264,15 @@ result of the operation.</doc>
             <doc xml:space="preserve">a #GInputStream from which to load the animation</doc>
             <type name="Gio.InputStream" c:type="GInputStream*"/>
           </parameter>
-          <parameter name="cancellable"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">optional #GCancellable object, %NULL to ignore</doc>
             <type name="Gio.Cancellable" c:type="GCancellable*"/>
           </parameter>
-          <parameter name="callback"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="async"
-                     closure="3">
+          <parameter name="callback" transfer-ownership="none" nullable="1" allow-none="1" scope="async" closure="3">
             <doc xml:space="preserve">a #GAsyncReadyCallback to call when the pixbuf is loaded</doc>
             <type name="Gio.AsyncReadyCallback" c:type="GAsyncReadyCallback"/>
           </parameter>
-          <parameter name="user_data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the data to pass to the callback function</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -2683,17 +2334,13 @@ A delay time of -1 is possible, indicating "infinite."</doc>
             <doc xml:space="preserve">a #GdkPixbufAnimation</doc>
             <type name="PixbufAnimation" c:type="GdkPixbufAnimation*"/>
           </instance-parameter>
-          <parameter name="start_time"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="start_time" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">time when the animation starts playing</doc>
             <type name="GLib.TimeVal" c:type="const GTimeVal*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="get_static_image"
-              c:identifier="gdk_pixbuf_animation_get_static_image">
+      <method name="get_static_image" c:identifier="gdk_pixbuf_animation_get_static_image">
         <doc xml:space="preserve">If an animation is really just a plain image (has only one frame),
 this function returns that image. If the animation is an animation,
 this function returns a reasonable thing to display as a static
@@ -2724,8 +2371,7 @@ function will return %NULL.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="is_static_image"
-              c:identifier="gdk_pixbuf_animation_is_static_image">
+      <method name="is_static_image" c:identifier="gdk_pixbuf_animation_is_static_image">
         <doc xml:space="preserve">If you load a file with gdk_pixbuf_animation_new_from_file() and it
 turns out to be a plain, unanimated image, then this function will
 return %TRUE. Use gdk_pixbuf_animation_get_static_image() to retrieve
@@ -2741,11 +2387,7 @@ the image.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="ref"
-              c:identifier="gdk_pixbuf_animation_ref"
-              introspectable="0"
-              deprecated="1"
-              deprecated-version="2.0">
+      <method name="ref" c:identifier="gdk_pixbuf_animation_ref" introspectable="0" deprecated="1" deprecated-version="2.0">
         <doc xml:space="preserve">Adds a reference to an animation.</doc>
         <doc-deprecated xml:space="preserve">Use g_object_ref().</doc-deprecated>
         <return-value>
@@ -2759,11 +2401,7 @@ the image.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="unref"
-              c:identifier="gdk_pixbuf_animation_unref"
-              introspectable="0"
-              deprecated="1"
-              deprecated-version="2.0">
+      <method name="unref" c:identifier="gdk_pixbuf_animation_unref" introspectable="0" deprecated="1" deprecated-version="2.0">
         <doc xml:space="preserve">Removes a reference from an animation.</doc>
         <doc-deprecated xml:space="preserve">Use g_object_unref().</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -2777,12 +2415,7 @@ the image.</doc>
         </parameters>
       </method>
     </class>
-    <class name="PixbufAnimationIter"
-           c:symbol-prefix="pixbuf_animation_iter"
-           c:type="GdkPixbufAnimationIter"
-           parent="GObject.Object"
-           glib:type-name="GdkPixbufAnimationIter"
-           glib:get-type="gdk_pixbuf_animation_iter_get_type">
+    <class name="PixbufAnimationIter" c:symbol-prefix="pixbuf_animation_iter" c:type="GdkPixbufAnimationIter" parent="GObject.Object" glib:type-name="GdkPixbufAnimationIter" glib:get-type="gdk_pixbuf_animation_iter_get_type">
       <doc xml:space="preserve">An opaque struct representing an iterator which points to a
 certain position in an animation.</doc>
       <method name="advance" c:identifier="gdk_pixbuf_animation_iter_advance">
@@ -2814,17 +2447,13 @@ and update the display with the new pixbuf.</doc>
             <doc xml:space="preserve">a #GdkPixbufAnimationIter</doc>
             <type name="PixbufAnimationIter" c:type="GdkPixbufAnimationIter*"/>
           </instance-parameter>
-          <parameter name="current_time"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="current_time" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">current time</doc>
             <type name="GLib.TimeVal" c:type="const GTimeVal*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="get_delay_time"
-              c:identifier="gdk_pixbuf_animation_iter_get_delay_time">
+      <method name="get_delay_time" c:identifier="gdk_pixbuf_animation_iter_get_delay_time">
         <doc xml:space="preserve">Gets the number of milliseconds the current pixbuf should be displayed,
 or -1 if the current pixbuf should be displayed forever. g_timeout_add()
 conveniently takes a timeout in milliseconds, so you can use a timeout
@@ -2844,8 +2473,7 @@ for GIF images is currently 20 milliseconds.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_pixbuf"
-              c:identifier="gdk_pixbuf_animation_iter_get_pixbuf">
+      <method name="get_pixbuf" c:identifier="gdk_pixbuf_animation_iter_get_pixbuf">
         <doc xml:space="preserve">Gets the current pixbuf which should be displayed; the pixbuf might not
 be the same size as the animation itself
 (gdk_pixbuf_animation_get_width(), gdk_pixbuf_animation_get_height()).
@@ -2868,8 +2496,7 @@ the iterator.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="on_currently_loading_frame"
-              c:identifier="gdk_pixbuf_animation_iter_on_currently_loading_frame">
+      <method name="on_currently_loading_frame" c:identifier="gdk_pixbuf_animation_iter_on_currently_loading_frame">
         <doc xml:space="preserve">Used to determine how to respond to the area_updated signal on
 #GdkPixbufLoader when loading an animation. area_updated is emitted
 for an area of the frame currently streaming in to the loader. So if
@@ -2905,65 +2532,36 @@ when the pixbuf is finalized.</doc>
             <type name="guint8"/>
           </array>
         </parameter>
-        <parameter name="data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1"
-                   closure="1">
+        <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
           <doc xml:space="preserve">User closure data.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
       </parameters>
     </callback>
-    <enumeration name="PixbufError"
-                 glib:type-name="GdkPixbufError"
-                 glib:get-type="gdk_pixbuf_error_get_type"
-                 c:type="GdkPixbufError"
-                 glib:error-domain="gdk-pixbuf-error-quark">
+    <enumeration name="PixbufError" glib:type-name="GdkPixbufError" glib:get-type="gdk_pixbuf_error_get_type" c:type="GdkPixbufError" glib:error-domain="gdk-pixbuf-error-quark">
       <doc xml:space="preserve">An error code in the #GDK_PIXBUF_ERROR domain. Many gdk-pixbuf
 operations can cause errors in this domain, or in the #G_FILE_ERROR
 domain.</doc>
-      <member name="corrupt_image"
-              value="0"
-              c:identifier="GDK_PIXBUF_ERROR_CORRUPT_IMAGE"
-              glib:nick="corrupt-image">
+      <member name="corrupt_image" value="0" c:identifier="GDK_PIXBUF_ERROR_CORRUPT_IMAGE" glib:nick="corrupt-image">
         <doc xml:space="preserve">An image file was broken somehow.</doc>
       </member>
-      <member name="insufficient_memory"
-              value="1"
-              c:identifier="GDK_PIXBUF_ERROR_INSUFFICIENT_MEMORY"
-              glib:nick="insufficient-memory">
+      <member name="insufficient_memory" value="1" c:identifier="GDK_PIXBUF_ERROR_INSUFFICIENT_MEMORY" glib:nick="insufficient-memory">
         <doc xml:space="preserve">Not enough memory.</doc>
       </member>
-      <member name="bad_option"
-              value="2"
-              c:identifier="GDK_PIXBUF_ERROR_BAD_OPTION"
-              glib:nick="bad-option">
+      <member name="bad_option" value="2" c:identifier="GDK_PIXBUF_ERROR_BAD_OPTION" glib:nick="bad-option">
         <doc xml:space="preserve">A bad option was passed to a pixbuf save module.</doc>
       </member>
-      <member name="unknown_type"
-              value="3"
-              c:identifier="GDK_PIXBUF_ERROR_UNKNOWN_TYPE"
-              glib:nick="unknown-type">
+      <member name="unknown_type" value="3" c:identifier="GDK_PIXBUF_ERROR_UNKNOWN_TYPE" glib:nick="unknown-type">
         <doc xml:space="preserve">Unknown image type.</doc>
       </member>
-      <member name="unsupported_operation"
-              value="4"
-              c:identifier="GDK_PIXBUF_ERROR_UNSUPPORTED_OPERATION"
-              glib:nick="unsupported-operation">
+      <member name="unsupported_operation" value="4" c:identifier="GDK_PIXBUF_ERROR_UNSUPPORTED_OPERATION" glib:nick="unsupported-operation">
         <doc xml:space="preserve">Don't know how to perform the
  given operation on the type of image at hand.</doc>
       </member>
-      <member name="failed"
-              value="5"
-              c:identifier="GDK_PIXBUF_ERROR_FAILED"
-              glib:nick="failed">
+      <member name="failed" value="5" c:identifier="GDK_PIXBUF_ERROR_FAILED" glib:nick="failed">
         <doc xml:space="preserve">Generic failure code, something went wrong.</doc>
       </member>
-      <member name="incomplete_animation"
-              value="6"
-              c:identifier="GDK_PIXBUF_ERROR_INCOMPLETE_ANIMATION"
-              glib:nick="incomplete-animation">
+      <member name="incomplete_animation" value="6" c:identifier="GDK_PIXBUF_ERROR_INCOMPLETE_ANIMATION" glib:nick="incomplete-animation">
         <doc xml:space="preserve">Only part of the animation was loaded.</doc>
       </member>
       <function name="quark" c:identifier="gdk_pixbuf_error_quark">
@@ -2972,11 +2570,7 @@ domain.</doc>
         </return-value>
       </function>
     </enumeration>
-    <record name="PixbufFormat"
-            c:type="GdkPixbufFormat"
-            glib:type-name="GdkPixbufFormat"
-            glib:get-type="gdk_pixbuf_format_get_type"
-            c:symbol-prefix="pixbuf_format">
+    <record name="PixbufFormat" c:type="GdkPixbufFormat" glib:type-name="GdkPixbufFormat" glib:get-type="gdk_pixbuf_format_get_type" c:symbol-prefix="pixbuf_format">
       <method name="copy" c:identifier="gdk_pixbuf_format_copy" version="2.22">
         <doc xml:space="preserve">Creates a copy of @format</doc>
         <return-value transfer-ownership="full">
@@ -3004,9 +2598,7 @@ using gdk_pixbuf_format_copy()</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_description"
-              c:identifier="gdk_pixbuf_format_get_description"
-              version="2.2">
+      <method name="get_description" c:identifier="gdk_pixbuf_format_get_description" version="2.2">
         <doc xml:space="preserve">Returns a description of the format.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a description of the format.</doc>
@@ -3019,9 +2611,7 @@ using gdk_pixbuf_format_copy()</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_extensions"
-              c:identifier="gdk_pixbuf_format_get_extensions"
-              version="2.2">
+      <method name="get_extensions" c:identifier="gdk_pixbuf_format_get_extensions" version="2.2">
         <doc xml:space="preserve">Returns the filename extensions typically used for files in the
 given format.</doc>
         <return-value transfer-ownership="full">
@@ -3038,9 +2628,7 @@ freed with g_strfreev() when it is no longer needed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_license"
-              c:identifier="gdk_pixbuf_format_get_license"
-              version="2.6">
+      <method name="get_license" c:identifier="gdk_pixbuf_format_get_license" version="2.6">
         <doc xml:space="preserve">Returns information about the license of the image loader for the format. The
 returned string should be a shorthand for a wellknown license, e.g. "LGPL",
 "GPL", "QPL", "GPL/QPL", or "other" to indicate some other license.  This
@@ -3056,9 +2644,7 @@ string should be freed with g_free() when it's no longer needed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_mime_types"
-              c:identifier="gdk_pixbuf_format_get_mime_types"
-              version="2.2">
+      <method name="get_mime_types" c:identifier="gdk_pixbuf_format_get_mime_types" version="2.2">
         <doc xml:space="preserve">Returns the mime types supported by the format.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a %NULL-terminated array of mime types which must be freed with
@@ -3074,9 +2660,7 @@ g_strfreev() when it is no longer needed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name"
-              c:identifier="gdk_pixbuf_format_get_name"
-              version="2.2">
+      <method name="get_name" c:identifier="gdk_pixbuf_format_get_name" version="2.2">
         <doc xml:space="preserve">Returns the name of the format.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">the name of the format.</doc>
@@ -3089,9 +2673,7 @@ g_strfreev() when it is no longer needed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="is_disabled"
-              c:identifier="gdk_pixbuf_format_is_disabled"
-              version="2.6">
+      <method name="is_disabled" c:identifier="gdk_pixbuf_format_is_disabled" version="2.6">
         <doc xml:space="preserve">Returns whether this image format is disabled. See
 gdk_pixbuf_format_set_disabled().</doc>
         <return-value transfer-ownership="none">
@@ -3105,9 +2687,7 @@ gdk_pixbuf_format_set_disabled().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="is_save_option_supported"
-              c:identifier="gdk_pixbuf_format_is_save_option_supported"
-              version="2.36">
+      <method name="is_save_option_supported" c:identifier="gdk_pixbuf_format_is_save_option_supported" version="2.36">
         <doc xml:space="preserve">Returns %TRUE if the save option specified by @option_key is supported when
 saving a pixbuf using the module implementing @format.
 See gdk_pixbuf_save() for more information about option keys.</doc>
@@ -3126,9 +2706,7 @@ See gdk_pixbuf_save() for more information about option keys.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="is_scalable"
-              c:identifier="gdk_pixbuf_format_is_scalable"
-              version="2.6">
+      <method name="is_scalable" c:identifier="gdk_pixbuf_format_is_scalable" version="2.6">
         <doc xml:space="preserve">Returns whether this image format is scalable. If a file is in a
 scalable format, it is preferable to load it at the desired size,
 rather than loading it at the default size and scaling the
@@ -3144,9 +2722,7 @@ resulting pixbuf to the desired size.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="is_writable"
-              c:identifier="gdk_pixbuf_format_is_writable"
-              version="2.2">
+      <method name="is_writable" c:identifier="gdk_pixbuf_format_is_writable" version="2.2">
         <doc xml:space="preserve">Returns whether pixbufs can be saved in the given format.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">whether pixbufs can be saved in the given format.</doc>
@@ -3159,9 +2735,7 @@ resulting pixbuf to the desired size.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_disabled"
-              c:identifier="gdk_pixbuf_format_set_disabled"
-              version="2.6">
+      <method name="set_disabled" c:identifier="gdk_pixbuf_format_set_disabled" version="2.6">
         <doc xml:space="preserve">Disables or enables an image format. If a format is disabled,
 gdk-pixbuf won't use the image loader for this format to load
 images. Applications can use this to avoid using image loaders
@@ -3181,13 +2755,7 @@ with an inappropriate license, see gdk_pixbuf_format_get_license().</doc>
         </parameters>
       </method>
     </record>
-    <class name="PixbufLoader"
-           c:symbol-prefix="pixbuf_loader"
-           c:type="GdkPixbufLoader"
-           parent="GObject.Object"
-           glib:type-name="GdkPixbufLoader"
-           glib:get-type="gdk_pixbuf_loader_get_type"
-           glib:type-struct="PixbufLoaderClass">
+    <class name="PixbufLoader" c:symbol-prefix="pixbuf_loader" c:type="GdkPixbufLoader" parent="GObject.Object" glib:type-name="GdkPixbufLoader" glib:get-type="gdk_pixbuf_loader_get_type" glib:type-struct="PixbufLoaderClass">
       <doc xml:space="preserve">The GdkPixbufLoader struct contains only private
 fields.</doc>
       <constructor name="new" c:identifier="gdk_pixbuf_loader_new">
@@ -3197,10 +2765,7 @@ fields.</doc>
           <type name="PixbufLoader" c:type="GdkPixbufLoader*"/>
         </return-value>
       </constructor>
-      <constructor name="new_with_mime_type"
-                   c:identifier="gdk_pixbuf_loader_new_with_mime_type"
-                   version="2.4"
-                   throws="1">
+      <constructor name="new_with_mime_type" c:identifier="gdk_pixbuf_loader_new_with_mime_type" version="2.4" throws="1">
         <doc xml:space="preserve">Creates a new pixbuf loader object that always attempts to parse
 image data as if it were an image of mime type @mime_type, instead of
 identifying the type automatically. Useful if you want an error if
@@ -3225,9 +2790,7 @@ structs returned by gdk_pixbuf_get_formats().</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_with_type"
-                   c:identifier="gdk_pixbuf_loader_new_with_type"
-                   throws="1">
+      <constructor name="new_with_type" c:identifier="gdk_pixbuf_loader_new_with_type" throws="1">
         <doc xml:space="preserve">Creates a new pixbuf loader object that always attempts to parse
 image data as if it were an image of type @image_type, instead of
 identifying the type automatically. Useful if you want an error if
@@ -3334,8 +2897,7 @@ use it anymore, please g_object_unref() it.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_animation"
-              c:identifier="gdk_pixbuf_loader_get_animation">
+      <method name="get_animation" c:identifier="gdk_pixbuf_loader_get_animation">
         <doc xml:space="preserve">Queries the #GdkPixbufAnimation that a pixbuf loader is currently creating.
 In general it only makes sense to call this function after the "area-prepared"
 signal has been emitted by the loader. If the loader doesn't have enough
@@ -3353,9 +2915,7 @@ not enough data has been read to determine the information.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_format"
-              c:identifier="gdk_pixbuf_loader_get_format"
-              version="2.2">
+      <method name="get_format" c:identifier="gdk_pixbuf_loader_get_format" version="2.2">
         <doc xml:space="preserve">Obtains the available information about the format of the
 currently loading image file.</doc>
         <return-value transfer-ownership="none" nullable="1">
@@ -3395,9 +2955,7 @@ enough data has been read to determine how to create the image buffer.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_size"
-              c:identifier="gdk_pixbuf_loader_set_size"
-              version="2.2">
+      <method name="set_size" c:identifier="gdk_pixbuf_loader_set_size" version="2.2">
         <doc xml:space="preserve">Causes the image to be scaled while it is loaded. The desired
 image size can be determined relative to the original size of
 the image by calling gdk_pixbuf_loader_set_size() from a
@@ -3452,10 +3010,7 @@ cannot parse the buffer.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="write_bytes"
-              c:identifier="gdk_pixbuf_loader_write_bytes"
-              version="2.30"
-              throws="1">
+      <method name="write_bytes" c:identifier="gdk_pixbuf_loader_write_bytes" version="2.30" throws="1">
         <doc xml:space="preserve">This will cause a pixbuf loader to parse a buffer inside a #GBytes
 for an image.  It will return %TRUE if the data was loaded successfully,
 and %FALSE if an error occurred.  In the latter case, the loader
@@ -3553,9 +3108,7 @@ the desired size to which the image should be scaled.</doc>
         </parameters>
       </glib:signal>
     </class>
-    <record name="PixbufLoaderClass"
-            c:type="GdkPixbufLoaderClass"
-            glib:is-gtype-struct-for="PixbufLoader">
+    <record name="PixbufLoaderClass" c:type="GdkPixbufLoaderClass" glib:is-gtype-struct-for="PixbufLoader">
       <field name="parent_class">
         <type name="GObject.ObjectClass" c:type="GObjectClass"/>
       </field>
@@ -3626,34 +3179,19 @@ the desired size to which the image should be scaled.</doc>
         </callback>
       </field>
     </record>
-    <enumeration name="PixbufRotation"
-                 glib:type-name="GdkPixbufRotation"
-                 glib:get-type="gdk_pixbuf_rotation_get_type"
-                 c:type="GdkPixbufRotation">
+    <enumeration name="PixbufRotation" glib:type-name="GdkPixbufRotation" glib:get-type="gdk_pixbuf_rotation_get_type" c:type="GdkPixbufRotation">
       <doc xml:space="preserve">The possible rotations which can be passed to gdk_pixbuf_rotate_simple().
 To make them easier to use, their numerical values are the actual degrees.</doc>
-      <member name="none"
-              value="0"
-              c:identifier="GDK_PIXBUF_ROTATE_NONE"
-              glib:nick="none">
+      <member name="none" value="0" c:identifier="GDK_PIXBUF_ROTATE_NONE" glib:nick="none">
         <doc xml:space="preserve">No rotation.</doc>
       </member>
-      <member name="counterclockwise"
-              value="90"
-              c:identifier="GDK_PIXBUF_ROTATE_COUNTERCLOCKWISE"
-              glib:nick="counterclockwise">
+      <member name="counterclockwise" value="90" c:identifier="GDK_PIXBUF_ROTATE_COUNTERCLOCKWISE" glib:nick="counterclockwise">
         <doc xml:space="preserve">Rotate by 90 degrees.</doc>
       </member>
-      <member name="upsidedown"
-              value="180"
-              c:identifier="GDK_PIXBUF_ROTATE_UPSIDEDOWN"
-              glib:nick="upsidedown">
+      <member name="upsidedown" value="180" c:identifier="GDK_PIXBUF_ROTATE_UPSIDEDOWN" glib:nick="upsidedown">
         <doc xml:space="preserve">Rotate by 180 degrees.</doc>
       </member>
-      <member name="clockwise"
-              value="270"
-              c:identifier="GDK_PIXBUF_ROTATE_CLOCKWISE"
-              glib:nick="clockwise">
+      <member name="clockwise" value="270" c:identifier="GDK_PIXBUF_ROTATE_CLOCKWISE" glib:nick="clockwise">
         <doc xml:space="preserve">Rotate by 270 degrees.</doc>
       </member>
     </enumeration>
@@ -3679,34 +3217,19 @@ will fail with the same error.</doc>
           <doc xml:space="preserve">number of bytes in @buf.</doc>
           <type name="gsize" c:type="gsize"/>
         </parameter>
-        <parameter name="error"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="error" direction="out" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">A location to return an error.</doc>
           <type name="GLib.Error" c:type="GError**"/>
         </parameter>
-        <parameter name="data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1"
-                   closure="3">
+        <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1" closure="3">
           <doc xml:space="preserve">user data passed to gdk_pixbuf_save_to_callback().</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
       </parameters>
     </callback>
-    <class name="PixbufSimpleAnim"
-           c:symbol-prefix="pixbuf_simple_anim"
-           c:type="GdkPixbufSimpleAnim"
-           parent="PixbufAnimation"
-           glib:type-name="GdkPixbufSimpleAnim"
-           glib:get-type="gdk_pixbuf_simple_anim_get_type"
-           glib:type-struct="PixbufSimpleAnimClass">
+    <class name="PixbufSimpleAnim" c:symbol-prefix="pixbuf_simple_anim" c:type="GdkPixbufSimpleAnim" parent="PixbufAnimation" glib:type-name="GdkPixbufSimpleAnim" glib:get-type="gdk_pixbuf_simple_anim_get_type" glib:type-struct="PixbufSimpleAnimClass">
       <doc xml:space="preserve">An opaque struct representing a simple animation.</doc>
-      <constructor name="new"
-                   c:identifier="gdk_pixbuf_simple_anim_new"
-                   version="2.8">
+      <constructor name="new" c:identifier="gdk_pixbuf_simple_anim_new" version="2.8">
         <doc xml:space="preserve">Creates a new, empty animation.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a newly allocated #GdkPixbufSimpleAnim</doc>
@@ -3727,9 +3250,7 @@ will fail with the same error.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <method name="add_frame"
-              c:identifier="gdk_pixbuf_simple_anim_add_frame"
-              version="2.8">
+      <method name="add_frame" c:identifier="gdk_pixbuf_simple_anim_add_frame" version="2.8">
         <doc xml:space="preserve">Adds a new frame to @animation. The @pixbuf must
 have the dimensions specified when the animation
 was constructed.</doc>
@@ -3747,9 +3268,7 @@ was constructed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_loop"
-              c:identifier="gdk_pixbuf_simple_anim_get_loop"
-              version="2.18">
+      <method name="get_loop" c:identifier="gdk_pixbuf_simple_anim_get_loop" version="2.18">
         <doc xml:space="preserve">Gets whether @animation should loop indefinitely when it reaches the end.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE if the animation loops forever, %FALSE otherwise</doc>
@@ -3762,9 +3281,7 @@ was constructed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_loop"
-              c:identifier="gdk_pixbuf_simple_anim_set_loop"
-              version="2.18">
+      <method name="set_loop" c:identifier="gdk_pixbuf_simple_anim_set_loop" version="2.18">
         <doc xml:space="preserve">Sets whether @animation should loop indefinitely when it reaches the end.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -3780,24 +3297,14 @@ was constructed.</doc>
           </parameter>
         </parameters>
       </method>
-      <property name="loop"
-                version="2.18"
-                writable="1"
-                transfer-ownership="none">
+      <property name="loop" version="2.18" writable="1" transfer-ownership="none">
         <doc xml:space="preserve">Whether the animation should loop when it reaches the end.</doc>
         <type name="gboolean" c:type="gboolean"/>
       </property>
     </class>
-    <record name="PixbufSimpleAnimClass"
-            c:type="GdkPixbufSimpleAnimClass"
-            disguised="1"
-            glib:is-gtype-struct-for="PixbufSimpleAnim">
+    <record name="PixbufSimpleAnimClass" c:type="GdkPixbufSimpleAnimClass" disguised="1" glib:is-gtype-struct-for="PixbufSimpleAnim">
     </record>
-    <class name="PixbufSimpleAnimIter"
-           c:symbol-prefix="pixbuf_simple_anim_iter"
-           parent="PixbufAnimationIter"
-           glib:type-name="GdkPixbufSimpleAnimIter"
-           glib:get-type="gdk_pixbuf_simple_anim_iter_get_type">
+    <class name="PixbufSimpleAnimIter" c:symbol-prefix="pixbuf_simple_anim_iter" parent="PixbufAnimationIter" glib:type-name="GdkPixbufSimpleAnimIter" glib:get-type="gdk_pixbuf_simple_anim_iter_get_type">
     </class>
     <record name="Pixdata" c:type="GdkPixdata">
       <doc xml:space="preserve">A #GdkPixdata contains pixbuf information in a form suitable for
@@ -3836,11 +3343,7 @@ serialization and streaming.</doc>
           <type name="guint8"/>
         </array>
       </field>
-      <method name="deserialize"
-              c:identifier="gdk_pixdata_deserialize"
-              deprecated="1"
-              deprecated-version="2.32"
-              throws="1">
+      <method name="deserialize" c:identifier="gdk_pixdata_deserialize" deprecated="1" deprecated-version="2.32" throws="1">
         <doc xml:space="preserve">Deserializes (reconstruct) a #GdkPixdata structure from a byte stream.
 The byte stream consists of a straightforward writeout of the
 #GdkPixdata fields in network byte order, plus the @pixel_data
@@ -3872,11 +3375,7 @@ or %GDK_PIXBUF_ERROR_UNKNOWN_TYPE.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="from_pixbuf"
-              c:identifier="gdk_pixdata_from_pixbuf"
-              introspectable="0"
-              deprecated="1"
-              deprecated-version="2.32">
+      <method name="from_pixbuf" c:identifier="gdk_pixdata_from_pixbuf" introspectable="0" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Converts a #GdkPixbuf to a #GdkPixdata. If @use_rle is %TRUE, the
 pixel data is run-length encoded into newly-allocated memory and a
 pointer to that memory is returned.</doc>
@@ -3902,10 +3401,7 @@ pointer to that memory is returned.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="serialize"
-              c:identifier="gdk_pixdata_serialize"
-              deprecated="1"
-              deprecated-version="2.32">
+      <method name="serialize" c:identifier="gdk_pixdata_serialize" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Serializes a #GdkPixdata structure into a byte stream.
 The byte stream consists of a straightforward writeout of the
 #GdkPixdata fields in network byte order, plus the @pixel_data
@@ -3924,19 +3420,13 @@ structure.</doc>
             <doc xml:space="preserve">a valid #GdkPixdata structure to serialize.</doc>
             <type name="Pixdata" c:type="const GdkPixdata*"/>
           </instance-parameter>
-          <parameter name="stream_length_p"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="stream_length_p" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store the resulting stream length in.</doc>
             <type name="guint" c:type="guint*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="to_csource"
-              c:identifier="gdk_pixdata_to_csource"
-              deprecated="1"
-              deprecated-version="2.32">
+      <method name="to_csource" c:identifier="gdk_pixdata_to_csource" deprecated="1" deprecated-version="2.32">
         <doc xml:space="preserve">Generates C source code suitable for compiling images directly
 into programs.
 
@@ -3973,16 +3463,12 @@ determine the form of C source to be generated. The three values
 and @GDK_PIXDATA_DUMP_MACROS are mutually exclusive, as are
 @GDK_PIXBUF_DUMP_GTYPES and @GDK_PIXBUF_DUMP_CTYPES. The remaining
 elements are optional flags that can be freely added.</doc>
-      <member name="pixdata_stream"
-              value="0"
-              c:identifier="GDK_PIXDATA_DUMP_PIXDATA_STREAM">
+      <member name="pixdata_stream" value="0" c:identifier="GDK_PIXDATA_DUMP_PIXDATA_STREAM">
         <doc xml:space="preserve">Generate pixbuf data stream (a single
    string containing a serialized #GdkPixdata structure in network byte
    order).</doc>
       </member>
-      <member name="pixdata_struct"
-              value="1"
-              c:identifier="GDK_PIXDATA_DUMP_PIXDATA_STRUCT">
+      <member name="pixdata_struct" value="1" c:identifier="GDK_PIXDATA_DUMP_PIXDATA_STRUCT">
         <doc xml:space="preserve">Generate #GdkPixdata structure (needs
    the #GdkPixdata structure definition from gdk-pixdata.h).</doc>
       </member>
@@ -4007,9 +3493,7 @@ elements are optional flags that can be freely added.</doc>
       <member name="const" value="1024" c:identifier="GDK_PIXDATA_DUMP_CONST">
         <doc xml:space="preserve">Generate const symbols.</doc>
       </member>
-      <member name="rle_decoder"
-              value="65536"
-              c:identifier="GDK_PIXDATA_DUMP_RLE_DECODER">
+      <member name="rle_decoder" value="65536" c:identifier="GDK_PIXDATA_DUMP_RLE_DECODER">
         <doc xml:space="preserve">Provide a &lt;function&gt;*_RUN_LENGTH_DECODE(image_buf, rle_data, size, bpp)&lt;/function&gt;
    macro definition  to  decode  run-length encoded image data.</doc>
       </member>
@@ -4018,55 +3502,37 @@ elements are optional flags that can be freely added.</doc>
       <doc xml:space="preserve">An enumeration containing three sets of flags for a #GdkPixdata struct:
 one for the used colorspace, one for the width of the samples and one
 for the encoding of the pixel data.</doc>
-      <member name="color_type_rgb"
-              value="1"
-              c:identifier="GDK_PIXDATA_COLOR_TYPE_RGB">
+      <member name="color_type_rgb" value="1" c:identifier="GDK_PIXDATA_COLOR_TYPE_RGB">
         <doc xml:space="preserve">each pixel has red, green and blue samples.</doc>
       </member>
-      <member name="color_type_rgba"
-              value="2"
-              c:identifier="GDK_PIXDATA_COLOR_TYPE_RGBA">
+      <member name="color_type_rgba" value="2" c:identifier="GDK_PIXDATA_COLOR_TYPE_RGBA">
         <doc xml:space="preserve">each pixel has red, green and blue samples
    and an alpha value.</doc>
       </member>
-      <member name="color_type_mask"
-              value="255"
-              c:identifier="GDK_PIXDATA_COLOR_TYPE_MASK">
+      <member name="color_type_mask" value="255" c:identifier="GDK_PIXDATA_COLOR_TYPE_MASK">
         <doc xml:space="preserve">mask for the colortype flags of the enum.</doc>
       </member>
-      <member name="sample_width_8"
-              value="65536"
-              c:identifier="GDK_PIXDATA_SAMPLE_WIDTH_8">
+      <member name="sample_width_8" value="65536" c:identifier="GDK_PIXDATA_SAMPLE_WIDTH_8">
         <doc xml:space="preserve">each sample has 8 bits.</doc>
       </member>
-      <member name="sample_width_mask"
-              value="983040"
-              c:identifier="GDK_PIXDATA_SAMPLE_WIDTH_MASK">
+      <member name="sample_width_mask" value="983040" c:identifier="GDK_PIXDATA_SAMPLE_WIDTH_MASK">
         <doc xml:space="preserve">mask for the sample width flags of the enum.</doc>
       </member>
-      <member name="encoding_raw"
-              value="16777216"
-              c:identifier="GDK_PIXDATA_ENCODING_RAW">
+      <member name="encoding_raw" value="16777216" c:identifier="GDK_PIXDATA_ENCODING_RAW">
         <doc xml:space="preserve">the pixel data is in raw form.</doc>
       </member>
-      <member name="encoding_rle"
-              value="33554432"
-              c:identifier="GDK_PIXDATA_ENCODING_RLE">
+      <member name="encoding_rle" value="33554432" c:identifier="GDK_PIXDATA_ENCODING_RLE">
         <doc xml:space="preserve">the pixel data is run-length encoded. Runs may
    be up to 127 bytes long; their length is stored in a single byte
    preceding the pixel data for the run. If a run is constant, its length
    byte has the high bit set and the pixel data consists of a single pixel
    which must be repeated.</doc>
       </member>
-      <member name="encoding_mask"
-              value="251658240"
-              c:identifier="GDK_PIXDATA_ENCODING_MASK">
+      <member name="encoding_mask" value="251658240" c:identifier="GDK_PIXDATA_ENCODING_MASK">
         <doc xml:space="preserve">mask for the encoding flags of the enum.</doc>
       </member>
     </bitfield>
-    <function name="pixbuf_error_quark"
-              c:identifier="gdk_pixbuf_error_quark"
-              moved-to="PixbufError.quark">
+    <function name="pixbuf_error_quark" c:identifier="gdk_pixbuf_error_quark" moved-to="PixbufError.quark">
       <return-value transfer-ownership="none">
         <type name="GLib.Quark" c:type="GQuark"/>
       </return-value>

--- a/Pango-1.0.gir
+++ b/Pango-1.0.gir
@@ -7,7 +7,7 @@ and/or use gtk-doc annotations.  -->
   <include name="cairo" version="1.0"/>
   <package name="pango"/>
   <c:include name="pango/pango.h"/>
-  <namespace name="Pango" version="1.0" shared-library="libpango-1.0.so.0" c:identifier-prefixes="Pango" c:symbol-prefixes="pango">
+  <c:include name="pango/pango-modules.h"/><namespace name="Pango" version="1.0" shared-library="libpango-1.0.so.0" c:identifier-prefixes="Pango" c:symbol-prefixes="pango">
     <alias name="Glyph" c:type="PangoGlyph">
       <doc xml:space="preserve">A #PangoGlyph represents a single glyph in the output form of a string.</doc>
       <type name="guint32" c:type="guint32"/>

--- a/Pango-1.0.gir
+++ b/Pango-1.0.gir
@@ -2,19 +2,12 @@
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
-<repository version="1.2"
-            xmlns="http://www.gtk.org/introspection/core/1.0"
-            xmlns:c="http://www.gtk.org/introspection/c/1.0"
-            xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+<repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0" version="1.2">
   <include name="GObject" version="2.0"/>
   <include name="cairo" version="1.0"/>
   <package name="pango"/>
   <c:include name="pango/pango.h"/>
-  <namespace name="Pango"
-             version="1.0"
-             shared-library="libpango-1.0.so.0"
-             c:identifier-prefixes="Pango"
-             c:symbol-prefixes="pango">
+  <namespace name="Pango" version="1.0" shared-library="libpango-1.0.so.0" c:identifier-prefixes="Pango" c:symbol-prefixes="pango">
     <alias name="Glyph" c:type="PangoGlyph">
       <doc xml:space="preserve">A #PangoGlyph represents a single glyph in the output form of a string.</doc>
       <type name="guint32" c:type="guint32"/>
@@ -36,53 +29,32 @@ a #PangoLayoutLine; it is simply an alternate name for
 See the #PangoGlyphItem docs for details on the fields.</doc>
       <type name="GlyphItem" c:type="PangoGlyphItem"/>
     </alias>
-    <constant name="ANALYSIS_FLAG_CENTERED_BASELINE"
-              value="1"
-              c:type="PANGO_ANALYSIS_FLAG_CENTERED_BASELINE"
-              version="1.16">
+    <constant name="ANALYSIS_FLAG_CENTERED_BASELINE" value="1" c:type="PANGO_ANALYSIS_FLAG_CENTERED_BASELINE" version="1.16">
       <doc xml:space="preserve">Whether the segment should be shifted to center around the baseline.
 Used in vertical writing directions mostly.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="ANALYSIS_FLAG_IS_ELLIPSIS"
-              value="2"
-              c:type="PANGO_ANALYSIS_FLAG_IS_ELLIPSIS"
-              version="1.36.7">
+    <constant name="ANALYSIS_FLAG_IS_ELLIPSIS" value="2" c:type="PANGO_ANALYSIS_FLAG_IS_ELLIPSIS" version="1.36.7">
       <doc xml:space="preserve">This flag is used to mark runs that hold ellipsized text,
 in an ellipsized layout.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="ATTR_INDEX_FROM_TEXT_BEGINNING"
-              value="0"
-              c:type="PANGO_ATTR_INDEX_FROM_TEXT_BEGINNING"
-              version="1.24">
+    <constant name="ATTR_INDEX_FROM_TEXT_BEGINNING" value="0" c:type="PANGO_ATTR_INDEX_FROM_TEXT_BEGINNING" version="1.24">
       <doc xml:space="preserve">This value can be used to set the start_index member of a #PangoAttribute
 such that the attribute covers from the beginning of the text.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <enumeration name="Alignment"
-                 glib:type-name="PangoAlignment"
-                 glib:get-type="pango_alignment_get_type"
-                 c:type="PangoAlignment">
+    <enumeration name="Alignment" glib:type-name="PangoAlignment" glib:get-type="pango_alignment_get_type" c:type="PangoAlignment">
       <doc xml:space="preserve">A #PangoAlignment describes how to align the lines of a #PangoLayout within the
 available space. If the #PangoLayout is set to justify
 using pango_layout_set_justify(), this only has effect for partial lines.</doc>
-      <member name="left"
-              value="0"
-              c:identifier="PANGO_ALIGN_LEFT"
-              glib:nick="left">
+      <member name="left" value="0" c:identifier="PANGO_ALIGN_LEFT" glib:nick="left">
         <doc xml:space="preserve">Put all available space on the right</doc>
       </member>
-      <member name="center"
-              value="1"
-              c:identifier="PANGO_ALIGN_CENTER"
-              glib:nick="center">
+      <member name="center" value="1" c:identifier="PANGO_ALIGN_CENTER" glib:nick="center">
         <doc xml:space="preserve">Center the line within the available space</doc>
       </member>
-      <member name="right"
-              value="2"
-              c:identifier="PANGO_ALIGN_RIGHT"
-              glib:nick="right">
+      <member name="right" value="2" c:identifier="PANGO_ALIGN_RIGHT" glib:nick="right">
         <doc xml:space="preserve">Put all available space on the left</doc>
       </member>
     </enumeration>
@@ -196,11 +168,7 @@ are colors.</doc>
         <type name="gpointer" c:type="gpointer"/>
       </return-value>
       <parameters>
-        <parameter name="user_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1"
-                   closure="0">
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="0">
           <doc xml:space="preserve">user data to copy</doc>
           <type name="gpointer" c:type="gconstpointer"/>
         </parameter>
@@ -218,11 +186,7 @@ filtering, %FALSE otherwise.</doc>
           <doc xml:space="preserve">a Pango attribute</doc>
           <type name="Attribute" c:type="PangoAttribute*"/>
         </parameter>
-        <parameter name="user_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1"
-                   closure="1">
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
           <doc xml:space="preserve">user data passed to the function</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
@@ -251,9 +215,7 @@ sets all aspects of the font description at once.</doc>
         <doc xml:space="preserve">the font description which is the value of this attribute</doc>
         <type name="FontDescription" c:type="PangoFontDescription*"/>
       </field>
-      <function name="new"
-                c:identifier="pango_attr_font_desc_new"
-                introspectable="0">
+      <function name="new" c:identifier="pango_attr_font_desc_new" introspectable="0">
         <doc xml:space="preserve">Create a new font description attribute. This attribute
 allows setting family, style, weight, variant, stretch,
 and size simultaneously.</doc>
@@ -270,9 +232,7 @@ and size simultaneously.</doc>
         </parameters>
       </function>
     </record>
-    <record name="AttrFontFeatures"
-            c:type="PangoAttrFontFeatures"
-            version="1.38">
+    <record name="AttrFontFeatures" c:type="PangoAttrFontFeatures" version="1.38">
       <doc xml:space="preserve">The #PangoAttrFontFeatures structure is used to represent OpenType
 font features as an attribute.</doc>
       <field name="attr" writable="1">
@@ -283,10 +243,7 @@ font features as an attribute.</doc>
         <doc xml:space="preserve">the featues, as a string in CSS syntax</doc>
         <type name="utf8" c:type="gchar*"/>
       </field>
-      <function name="new"
-                c:identifier="pango_attr_font_features_new"
-                version="1.38"
-                introspectable="0">
+      <function name="new" c:identifier="pango_attr_font_features_new" version="1.38" introspectable="0">
         <doc xml:space="preserve">Create a new font features tag attribute.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -321,9 +278,7 @@ is created, it can be advanced through the style changes
 in the text using pango_attr_iterator_next(). At each
 style change, the range of the current style segment and the
 attributes currently in effect can be queried.</doc>
-      <method name="copy"
-              c:identifier="pango_attr_iterator_copy"
-              introspectable="0">
+      <method name="copy" c:identifier="pango_attr_iterator_copy" introspectable="0">
         <doc xml:space="preserve">Copy a #PangoAttrIterator</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">the newly allocated
@@ -350,9 +305,7 @@ attributes currently in effect can be queried.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get"
-              c:identifier="pango_attr_iterator_get"
-              introspectable="0">
+      <method name="get" c:identifier="pango_attr_iterator_get" introspectable="0">
         <doc xml:space="preserve">Find the current attribute of a particular type at the iterator
 location. When multiple attributes of the same type overlap,
 the attribute whose range starts closest to the current location
@@ -374,9 +327,7 @@ is used.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_attrs"
-              c:identifier="pango_attr_iterator_get_attrs"
-              version="1.2">
+      <method name="get_attrs" c:identifier="pango_attr_iterator_get_attrs" version="1.2">
         <doc xml:space="preserve">Gets a list of all attributes at the current position of the
 iterator.</doc>
         <return-value transfer-ownership="full">
@@ -414,18 +365,12 @@ iterator.</doc>
        &lt;literal&gt;pango_font_description_set_family (desc, pango_font_description_get_family (desc))&lt;/literal&gt;.</doc>
             <type name="FontDescription" c:type="PangoFontDescription*"/>
           </parameter>
-          <parameter name="language"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="language" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">if non-%NULL, location to store language tag for item, or %NULL
            if none is found.</doc>
             <type name="Language" c:type="PangoLanguage**"/>
           </parameter>
-          <parameter name="extra_attrs"
-                     transfer-ownership="full"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="extra_attrs" transfer-ownership="full" nullable="1" allow-none="1">
             <doc xml:space="preserve">if non-%NULL,
           location in which to store a list of non-font
           attributes at the the current position; only the highest priority
@@ -465,17 +410,11 @@ a signed integer are clamped to %G_MAXINT.</doc>
             <doc xml:space="preserve">a #PangoAttrIterator</doc>
             <type name="AttrIterator" c:type="PangoAttrIterator*"/>
           </instance-parameter>
-          <parameter name="start"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="start" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store the start of the range</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
-          <parameter name="end"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="end" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store the end of the range</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
@@ -493,9 +432,7 @@ are languages.</doc>
         <doc xml:space="preserve">the #PangoLanguage which is the value of the attribute</doc>
         <type name="Language" c:type="PangoLanguage*"/>
       </field>
-      <function name="new"
-                c:identifier="pango_attr_language_new"
-                introspectable="0">
+      <function name="new" c:identifier="pango_attr_language_new" introspectable="0">
         <doc xml:space="preserve">Create a new language tag attribute.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -510,11 +447,7 @@ are languages.</doc>
         </parameters>
       </function>
     </record>
-    <record name="AttrList"
-            c:type="PangoAttrList"
-            glib:type-name="PangoAttrList"
-            glib:get-type="pango_attr_list_get_type"
-            c:symbol-prefix="attr_list">
+    <record name="AttrList" c:type="PangoAttrList" glib:type-name="PangoAttrList" glib:get-type="pango_attr_list_get_type" c:symbol-prefix="attr_list">
       <doc xml:space="preserve">The #PangoAttrList structure represents a list of attributes
 that apply to a section of text. The attributes are, in general,
 allowed to overlap in an arbitrary fashion, however, if the
@@ -568,18 +501,13 @@ since it never removes or combines existing attributes.</doc>
           <type name="AttrList" c:type="PangoAttrList*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="list"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="list" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoAttrList, may be %NULL</doc>
             <type name="AttrList" c:type="PangoAttrList*"/>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="filter"
-              c:identifier="pango_attr_list_filter"
-              version="1.2">
+      <method name="filter" c:identifier="pango_attr_list_filter" version="1.2">
         <doc xml:space="preserve">Given a #PangoAttrList and callback function, removes any elements
 of @list for which @func returns %TRUE and inserts them into
 a new list.</doc>
@@ -593,26 +521,18 @@ a new list.</doc>
             <doc xml:space="preserve">a #PangoAttrList</doc>
             <type name="AttrList" c:type="PangoAttrList*"/>
           </instance-parameter>
-          <parameter name="func"
-                     transfer-ownership="none"
-                     scope="call"
-                     closure="1">
+          <parameter name="func" transfer-ownership="none" scope="call" closure="1">
             <doc xml:space="preserve">callback function; returns %TRUE
        if an attribute should be filtered out.</doc>
             <type name="AttrFilterFunc" c:type="PangoAttrFilterFunc"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">Data to be passed to @func</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
       </method>
-      <method name="get_iterator"
-              c:identifier="pango_attr_list_get_iterator"
-              introspectable="0">
+      <method name="get_iterator" c:identifier="pango_attr_list_get_iterator" introspectable="0">
         <doc xml:space="preserve">Create a iterator initialized to the beginning of the list.
 @list must not be modified until this iterator is freed.</doc>
         <return-value transfer-ownership="full">
@@ -646,8 +566,7 @@ be inserted after all other attributes with a matching
           </parameter>
         </parameters>
       </method>
-      <method name="insert_before"
-              c:identifier="pango_attr_list_insert_before">
+      <method name="insert_before" c:identifier="pango_attr_list_insert_before">
         <doc xml:space="preserve">Insert the given attribute into the #PangoAttrList. It will
 be inserted before all other attributes with a matching
 @start_index.</doc>
@@ -673,10 +592,7 @@ be inserted before all other attributes with a matching
           <type name="AttrList" c:type="PangoAttrList*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="list"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="list" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoAttrList, may be %NULL</doc>
             <type name="AttrList" c:type="PangoAttrList*"/>
           </instance-parameter>
@@ -725,10 +641,7 @@ it contains.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="list"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="list" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoAttrList, may be %NULL</doc>
             <type name="AttrList" c:type="PangoAttrList*"/>
           </instance-parameter>
@@ -762,9 +675,7 @@ impose shape restrictions.</doc>
         <doc xml:space="preserve">destroy function for the user data</doc>
         <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
       </field>
-      <function name="new"
-                c:identifier="pango_attr_shape_new"
-                introspectable="0">
+      <function name="new" c:identifier="pango_attr_shape_new" introspectable="0">
         <doc xml:space="preserve">Create a new shape attribute. A shape is used to impose a
 particular ink and logical rectangle on the result of shaping a
 particular glyph. This might be used, for instance, for
@@ -785,10 +696,7 @@ embedding a picture or a widget inside a #PangoLayout.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="new_with_data"
-                c:identifier="pango_attr_shape_new_with_data"
-                version="1.8"
-                introspectable="0">
+      <function name="new_with_data" c:identifier="pango_attr_shape_new_with_data" version="1.8" introspectable="0">
         <doc xml:space="preserve">Like pango_attr_shape_new(), but a user data pointer is also
 provided; this pointer can be accessed when later
 rendering the glyph.</doc>
@@ -806,29 +714,17 @@ rendering the glyph.</doc>
             <doc xml:space="preserve">logical rectangle to assign to each character</doc>
             <type name="Rectangle" c:type="const PangoRectangle*"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">user data pointer</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
-          <parameter name="copy_func"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="notified"
-                     destroy="4">
+          <parameter name="copy_func" transfer-ownership="none" nullable="1" allow-none="1" scope="notified" destroy="4">
             <doc xml:space="preserve">function to copy @data when the
                attribute is copied. If %NULL, @data is simply
                copied as a pointer.</doc>
             <type name="AttrDataCopyFunc" c:type="PangoAttrDataCopyFunc"/>
           </parameter>
-          <parameter name="destroy_func"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1"
-                     scope="async">
+          <parameter name="destroy_func" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
             <doc xml:space="preserve">function to free @data when the
                attribute is freed, or %NULL</doc>
             <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
@@ -855,9 +751,7 @@ This field is only present for compatibility with Pango-1.8.0
 be %FALSE for %PANGO_ATTR_SIZE and %TRUE for %PANGO_ATTR_ABSOLUTE_SIZE.</doc>
         <type name="guint" c:type="guint"/>
       </field>
-      <function name="new"
-                c:identifier="pango_attr_size_new"
-                introspectable="0">
+      <function name="new" c:identifier="pango_attr_size_new" introspectable="0">
         <doc xml:space="preserve">Create a new font-size attribute in fractional points.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -871,10 +765,7 @@ be %FALSE for %PANGO_ATTR_SIZE and %TRUE for %PANGO_ATTR_ABSOLUTE_SIZE.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="new_absolute"
-                c:identifier="pango_attr_size_new_absolute"
-                version="1.8"
-                introspectable="0">
+      <function name="new_absolute" c:identifier="pango_attr_size_new_absolute" version="1.8" introspectable="0">
         <doc xml:space="preserve">Create a new font-size attribute in device units.</doc>
         <return-value>
           <doc xml:space="preserve">the newly allocated #PangoAttribute, which should be
@@ -901,175 +792,92 @@ a string value.</doc>
         <type name="utf8" c:type="char*"/>
       </field>
     </record>
-    <enumeration name="AttrType"
-                 glib:type-name="PangoAttrType"
-                 glib:get-type="pango_attr_type_get_type"
-                 c:type="PangoAttrType">
+    <enumeration name="AttrType" glib:type-name="PangoAttrType" glib:get-type="pango_attr_type_get_type" c:type="PangoAttrType">
       <doc xml:space="preserve">The #PangoAttrType
 distinguishes between different types of attributes. Along with the
 predefined values, it is possible to allocate additional values
 for custom attributes using pango_attr_type_register(). The predefined
 values are given below. The type of structure used to store the
 attribute is listed in parentheses after the description.</doc>
-      <member name="invalid"
-              value="0"
-              c:identifier="PANGO_ATTR_INVALID"
-              glib:nick="invalid">
+      <member name="invalid" value="0" c:identifier="PANGO_ATTR_INVALID" glib:nick="invalid">
         <doc xml:space="preserve">does not happen</doc>
       </member>
-      <member name="language"
-              value="1"
-              c:identifier="PANGO_ATTR_LANGUAGE"
-              glib:nick="language">
+      <member name="language" value="1" c:identifier="PANGO_ATTR_LANGUAGE" glib:nick="language">
         <doc xml:space="preserve">language (#PangoAttrLanguage)</doc>
       </member>
-      <member name="family"
-              value="2"
-              c:identifier="PANGO_ATTR_FAMILY"
-              glib:nick="family">
+      <member name="family" value="2" c:identifier="PANGO_ATTR_FAMILY" glib:nick="family">
         <doc xml:space="preserve">font family name list (#PangoAttrString)</doc>
       </member>
-      <member name="style"
-              value="3"
-              c:identifier="PANGO_ATTR_STYLE"
-              glib:nick="style">
+      <member name="style" value="3" c:identifier="PANGO_ATTR_STYLE" glib:nick="style">
         <doc xml:space="preserve">font slant style (#PangoAttrInt)</doc>
       </member>
-      <member name="weight"
-              value="4"
-              c:identifier="PANGO_ATTR_WEIGHT"
-              glib:nick="weight">
+      <member name="weight" value="4" c:identifier="PANGO_ATTR_WEIGHT" glib:nick="weight">
         <doc xml:space="preserve">font weight (#PangoAttrInt)</doc>
       </member>
-      <member name="variant"
-              value="5"
-              c:identifier="PANGO_ATTR_VARIANT"
-              glib:nick="variant">
+      <member name="variant" value="5" c:identifier="PANGO_ATTR_VARIANT" glib:nick="variant">
         <doc xml:space="preserve">font variant (normal or small caps) (#PangoAttrInt)</doc>
       </member>
-      <member name="stretch"
-              value="6"
-              c:identifier="PANGO_ATTR_STRETCH"
-              glib:nick="stretch">
+      <member name="stretch" value="6" c:identifier="PANGO_ATTR_STRETCH" glib:nick="stretch">
         <doc xml:space="preserve">font stretch (#PangoAttrInt)</doc>
       </member>
-      <member name="size"
-              value="7"
-              c:identifier="PANGO_ATTR_SIZE"
-              glib:nick="size">
+      <member name="size" value="7" c:identifier="PANGO_ATTR_SIZE" glib:nick="size">
         <doc xml:space="preserve">font size in points scaled by %PANGO_SCALE (#PangoAttrInt)</doc>
       </member>
-      <member name="font_desc"
-              value="8"
-              c:identifier="PANGO_ATTR_FONT_DESC"
-              glib:nick="font-desc">
+      <member name="font_desc" value="8" c:identifier="PANGO_ATTR_FONT_DESC" glib:nick="font-desc">
         <doc xml:space="preserve">font description (#PangoAttrFontDesc)</doc>
       </member>
-      <member name="foreground"
-              value="9"
-              c:identifier="PANGO_ATTR_FOREGROUND"
-              glib:nick="foreground">
+      <member name="foreground" value="9" c:identifier="PANGO_ATTR_FOREGROUND" glib:nick="foreground">
         <doc xml:space="preserve">foreground color (#PangoAttrColor)</doc>
       </member>
-      <member name="background"
-              value="10"
-              c:identifier="PANGO_ATTR_BACKGROUND"
-              glib:nick="background">
+      <member name="background" value="10" c:identifier="PANGO_ATTR_BACKGROUND" glib:nick="background">
         <doc xml:space="preserve">background color (#PangoAttrColor)</doc>
       </member>
-      <member name="underline"
-              value="11"
-              c:identifier="PANGO_ATTR_UNDERLINE"
-              glib:nick="underline">
+      <member name="underline" value="11" c:identifier="PANGO_ATTR_UNDERLINE" glib:nick="underline">
         <doc xml:space="preserve">whether the text has an underline (#PangoAttrInt)</doc>
       </member>
-      <member name="strikethrough"
-              value="12"
-              c:identifier="PANGO_ATTR_STRIKETHROUGH"
-              glib:nick="strikethrough">
+      <member name="strikethrough" value="12" c:identifier="PANGO_ATTR_STRIKETHROUGH" glib:nick="strikethrough">
         <doc xml:space="preserve">whether the text is struck-through (#PangoAttrInt)</doc>
       </member>
-      <member name="rise"
-              value="13"
-              c:identifier="PANGO_ATTR_RISE"
-              glib:nick="rise">
+      <member name="rise" value="13" c:identifier="PANGO_ATTR_RISE" glib:nick="rise">
         <doc xml:space="preserve">baseline displacement (#PangoAttrInt)</doc>
       </member>
-      <member name="shape"
-              value="14"
-              c:identifier="PANGO_ATTR_SHAPE"
-              glib:nick="shape">
+      <member name="shape" value="14" c:identifier="PANGO_ATTR_SHAPE" glib:nick="shape">
         <doc xml:space="preserve">shape (#PangoAttrShape)</doc>
       </member>
-      <member name="scale"
-              value="15"
-              c:identifier="PANGO_ATTR_SCALE"
-              glib:nick="scale">
+      <member name="scale" value="15" c:identifier="PANGO_ATTR_SCALE" glib:nick="scale">
         <doc xml:space="preserve">font size scale factor (#PangoAttrFloat)</doc>
       </member>
-      <member name="fallback"
-              value="16"
-              c:identifier="PANGO_ATTR_FALLBACK"
-              glib:nick="fallback">
+      <member name="fallback" value="16" c:identifier="PANGO_ATTR_FALLBACK" glib:nick="fallback">
         <doc xml:space="preserve">whether fallback is enabled (#PangoAttrInt)</doc>
       </member>
-      <member name="letter_spacing"
-              value="17"
-              c:identifier="PANGO_ATTR_LETTER_SPACING"
-              glib:nick="letter-spacing">
+      <member name="letter_spacing" value="17" c:identifier="PANGO_ATTR_LETTER_SPACING" glib:nick="letter-spacing">
         <doc xml:space="preserve">letter spacing (#PangoAttrInt)</doc>
       </member>
-      <member name="underline_color"
-              value="18"
-              c:identifier="PANGO_ATTR_UNDERLINE_COLOR"
-              glib:nick="underline-color">
+      <member name="underline_color" value="18" c:identifier="PANGO_ATTR_UNDERLINE_COLOR" glib:nick="underline-color">
         <doc xml:space="preserve">underline color (#PangoAttrColor)</doc>
       </member>
-      <member name="strikethrough_color"
-              value="19"
-              c:identifier="PANGO_ATTR_STRIKETHROUGH_COLOR"
-              glib:nick="strikethrough-color">
+      <member name="strikethrough_color" value="19" c:identifier="PANGO_ATTR_STRIKETHROUGH_COLOR" glib:nick="strikethrough-color">
         <doc xml:space="preserve">strikethrough color (#PangoAttrColor)</doc>
       </member>
-      <member name="absolute_size"
-              value="20"
-              c:identifier="PANGO_ATTR_ABSOLUTE_SIZE"
-              glib:nick="absolute-size">
+      <member name="absolute_size" value="20" c:identifier="PANGO_ATTR_ABSOLUTE_SIZE" glib:nick="absolute-size">
         <doc xml:space="preserve">font size in pixels scaled by %PANGO_SCALE (#PangoAttrInt)</doc>
       </member>
-      <member name="gravity"
-              value="21"
-              c:identifier="PANGO_ATTR_GRAVITY"
-              glib:nick="gravity">
+      <member name="gravity" value="21" c:identifier="PANGO_ATTR_GRAVITY" glib:nick="gravity">
         <doc xml:space="preserve">base text gravity (#PangoAttrInt)</doc>
       </member>
-      <member name="gravity_hint"
-              value="22"
-              c:identifier="PANGO_ATTR_GRAVITY_HINT"
-              glib:nick="gravity-hint">
+      <member name="gravity_hint" value="22" c:identifier="PANGO_ATTR_GRAVITY_HINT" glib:nick="gravity-hint">
         <doc xml:space="preserve">gravity hint (#PangoAttrInt)</doc>
       </member>
-      <member name="font_features"
-              value="23"
-              c:identifier="PANGO_ATTR_FONT_FEATURES"
-              glib:nick="font-features">
+      <member name="font_features" value="23" c:identifier="PANGO_ATTR_FONT_FEATURES" glib:nick="font-features">
         <doc xml:space="preserve">OpenType font features (#PangoAttrString). Since 1.38</doc>
       </member>
-      <member name="foreground_alpha"
-              value="24"
-              c:identifier="PANGO_ATTR_FOREGROUND_ALPHA"
-              glib:nick="foreground-alpha">
+      <member name="foreground_alpha" value="24" c:identifier="PANGO_ATTR_FOREGROUND_ALPHA" glib:nick="foreground-alpha">
         <doc xml:space="preserve">foreground alpha (#PangoAttrInt). Since 1.38</doc>
       </member>
-      <member name="background_alpha"
-              value="25"
-              c:identifier="PANGO_ATTR_BACKGROUND_ALPHA"
-              glib:nick="background-alpha">
+      <member name="background_alpha" value="25" c:identifier="PANGO_ATTR_BACKGROUND_ALPHA" glib:nick="background-alpha">
         <doc xml:space="preserve">background alpha (#PangoAttrInt). Since 1.38</doc>
       </member>
-      <function name="get_name"
-                c:identifier="pango_attr_type_get_name"
-                version="1.22">
+      <function name="get_name" c:identifier="pango_attr_type_get_name" version="1.22">
         <doc xml:space="preserve">Fetches the attribute type name passed in when registering the type using
 pango_attr_type_register().
 
@@ -1122,9 +930,7 @@ By default an attribute will have an all-inclusive range of [0,%G_MAXUINT].</doc
 is not included in the range.</doc>
         <type name="guint" c:type="guint"/>
       </field>
-      <method name="copy"
-              c:identifier="pango_attribute_copy"
-              introspectable="0">
+      <method name="copy" c:identifier="pango_attribute_copy" introspectable="0">
         <doc xml:space="preserve">Make a copy of an attribute.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -1190,131 +996,68 @@ to the entire text by default.</doc>
         </parameters>
       </method>
     </record>
-    <enumeration name="BidiType"
-                 version="1.22"
-                 glib:type-name="PangoBidiType"
-                 glib:get-type="pango_bidi_type_get_type"
-                 c:type="PangoBidiType">
+    <enumeration name="BidiType" version="1.22" glib:type-name="PangoBidiType" glib:get-type="pango_bidi_type_get_type" c:type="PangoBidiType">
       <doc xml:space="preserve">The #PangoBidiType type represents the bidirectional character
 type of a Unicode character as specified by the
 &lt;ulink url="http://www.unicode.org/reports/tr9/"&gt;Unicode bidirectional algorithm&lt;/ulink&gt;.</doc>
-      <member name="l"
-              value="0"
-              c:identifier="PANGO_BIDI_TYPE_L"
-              glib:nick="l">
+      <member name="l" value="0" c:identifier="PANGO_BIDI_TYPE_L" glib:nick="l">
         <doc xml:space="preserve">Left-to-Right</doc>
       </member>
-      <member name="lre"
-              value="1"
-              c:identifier="PANGO_BIDI_TYPE_LRE"
-              glib:nick="lre">
+      <member name="lre" value="1" c:identifier="PANGO_BIDI_TYPE_LRE" glib:nick="lre">
         <doc xml:space="preserve">Left-to-Right Embedding</doc>
       </member>
-      <member name="lro"
-              value="2"
-              c:identifier="PANGO_BIDI_TYPE_LRO"
-              glib:nick="lro">
+      <member name="lro" value="2" c:identifier="PANGO_BIDI_TYPE_LRO" glib:nick="lro">
         <doc xml:space="preserve">Left-to-Right Override</doc>
       </member>
-      <member name="r"
-              value="3"
-              c:identifier="PANGO_BIDI_TYPE_R"
-              glib:nick="r">
+      <member name="r" value="3" c:identifier="PANGO_BIDI_TYPE_R" glib:nick="r">
         <doc xml:space="preserve">Right-to-Left</doc>
       </member>
-      <member name="al"
-              value="4"
-              c:identifier="PANGO_BIDI_TYPE_AL"
-              glib:nick="al">
+      <member name="al" value="4" c:identifier="PANGO_BIDI_TYPE_AL" glib:nick="al">
         <doc xml:space="preserve">Right-to-Left Arabic</doc>
       </member>
-      <member name="rle"
-              value="5"
-              c:identifier="PANGO_BIDI_TYPE_RLE"
-              glib:nick="rle">
+      <member name="rle" value="5" c:identifier="PANGO_BIDI_TYPE_RLE" glib:nick="rle">
         <doc xml:space="preserve">Right-to-Left Embedding</doc>
       </member>
-      <member name="rlo"
-              value="6"
-              c:identifier="PANGO_BIDI_TYPE_RLO"
-              glib:nick="rlo">
+      <member name="rlo" value="6" c:identifier="PANGO_BIDI_TYPE_RLO" glib:nick="rlo">
         <doc xml:space="preserve">Right-to-Left Override</doc>
       </member>
-      <member name="pdf"
-              value="7"
-              c:identifier="PANGO_BIDI_TYPE_PDF"
-              glib:nick="pdf">
+      <member name="pdf" value="7" c:identifier="PANGO_BIDI_TYPE_PDF" glib:nick="pdf">
         <doc xml:space="preserve">Pop Directional Format</doc>
       </member>
-      <member name="en"
-              value="8"
-              c:identifier="PANGO_BIDI_TYPE_EN"
-              glib:nick="en">
+      <member name="en" value="8" c:identifier="PANGO_BIDI_TYPE_EN" glib:nick="en">
         <doc xml:space="preserve">European Number</doc>
       </member>
-      <member name="es"
-              value="9"
-              c:identifier="PANGO_BIDI_TYPE_ES"
-              glib:nick="es">
+      <member name="es" value="9" c:identifier="PANGO_BIDI_TYPE_ES" glib:nick="es">
         <doc xml:space="preserve">European Number Separator</doc>
       </member>
-      <member name="et"
-              value="10"
-              c:identifier="PANGO_BIDI_TYPE_ET"
-              glib:nick="et">
+      <member name="et" value="10" c:identifier="PANGO_BIDI_TYPE_ET" glib:nick="et">
         <doc xml:space="preserve">European Number Terminator</doc>
       </member>
-      <member name="an"
-              value="11"
-              c:identifier="PANGO_BIDI_TYPE_AN"
-              glib:nick="an">
+      <member name="an" value="11" c:identifier="PANGO_BIDI_TYPE_AN" glib:nick="an">
         <doc xml:space="preserve">Arabic Number</doc>
       </member>
-      <member name="cs"
-              value="12"
-              c:identifier="PANGO_BIDI_TYPE_CS"
-              glib:nick="cs">
+      <member name="cs" value="12" c:identifier="PANGO_BIDI_TYPE_CS" glib:nick="cs">
         <doc xml:space="preserve">Common Number Separator</doc>
       </member>
-      <member name="nsm"
-              value="13"
-              c:identifier="PANGO_BIDI_TYPE_NSM"
-              glib:nick="nsm">
+      <member name="nsm" value="13" c:identifier="PANGO_BIDI_TYPE_NSM" glib:nick="nsm">
         <doc xml:space="preserve">Nonspacing Mark</doc>
       </member>
-      <member name="bn"
-              value="14"
-              c:identifier="PANGO_BIDI_TYPE_BN"
-              glib:nick="bn">
+      <member name="bn" value="14" c:identifier="PANGO_BIDI_TYPE_BN" glib:nick="bn">
         <doc xml:space="preserve">Boundary Neutral</doc>
       </member>
-      <member name="b"
-              value="15"
-              c:identifier="PANGO_BIDI_TYPE_B"
-              glib:nick="b">
+      <member name="b" value="15" c:identifier="PANGO_BIDI_TYPE_B" glib:nick="b">
         <doc xml:space="preserve">Paragraph Separator</doc>
       </member>
-      <member name="s"
-              value="16"
-              c:identifier="PANGO_BIDI_TYPE_S"
-              glib:nick="s">
+      <member name="s" value="16" c:identifier="PANGO_BIDI_TYPE_S" glib:nick="s">
         <doc xml:space="preserve">Segment Separator</doc>
       </member>
-      <member name="ws"
-              value="17"
-              c:identifier="PANGO_BIDI_TYPE_WS"
-              glib:nick="ws">
+      <member name="ws" value="17" c:identifier="PANGO_BIDI_TYPE_WS" glib:nick="ws">
         <doc xml:space="preserve">Whitespace</doc>
       </member>
-      <member name="on"
-              value="18"
-              c:identifier="PANGO_BIDI_TYPE_ON"
-              glib:nick="on">
+      <member name="on" value="18" c:identifier="PANGO_BIDI_TYPE_ON" glib:nick="on">
         <doc xml:space="preserve">Other Neutrals</doc>
       </member>
-      <function name="for_unichar"
-                c:identifier="pango_bidi_type_for_unichar"
-                version="1.22">
+      <function name="for_unichar" c:identifier="pango_bidi_type_for_unichar" version="1.22">
         <doc xml:space="preserve">Determines the normative bidirectional character type of a
 character, as specified in the Unicode Character Database.
 
@@ -1333,11 +1076,7 @@ Unicode bidirectional algorithm.</doc>
         </parameters>
       </function>
     </enumeration>
-    <record name="Color"
-            c:type="PangoColor"
-            glib:type-name="PangoColor"
-            glib:get-type="pango_color_get_type"
-            c:symbol-prefix="color">
+    <record name="Color" c:type="PangoColor" glib:type-name="PangoColor" glib:get-type="pango_color_get_type" c:symbol-prefix="color">
       <doc xml:space="preserve">The #PangoColor structure is used to
 represent a color in an uncalibrated RGB color-space.</doc>
       <field name="red" writable="1">
@@ -1364,10 +1103,7 @@ by assignment in C).</doc>
           <type name="Color" c:type="PangoColor*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="src"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="src" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">color to copy, may be %NULL</doc>
             <type name="Color" c:type="const PangoColor*"/>
           </instance-parameter>
@@ -1379,10 +1115,7 @@ by assignment in C).</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="color"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="color" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">an allocated #PangoColor, may be %NULL</doc>
             <type name="Color" c:type="PangoColor*"/>
           </instance-parameter>
@@ -1403,10 +1136,7 @@ forms is '&amp;num;fff' '&amp;num;ffffff' '&amp;num;fffffffff' and '&amp;num;fff
           <type name="gboolean" c:type="gboolean"/>
         </return-value>
         <parameters>
-          <instance-parameter name="color"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="color" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoColor structure in which to store the
   result, or %NULL</doc>
             <type name="Color" c:type="PangoColor*"/>
@@ -1417,9 +1147,7 @@ forms is '&amp;num;fff' '&amp;num;ffffff' '&amp;num;fffffffff' and '&amp;num;fff
           </parameter>
         </parameters>
       </method>
-      <method name="to_string"
-              c:identifier="pango_color_to_string"
-              version="1.16">
+      <method name="to_string" c:identifier="pango_color_to_string" version="1.16">
         <doc xml:space="preserve">Returns a textual specification of @color in the hexadecimal form
 &lt;literal&gt;&amp;num;rrrrggggbbbb&lt;/literal&gt;, where &lt;literal&gt;r&lt;/literal&gt;,
 &lt;literal&gt;g&lt;/literal&gt; and &lt;literal&gt;b&lt;/literal&gt; are hex digits representing
@@ -1436,13 +1164,7 @@ the red, green, and blue components respectively.</doc>
         </parameters>
       </method>
     </record>
-    <class name="Context"
-           c:symbol-prefix="context"
-           c:type="PangoContext"
-           parent="GObject.Object"
-           glib:type-name="PangoContext"
-           glib:get-type="pango_context_get_type"
-           glib:type-struct="ContextClass">
+    <class name="Context" c:symbol-prefix="context" c:type="PangoContext" parent="GObject.Object" glib:type-name="PangoContext" glib:get-type="pango_context_get_type" glib:type-struct="ContextClass">
       <doc xml:space="preserve">The #PangoContext structure stores global information
 used to control the itemization process.</doc>
       <constructor name="new" c:identifier="pango_context_new">
@@ -1464,9 +1186,7 @@ gtk_widget_get_pango_context().  Use those instead.</doc>
           <type name="Context" c:type="PangoContext*"/>
         </return-value>
       </constructor>
-      <method name="changed"
-              c:identifier="pango_context_changed"
-              version="1.32.4">
+      <method name="changed" c:identifier="pango_context_changed" version="1.32.4">
         <doc xml:space="preserve">Forces a change in the context, which will cause any #PangoLayout
 using this context to re-layout.
 
@@ -1498,9 +1218,7 @@ pango_context_set_base_dir().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_base_gravity"
-              c:identifier="pango_context_get_base_gravity"
-              version="1.16">
+      <method name="get_base_gravity" c:identifier="pango_context_get_base_gravity" version="1.16">
         <doc xml:space="preserve">Retrieves the base gravity for the context. See
 pango_context_set_base_gravity().</doc>
         <return-value transfer-ownership="none">
@@ -1514,8 +1232,7 @@ pango_context_set_base_gravity().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_font_description"
-              c:identifier="pango_context_get_font_description">
+      <method name="get_font_description" c:identifier="pango_context_get_font_description">
         <doc xml:space="preserve">Retrieve the default font description for the context.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a pointer to the context's default font
@@ -1529,9 +1246,7 @@ pango_context_set_base_gravity().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_font_map"
-              c:identifier="pango_context_get_font_map"
-              version="1.6">
+      <method name="get_font_map" c:identifier="pango_context_get_font_map" version="1.6">
         <doc xml:space="preserve">Gets the #PangoFontMap used to look up fonts for this context.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the font map for the #PangoContext.
@@ -1545,9 +1260,7 @@ pango_context_set_base_gravity().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_gravity"
-              c:identifier="pango_context_get_gravity"
-              version="1.16">
+      <method name="get_gravity" c:identifier="pango_context_get_gravity" version="1.16">
         <doc xml:space="preserve">Retrieves the gravity for the context. This is similar to
 pango_context_get_base_gravity(), except for when the base gravity
 is %PANGO_GRAVITY_AUTO for which pango_gravity_get_for_matrix() is used
@@ -1563,9 +1276,7 @@ to return the gravity from the current context matrix.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_gravity_hint"
-              c:identifier="pango_context_get_gravity_hint"
-              version="1.16">
+      <method name="get_gravity_hint" c:identifier="pango_context_get_gravity_hint" version="1.16">
         <doc xml:space="preserve">Retrieves the gravity hint for the context. See
 pango_context_set_gravity_hint() for details.</doc>
         <return-value transfer-ownership="none">
@@ -1592,9 +1303,7 @@ pango_context_set_gravity_hint() for details.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_matrix"
-              c:identifier="pango_context_get_matrix"
-              version="1.6">
+      <method name="get_matrix" c:identifier="pango_context_get_matrix" version="1.6">
         <doc xml:space="preserve">Gets the transformation matrix that will be applied when
 rendering with this context. See pango_context_set_matrix().</doc>
         <return-value transfer-ownership="none" nullable="1">
@@ -1633,18 +1342,12 @@ individual families.</doc>
             <doc xml:space="preserve">a #PangoContext</doc>
             <type name="Context" c:type="PangoContext*"/>
           </instance-parameter>
-          <parameter name="desc"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="desc" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoFontDescription structure.  %NULL means that the
            font description from the context will be used.</doc>
             <type name="FontDescription" c:type="const PangoFontDescription*"/>
           </parameter>
-          <parameter name="language"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="language" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">language tag used to determine which script to get
            the metrics for. %NULL means that the language tag from the context
            will be used. If no language tag is set on the context, metrics
@@ -1654,9 +1357,7 @@ individual families.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_serial"
-              c:identifier="pango_context_get_serial"
-              version="1.32.4">
+      <method name="get_serial" c:identifier="pango_context_get_serial" version="1.32.4">
         <doc xml:space="preserve">Returns the current serial number of @context.  The serial number is
 initialized to an small number larger than zero when a new context
 is created and is increased whenever the context is changed using any
@@ -1688,10 +1389,7 @@ is only useful when implementing objects that need update when their
             <doc xml:space="preserve">a #PangoContext</doc>
             <type name="Context" c:type="PangoContext*"/>
           </instance-parameter>
-          <parameter name="families"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="container">
+          <parameter name="families" direction="out" caller-allocates="0" transfer-ownership="container">
             <doc xml:space="preserve">location to store a pointer to
            an array of #PangoFontFamily *. This array should be freed
            with g_free().</doc>
@@ -1699,10 +1397,7 @@ is only useful when implementing objects that need update when their
               <type name="FontFamily" c:type="PangoFontFamily**"/>
             </array>
           </parameter>
-          <parameter name="n_families"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="n_families" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store the number of elements in @descs</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
@@ -1773,9 +1468,7 @@ for paragraphs that do not contain any strong characters themselves.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_base_gravity"
-              c:identifier="pango_context_set_base_gravity"
-              version="1.16">
+      <method name="set_base_gravity" c:identifier="pango_context_set_base_gravity" version="1.16">
         <doc xml:space="preserve">Sets the base gravity for the context.
 
 The base gravity is used in laying vertical text out.</doc>
@@ -1793,8 +1486,7 @@ The base gravity is used in laying vertical text out.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_font_description"
-              c:identifier="pango_context_set_font_description">
+      <method name="set_font_description" c:identifier="pango_context_set_font_description">
         <doc xml:space="preserve">Set the default font description for the context</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -1828,9 +1520,7 @@ via one of the recommended methods should already have a suitable font map.</doc
           </parameter>
         </parameters>
       </method>
-      <method name="set_gravity_hint"
-              c:identifier="pango_context_set_gravity_hint"
-              version="1.16">
+      <method name="set_gravity_hint" c:identifier="pango_context_set_gravity_hint" version="1.16">
         <doc xml:space="preserve">Sets the gravity hint for the context.
 
 The gravity hint is used in laying vertical text out, and is only relevant
@@ -1868,9 +1558,7 @@ pango_language_get_default().</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_matrix"
-              c:identifier="pango_context_set_matrix"
-              version="1.6">
+      <method name="set_matrix" c:identifier="pango_context_set_matrix" version="1.6">
         <doc xml:space="preserve">Sets the transformation matrix that will be applied when rendering
 with this context. Note that reported metrics are in the user space
 coordinates before the application of the matrix, not device-space
@@ -1885,10 +1573,7 @@ matrices, depending on how the text is fit to the pixel grid.</doc>
             <doc xml:space="preserve">a #PangoContext</doc>
             <type name="Context" c:type="PangoContext*"/>
           </instance-parameter>
-          <parameter name="matrix"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="matrix" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoMatrix, or %NULL to unset any existing
 matrix. (No matrix set is the same as setting the identity matrix.)</doc>
             <type name="Matrix" c:type="const PangoMatrix*"/>
@@ -1896,17 +1581,12 @@ matrix. (No matrix set is the same as setting the identity matrix.)</doc>
         </parameters>
       </method>
     </class>
-    <record name="ContextClass"
-            c:type="PangoContextClass"
-            disguised="1"
-            glib:is-gtype-struct-for="Context">
+    <record name="ContextClass" c:type="PangoContextClass" disguised="1" glib:is-gtype-struct-for="Context">
     </record>
     <record name="Coverage" c:type="PangoCoverage" disguised="1">
       <doc xml:space="preserve">The #PangoCoverage structure represents a map from Unicode characters
 to #PangoCoverageLevel. It is an opaque structure with no public fields.</doc>
-      <method name="copy"
-              c:identifier="pango_coverage_copy"
-              introspectable="0">
+      <method name="copy" c:identifier="pango_coverage_copy" introspectable="0">
         <doc xml:space="preserve">Copy an existing #PangoCoverage. (This function may now be unnecessary
 since we refcount the structure. File a bug if you use it.)</doc>
         <return-value transfer-ownership="full">
@@ -2000,20 +1680,14 @@ the corresponding index in @other.</doc>
             <doc xml:space="preserve">a #PangoCoverage</doc>
             <type name="Coverage" c:type="PangoCoverage*"/>
           </instance-parameter>
-          <parameter name="bytes"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="bytes" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">
   location to store result (must be freed with g_free())</doc>
             <array length="1" zero-terminated="0" c:type="guchar**">
               <type name="guint8"/>
             </array>
           </parameter>
-          <parameter name="n_bytes"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="n_bytes" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store size of result</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
@@ -2032,9 +1706,7 @@ If the result is zero, free the coverage and all associated memory.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <function name="from_bytes"
-                c:identifier="pango_coverage_from_bytes"
-                introspectable="0">
+      <function name="from_bytes" c:identifier="pango_coverage_from_bytes" introspectable="0">
         <doc xml:space="preserve">Convert data generated from pango_coverage_to_bytes() back
 to a #PangoCoverage</doc>
         <return-value transfer-ownership="full" nullable="1">
@@ -2056,9 +1728,7 @@ to a #PangoCoverage</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="new"
-                c:identifier="pango_coverage_new"
-                introspectable="0">
+      <function name="new" c:identifier="pango_coverage_new" introspectable="0">
         <doc xml:space="preserve">Create a new #PangoCoverage</doc>
         <return-value>
           <doc xml:space="preserve">the newly allocated #PangoCoverage,
@@ -2069,46 +1739,28 @@ to a #PangoCoverage</doc>
         </return-value>
       </function>
     </record>
-    <enumeration name="CoverageLevel"
-                 glib:type-name="PangoCoverageLevel"
-                 glib:get-type="pango_coverage_level_get_type"
-                 c:type="PangoCoverageLevel">
+    <enumeration name="CoverageLevel" glib:type-name="PangoCoverageLevel" glib:get-type="pango_coverage_level_get_type" c:type="PangoCoverageLevel">
       <doc xml:space="preserve">Used to indicate how well a font can represent a particular Unicode
 character point for a particular script.</doc>
-      <member name="none"
-              value="0"
-              c:identifier="PANGO_COVERAGE_NONE"
-              glib:nick="none">
+      <member name="none" value="0" c:identifier="PANGO_COVERAGE_NONE" glib:nick="none">
         <doc xml:space="preserve">The character is not representable with the font.</doc>
       </member>
-      <member name="fallback"
-              value="1"
-              c:identifier="PANGO_COVERAGE_FALLBACK"
-              glib:nick="fallback">
+      <member name="fallback" value="1" c:identifier="PANGO_COVERAGE_FALLBACK" glib:nick="fallback">
         <doc xml:space="preserve">The character is represented in a way that may be
 comprehensible but is not the correct graphical form.
 For instance, a Hangul character represented as a
 a sequence of Jamos, or a Latin transliteration of a Cyrillic word.</doc>
       </member>
-      <member name="approximate"
-              value="2"
-              c:identifier="PANGO_COVERAGE_APPROXIMATE"
-              glib:nick="approximate">
+      <member name="approximate" value="2" c:identifier="PANGO_COVERAGE_APPROXIMATE" glib:nick="approximate">
         <doc xml:space="preserve">The character is represented as basically the correct
 graphical form, but with a stylistic variant inappropriate for
 the current script.</doc>
       </member>
-      <member name="exact"
-              value="3"
-              c:identifier="PANGO_COVERAGE_EXACT"
-              glib:nick="exact">
+      <member name="exact" value="3" c:identifier="PANGO_COVERAGE_EXACT" glib:nick="exact">
         <doc xml:space="preserve">The character is represented as the correct graphical form.</doc>
       </member>
     </enumeration>
-    <enumeration name="Direction"
-                 glib:type-name="PangoDirection"
-                 glib:get-type="pango_direction_get_type"
-                 c:type="PangoDirection">
+    <enumeration name="Direction" glib:type-name="PangoDirection" glib:get-type="pango_direction_get_type" c:type="PangoDirection">
       <doc xml:space="preserve">The #PangoDirection type represents a direction in the
 Unicode bidirectional algorithm; not every value in this
 enumeration makes sense for every usage of #PangoDirection;
@@ -2124,133 +1776,73 @@ values come from an earlier interpretation of this
 enumeration as the writing direction of a block of
 text and are no longer used; See #PangoGravity for how
 vertical text is handled in Pango.</doc>
-      <member name="ltr"
-              value="0"
-              c:identifier="PANGO_DIRECTION_LTR"
-              glib:nick="ltr">
+      <member name="ltr" value="0" c:identifier="PANGO_DIRECTION_LTR" glib:nick="ltr">
         <doc xml:space="preserve">A strong left-to-right direction</doc>
       </member>
-      <member name="rtl"
-              value="1"
-              c:identifier="PANGO_DIRECTION_RTL"
-              glib:nick="rtl">
+      <member name="rtl" value="1" c:identifier="PANGO_DIRECTION_RTL" glib:nick="rtl">
         <doc xml:space="preserve">A strong right-to-left direction</doc>
       </member>
-      <member name="ttb_ltr"
-              value="2"
-              c:identifier="PANGO_DIRECTION_TTB_LTR"
-              glib:nick="ttb-ltr">
+      <member name="ttb_ltr" value="2" c:identifier="PANGO_DIRECTION_TTB_LTR" glib:nick="ttb-ltr">
         <doc xml:space="preserve">Deprecated value; treated the
   same as %PANGO_DIRECTION_RTL.</doc>
       </member>
-      <member name="ttb_rtl"
-              value="3"
-              c:identifier="PANGO_DIRECTION_TTB_RTL"
-              glib:nick="ttb-rtl">
+      <member name="ttb_rtl" value="3" c:identifier="PANGO_DIRECTION_TTB_RTL" glib:nick="ttb-rtl">
         <doc xml:space="preserve">Deprecated value; treated the
   same as %PANGO_DIRECTION_LTR</doc>
       </member>
-      <member name="weak_ltr"
-              value="4"
-              c:identifier="PANGO_DIRECTION_WEAK_LTR"
-              glib:nick="weak-ltr">
+      <member name="weak_ltr" value="4" c:identifier="PANGO_DIRECTION_WEAK_LTR" glib:nick="weak-ltr">
         <doc xml:space="preserve">A weak left-to-right direction</doc>
       </member>
-      <member name="weak_rtl"
-              value="5"
-              c:identifier="PANGO_DIRECTION_WEAK_RTL"
-              glib:nick="weak-rtl">
+      <member name="weak_rtl" value="5" c:identifier="PANGO_DIRECTION_WEAK_RTL" glib:nick="weak-rtl">
         <doc xml:space="preserve">A weak right-to-left direction</doc>
       </member>
-      <member name="neutral"
-              value="6"
-              c:identifier="PANGO_DIRECTION_NEUTRAL"
-              glib:nick="neutral">
+      <member name="neutral" value="6" c:identifier="PANGO_DIRECTION_NEUTRAL" glib:nick="neutral">
         <doc xml:space="preserve">No direction specified</doc>
       </member>
     </enumeration>
-    <constant name="ENGINE_TYPE_LANG"
-              value="PangoEngineLang"
-              c:type="PANGO_ENGINE_TYPE_LANG"
-              deprecated="1"
-              deprecated-version="1.38">
+    <constant name="ENGINE_TYPE_LANG" value="PangoEngineLang" c:type="PANGO_ENGINE_TYPE_LANG" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">A string constant defining the engine type for language engines.
 These engines derive from #PangoEngineLang.</doc>
       <type name="utf8" c:type="gchar*"/>
     </constant>
-    <constant name="ENGINE_TYPE_SHAPE"
-              value="PangoEngineShape"
-              c:type="PANGO_ENGINE_TYPE_SHAPE"
-              deprecated="1"
-              deprecated-version="1.38">
+    <constant name="ENGINE_TYPE_SHAPE" value="PangoEngineShape" c:type="PANGO_ENGINE_TYPE_SHAPE" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">A string constant defining the engine type for shaping engines.
 These engines derive from #PangoEngineShape.</doc>
       <type name="utf8" c:type="gchar*"/>
     </constant>
-    <enumeration name="EllipsizeMode"
-                 glib:type-name="PangoEllipsizeMode"
-                 glib:get-type="pango_ellipsize_mode_get_type"
-                 c:type="PangoEllipsizeMode">
+    <enumeration name="EllipsizeMode" glib:type-name="PangoEllipsizeMode" glib:get-type="pango_ellipsize_mode_get_type" c:type="PangoEllipsizeMode">
       <doc xml:space="preserve">The #PangoEllipsizeMode type describes what sort of (if any)
 ellipsization should be applied to a line of text. In
 the ellipsization process characters are removed from the
 text in order to make it fit to a given width and replaced
 with an ellipsis.</doc>
-      <member name="none"
-              value="0"
-              c:identifier="PANGO_ELLIPSIZE_NONE"
-              glib:nick="none">
+      <member name="none" value="0" c:identifier="PANGO_ELLIPSIZE_NONE" glib:nick="none">
         <doc xml:space="preserve">No ellipsization</doc>
       </member>
-      <member name="start"
-              value="1"
-              c:identifier="PANGO_ELLIPSIZE_START"
-              glib:nick="start">
+      <member name="start" value="1" c:identifier="PANGO_ELLIPSIZE_START" glib:nick="start">
         <doc xml:space="preserve">Omit characters at the start of the text</doc>
       </member>
-      <member name="middle"
-              value="2"
-              c:identifier="PANGO_ELLIPSIZE_MIDDLE"
-              glib:nick="middle">
+      <member name="middle" value="2" c:identifier="PANGO_ELLIPSIZE_MIDDLE" glib:nick="middle">
         <doc xml:space="preserve">Omit characters in the middle of the text</doc>
       </member>
-      <member name="end"
-              value="3"
-              c:identifier="PANGO_ELLIPSIZE_END"
-              glib:nick="end">
+      <member name="end" value="3" c:identifier="PANGO_ELLIPSIZE_END" glib:nick="end">
         <doc xml:space="preserve">Omit characters at the end of the text</doc>
       </member>
     </enumeration>
-    <class name="Engine"
-           c:symbol-prefix="engine"
-           c:type="PangoEngine"
-           deprecated="1"
-           deprecated-version="1.38"
-           parent="GObject.Object"
-           abstract="1"
-           glib:type-name="PangoEngine"
-           glib:get-type="pango_engine_get_type"
-           glib:type-struct="EngineClass">
+    <class name="Engine" c:symbol-prefix="engine" c:type="PangoEngine" deprecated="1" deprecated-version="1.38" parent="GObject.Object" abstract="1" glib:type-name="PangoEngine" glib:get-type="pango_engine_get_type" glib:type-struct="EngineClass">
       <doc xml:space="preserve">#PangoEngine is the base class for all types of language and
 script specific engines. It has no functionality by itself.</doc>
       <field name="parent_instance" readable="0" private="1">
         <type name="GObject.Object" c:type="GObject"/>
       </field>
     </class>
-    <record name="EngineClass"
-            c:type="PangoEngineClass"
-            glib:is-gtype-struct-for="Engine"
-            deprecated="1"
-            deprecated-version="1.38">
+    <record name="EngineClass" c:type="PangoEngineClass" glib:is-gtype-struct-for="Engine" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Class structure for #PangoEngine</doc>
       <field name="parent_class" readable="0" private="1">
         <type name="GObject.ObjectClass" c:type="GObjectClass"/>
       </field>
     </record>
-    <record name="EngineInfo"
-            c:type="PangoEngineInfo"
-            deprecated="1"
-            deprecated-version="1.38">
+    <record name="EngineInfo" c:type="PangoEngineInfo" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">The #PangoEngineInfo structure contains information about a particular
 engine. It contains the following fields:</doc>
       <field name="id" writable="1">
@@ -2274,16 +1866,7 @@ engine. It contains the following fields:</doc>
         <type name="gint" c:type="gint"/>
       </field>
     </record>
-    <class name="EngineLang"
-           c:symbol-prefix="engine_lang"
-           c:type="PangoEngineLang"
-           deprecated="1"
-           deprecated-version="1.38"
-           parent="Engine"
-           abstract="1"
-           glib:type-name="PangoEngineLang"
-           glib:get-type="pango_engine_lang_get_type"
-           glib:type-struct="EngineLangClass">
+    <class name="EngineLang" c:symbol-prefix="engine_lang" c:type="PangoEngineLang" deprecated="1" deprecated-version="1.38" parent="Engine" abstract="1" glib:type-name="PangoEngineLang" glib:get-type="pango_engine_lang_get_type" glib:type-struct="EngineLangClass">
       <doc xml:space="preserve">The #PangoEngineLang class is implemented by engines that
 customize the rendering-system independent part of the
 Pango pipeline for a particular script or language. For
@@ -2319,11 +1902,7 @@ lookups needed for that language.</doc>
         <type name="Engine" c:type="PangoEngine"/>
       </field>
     </class>
-    <record name="EngineLangClass"
-            c:type="PangoEngineLangClass"
-            glib:is-gtype-struct-for="EngineLang"
-            deprecated="1"
-            deprecated-version="1.38">
+    <record name="EngineLangClass" c:type="PangoEngineLangClass" glib:is-gtype-struct-for="EngineLang" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Class structure for #PangoEngineLang</doc>
       <field name="parent_class" readable="0" private="1">
         <type name="EngineClass" c:type="PangoEngineClass"/>
@@ -2356,10 +1935,7 @@ lookups needed for that language.</doc>
         </callback>
       </field>
     </record>
-    <record name="EngineScriptInfo"
-            c:type="PangoEngineScriptInfo"
-            deprecated="1"
-            deprecated-version="1.38">
+    <record name="EngineScriptInfo" c:type="PangoEngineScriptInfo" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">The #PangoEngineScriptInfo structure contains
 information about how the shaper covers a particular script.</doc>
       <field name="script" writable="1">
@@ -2380,16 +1956,7 @@ languages for this range.</doc>
         <type name="utf8" c:type="const gchar*"/>
       </field>
     </record>
-    <class name="EngineShape"
-           c:symbol-prefix="engine_shape"
-           c:type="PangoEngineShape"
-           deprecated="1"
-           deprecated-version="1.38"
-           parent="Engine"
-           abstract="1"
-           glib:type-name="PangoEngineShape"
-           glib:get-type="pango_engine_shape_get_type"
-           glib:type-struct="EngineShapeClass">
+    <class name="EngineShape" c:symbol-prefix="engine_shape" c:type="PangoEngineShape" deprecated="1" deprecated-version="1.38" parent="Engine" abstract="1" glib:type-name="PangoEngineShape" glib:get-type="pango_engine_shape_get_type" glib:type-struct="EngineShapeClass">
       <doc xml:space="preserve">The #PangoEngineShape class is implemented by engines that
 customize the rendering-system dependent part of the
 Pango pipeline for a particular script or language.
@@ -2452,11 +2019,7 @@ for Fontconfig-based backends.</doc>
         <type name="Engine" c:type="PangoEngine"/>
       </field>
     </class>
-    <record name="EngineShapeClass"
-            c:type="PangoEngineShapeClass"
-            glib:is-gtype-struct-for="EngineShape"
-            deprecated="1"
-            deprecated-version="1.38">
+    <record name="EngineShapeClass" c:type="PangoEngineShapeClass" glib:is-gtype-struct-for="EngineShape" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Class structure for #PangoEngineShape</doc>
       <field name="parent_class" readable="0" private="1">
         <type name="EngineClass" c:type="PangoEngineClass"/>
@@ -2516,14 +2079,7 @@ for Fontconfig-based backends.</doc>
         </callback>
       </field>
     </record>
-    <class name="Font"
-           c:symbol-prefix="font"
-           c:type="PangoFont"
-           parent="GObject.Object"
-           abstract="1"
-           glib:type-name="PangoFont"
-           glib:get-type="pango_font_get_type"
-           glib:type-struct="FontClass">
+    <class name="Font" c:symbol-prefix="font" c:type="PangoFont" parent="GObject.Object" abstract="1" glib:type-name="PangoFont" glib:get-type="pango_font_get_type" glib:type-struct="FontClass">
       <doc xml:space="preserve">The #PangoFont structure is used to represent
 a font in a rendering-system-independent matter.
 To create an implementation of a #PangoFont,
@@ -2536,22 +2092,16 @@ pango_font_init() on the structure.
 
 The #PangoFont structure contains one member
 which the implementation fills in.</doc>
-      <function name="descriptions_free"
-                c:identifier="pango_font_descriptions_free">
+      <function name="descriptions_free" c:identifier="pango_font_descriptions_free">
         <doc xml:space="preserve">Frees an array of font descriptions.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <parameter name="descs"
-                     transfer-ownership="full"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="descs" transfer-ownership="full" nullable="1" allow-none="1">
             <doc xml:space="preserve">a pointer
 to an array of #PangoFontDescription, may be %NULL</doc>
-            <array length="1"
-                   zero-terminated="0"
-                   c:type="PangoFontDescription**">
+            <array length="1" zero-terminated="0" c:type="PangoFontDescription**">
               <type name="FontDescription" c:type="PangoFontDescription*"/>
             </array>
           </parameter>
@@ -2608,9 +2158,7 @@ language tag and character point.</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="get_coverage"
-                      invoker="get_coverage"
-                      introspectable="0">
+      <virtual-method name="get_coverage" invoker="get_coverage" introspectable="0">
         <doc xml:space="preserve">Computes the coverage map for a given font and language tag.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a newly-allocated #PangoCoverage
@@ -2628,9 +2176,7 @@ language tag and character point.</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="get_font_map"
-                      invoker="get_font_map"
-                      version="1.10">
+      <virtual-method name="get_font_map" invoker="get_font_map" version="1.10">
         <doc xml:space="preserve">Gets the font map for which the font was created.
 
 Note that the font maintains a &lt;firstterm&gt;weak&lt;/firstterm&gt; reference
@@ -2646,10 +2192,7 @@ a reference to the font map.</doc>
           <type name="FontMap" c:type="PangoFontMap*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="font"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="font" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoFont, or %NULL</doc>
             <type name="Font" c:type="PangoFont*"/>
           </instance-parameter>
@@ -2670,10 +2213,7 @@ output variables and returns.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="font"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="font" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoFont</doc>
             <type name="Font" c:type="PangoFont*"/>
           </instance-parameter>
@@ -2681,22 +2221,12 @@ output variables and returns.</doc>
             <doc xml:space="preserve">the glyph index</doc>
             <type name="Glyph" c:type="PangoGlyph"/>
           </parameter>
-          <parameter name="ink_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="ink_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to store the extents of the glyph
            as drawn or %NULL to indicate that the result is not needed.</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
-          <parameter name="logical_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="logical_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to store the logical extents of
            the glyph or %NULL to indicate that the result is not needed.</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
@@ -2717,17 +2247,11 @@ output variables and returns.</doc>
           <type name="FontMetrics" c:type="PangoFontMetrics*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="font"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="font" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoFont</doc>
             <type name="Font" c:type="PangoFont*"/>
           </instance-parameter>
-          <parameter name="language"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="language" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">language tag used to determine which script to get the metrics
            for, or %NULL to indicate to get the metrics for the entire font.</doc>
             <type name="Language" c:type="PangoLanguage*"/>
@@ -2749,9 +2273,7 @@ size in device units.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="describe_with_absolute_size"
-              c:identifier="pango_font_describe_with_absolute_size"
-              version="1.14">
+      <method name="describe_with_absolute_size" c:identifier="pango_font_describe_with_absolute_size" version="1.14">
         <doc xml:space="preserve">Returns a description of the font, with absolute font size set
 (in device units). Use pango_font_describe() if you want the font
 size in points.</doc>
@@ -2788,9 +2310,7 @@ language tag and character point.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_coverage"
-              c:identifier="pango_font_get_coverage"
-              introspectable="0">
+      <method name="get_coverage" c:identifier="pango_font_get_coverage" introspectable="0">
         <doc xml:space="preserve">Computes the coverage map for a given font and language tag.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a newly-allocated #PangoCoverage
@@ -2808,9 +2328,7 @@ language tag and character point.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_font_map"
-              c:identifier="pango_font_get_font_map"
-              version="1.10">
+      <method name="get_font_map" c:identifier="pango_font_get_font_map" version="1.10">
         <doc xml:space="preserve">Gets the font map for which the font was created.
 
 Note that the font maintains a &lt;firstterm&gt;weak&lt;/firstterm&gt; reference
@@ -2826,17 +2344,13 @@ a reference to the font map.</doc>
           <type name="FontMap" c:type="PangoFontMap*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="font"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="font" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoFont, or %NULL</doc>
             <type name="Font" c:type="PangoFont*"/>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_glyph_extents"
-              c:identifier="pango_font_get_glyph_extents">
+      <method name="get_glyph_extents" c:identifier="pango_font_get_glyph_extents">
         <doc xml:space="preserve">Gets the logical and ink extents of a glyph within a font. The
 coordinate system for each rectangle has its origin at the
 base line and horizontal origin of the character with increasing
@@ -2851,10 +2365,7 @@ output variables and returns.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="font"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="font" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoFont</doc>
             <type name="Font" c:type="PangoFont*"/>
           </instance-parameter>
@@ -2862,22 +2373,12 @@ output variables and returns.</doc>
             <doc xml:space="preserve">the glyph index</doc>
             <type name="Glyph" c:type="PangoGlyph"/>
           </parameter>
-          <parameter name="ink_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="ink_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to store the extents of the glyph
            as drawn or %NULL to indicate that the result is not needed.</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
-          <parameter name="logical_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="logical_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to store the logical extents of
            the glyph or %NULL to indicate that the result is not needed.</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
@@ -2898,17 +2399,11 @@ output variables and returns.</doc>
           <type name="FontMetrics" c:type="PangoFontMetrics*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="font"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="font" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoFont</doc>
             <type name="Font" c:type="PangoFont*"/>
           </instance-parameter>
-          <parameter name="language"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="language" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">language tag used to determine which script to get the metrics
            for, or %NULL to indicate to get the metrics for the entire font.</doc>
             <type name="Language" c:type="PangoLanguage*"/>
@@ -2919,9 +2414,7 @@ output variables and returns.</doc>
         <type name="GObject.Object" c:type="GObject"/>
       </field>
     </class>
-    <record name="FontClass"
-            c:type="PangoFontClass"
-            glib:is-gtype-struct-for="Font">
+    <record name="FontClass" c:type="PangoFontClass" glib:is-gtype-struct-for="Font">
       <field name="parent_class">
         <type name="GObject.ObjectClass" c:type="GObjectClass"/>
       </field>
@@ -2986,10 +2479,7 @@ output variables and returns.</doc>
             <type name="none" c:type="void"/>
           </return-value>
           <parameters>
-            <parameter name="font"
-                       transfer-ownership="none"
-                       nullable="1"
-                       allow-none="1">
+            <parameter name="font" transfer-ownership="none" nullable="1" allow-none="1">
               <doc xml:space="preserve">a #PangoFont</doc>
               <type name="Font" c:type="PangoFont*"/>
             </parameter>
@@ -2997,22 +2487,12 @@ output variables and returns.</doc>
               <doc xml:space="preserve">the glyph index</doc>
               <type name="Glyph" c:type="PangoGlyph"/>
             </parameter>
-            <parameter name="ink_rect"
-                       direction="out"
-                       caller-allocates="1"
-                       transfer-ownership="none"
-                       optional="1"
-                       allow-none="1">
+            <parameter name="ink_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
               <doc xml:space="preserve">rectangle used to store the extents of the glyph
            as drawn or %NULL to indicate that the result is not needed.</doc>
               <type name="Rectangle" c:type="PangoRectangle*"/>
             </parameter>
-            <parameter name="logical_rect"
-                       direction="out"
-                       caller-allocates="1"
-                       transfer-ownership="none"
-                       optional="1"
-                       allow-none="1">
+            <parameter name="logical_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
               <doc xml:space="preserve">rectangle used to store the logical extents of
            the glyph or %NULL to indicate that the result is not needed.</doc>
               <type name="Rectangle" c:type="PangoRectangle*"/>
@@ -3028,17 +2508,11 @@ output variables and returns.</doc>
             <type name="FontMetrics" c:type="PangoFontMetrics*"/>
           </return-value>
           <parameters>
-            <parameter name="font"
-                       transfer-ownership="none"
-                       nullable="1"
-                       allow-none="1">
+            <parameter name="font" transfer-ownership="none" nullable="1" allow-none="1">
               <doc xml:space="preserve">a #PangoFont</doc>
               <type name="Font" c:type="PangoFont*"/>
             </parameter>
-            <parameter name="language"
-                       transfer-ownership="none"
-                       nullable="1"
-                       allow-none="1">
+            <parameter name="language" transfer-ownership="none" nullable="1" allow-none="1">
               <doc xml:space="preserve">language tag used to determine which script to get the metrics
            for, or %NULL to indicate to get the metrics for the entire font.</doc>
               <type name="Language" c:type="PangoLanguage*"/>
@@ -3054,10 +2528,7 @@ output variables and returns.</doc>
             <type name="FontMap" c:type="PangoFontMap*"/>
           </return-value>
           <parameters>
-            <parameter name="font"
-                       transfer-ownership="none"
-                       nullable="1"
-                       allow-none="1">
+            <parameter name="font" transfer-ownership="none" nullable="1" allow-none="1">
               <doc xml:space="preserve">a #PangoFont, or %NULL</doc>
               <type name="Font" c:type="PangoFont*"/>
             </parameter>
@@ -3091,11 +2562,7 @@ output variables and returns.</doc>
         </callback>
       </field>
     </record>
-    <record name="FontDescription"
-            c:type="PangoFontDescription"
-            glib:type-name="PangoFontDescription"
-            glib:get-type="pango_font_description_get_type"
-            c:symbol-prefix="font_description">
+    <record name="FontDescription" c:type="PangoFontDescription" glib:type-name="PangoFontDescription" glib:get-type="pango_font_description_get_type" c:symbol-prefix="font_description">
       <doc xml:space="preserve">The #PangoFontDescription structure represents the description
 of an ideal font. These structures are used both to list
 what fonts are available on the system and also for specifying
@@ -3108,8 +2575,7 @@ the characteristics of a font to load.</doc>
           <type name="FontDescription" c:type="PangoFontDescription*"/>
         </return-value>
       </constructor>
-      <method name="better_match"
-              c:identifier="pango_font_description_better_match">
+      <method name="better_match" c:identifier="pango_font_description_better_match">
         <doc xml:space="preserve">Determines if the style attributes of @new_match are a closer match
 for @desc than those of @old_match are, or if @old_match is %NULL,
 determines if @new_match is a match at all.
@@ -3130,10 +2596,7 @@ Note that @old_match must match @desc.</doc>
             <doc xml:space="preserve">a #PangoFontDescription</doc>
             <type name="FontDescription" c:type="const PangoFontDescription*"/>
           </instance-parameter>
-          <parameter name="old_match"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="old_match" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoFontDescription, or %NULL</doc>
             <type name="FontDescription" c:type="const PangoFontDescription*"/>
           </parameter>
@@ -3153,17 +2616,13 @@ Note that @old_match must match @desc.</doc>
           <type name="FontDescription" c:type="PangoFontDescription*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="desc"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="desc" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoFontDescription, may be %NULL</doc>
             <type name="FontDescription" c:type="const PangoFontDescription*"/>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="copy_static"
-              c:identifier="pango_font_description_copy_static">
+      <method name="copy_static" c:identifier="pango_font_description_copy_static">
         <doc xml:space="preserve">Like pango_font_description_copy(), but only a shallow copy is made
 of the family name and other allocated fields. The result can only
 be used until @desc is modified or freed. This is meant to be used
@@ -3176,10 +2635,7 @@ when the copy is only needed temporarily.</doc>
           <type name="FontDescription" c:type="PangoFontDescription*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="desc"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="desc" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoFontDescription, may be %NULL</doc>
             <type name="FontDescription" c:type="const PangoFontDescription*"/>
           </instance-parameter>
@@ -3213,17 +2669,13 @@ being loaded, but still compare %FALSE.)</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="desc"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="desc" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoFontDescription, may be %NULL</doc>
             <type name="FontDescription" c:type="PangoFontDescription*"/>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_family"
-              c:identifier="pango_font_description_get_family">
+      <method name="get_family" c:identifier="pango_font_description_get_family">
         <doc xml:space="preserve">Gets the family name field of a font description. See
 pango_font_description_set_family().</doc>
         <return-value transfer-ownership="none" nullable="1">
@@ -3240,9 +2692,7 @@ pango_font_description_set_family().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_gravity"
-              c:identifier="pango_font_description_get_gravity"
-              version="1.16">
+      <method name="get_gravity" c:identifier="pango_font_description_get_gravity" version="1.16">
         <doc xml:space="preserve">Gets the gravity field of a font description. See
 pango_font_description_set_gravity().</doc>
         <return-value transfer-ownership="none">
@@ -3258,8 +2708,7 @@ pango_font_description_set_gravity().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_set_fields"
-              c:identifier="pango_font_description_get_set_fields">
+      <method name="get_set_fields" c:identifier="pango_font_description_get_set_fields">
         <doc xml:space="preserve">Determines which fields in a font description have been set.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a bitmask with bits set corresponding to the
@@ -3292,9 +2741,7 @@ See pango_font_description_set_size().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_size_is_absolute"
-              c:identifier="pango_font_description_get_size_is_absolute"
-              version="1.8">
+      <method name="get_size_is_absolute" c:identifier="pango_font_description_get_size_is_absolute" version="1.8">
         <doc xml:space="preserve">Determines whether the size of the font is in points (not absolute) or device units (absolute).
 See pango_font_description_set_size() and pango_font_description_set_absolute_size().</doc>
         <return-value transfer-ownership="none">
@@ -3310,8 +2757,7 @@ See pango_font_description_set_size() and pango_font_description_set_absolute_si
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_stretch"
-              c:identifier="pango_font_description_get_stretch">
+      <method name="get_stretch" c:identifier="pango_font_description_get_stretch">
         <doc xml:space="preserve">Gets the stretch field of a font description.
 See pango_font_description_set_stretch().</doc>
         <return-value transfer-ownership="none">
@@ -3343,8 +2789,7 @@ pango_font_description_set_style().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_variant"
-              c:identifier="pango_font_description_get_variant">
+      <method name="get_variant" c:identifier="pango_font_description_get_variant">
         <doc xml:space="preserve">Gets the variant field of a #PangoFontDescription. See
 pango_font_description_set_variant().</doc>
         <return-value transfer-ownership="none">
@@ -3360,8 +2805,7 @@ pango_font_description_set_variant().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_weight"
-              c:identifier="pango_font_description_get_weight">
+      <method name="get_weight" c:identifier="pango_font_description_get_weight">
         <doc xml:space="preserve">Gets the weight field of a font description. See
 pango_font_description_set_weight().</doc>
         <return-value transfer-ownership="none">
@@ -3407,10 +2851,7 @@ If @desc_to_merge is %NULL, this function performs nothing.</doc>
             <doc xml:space="preserve">a #PangoFontDescription</doc>
             <type name="FontDescription" c:type="PangoFontDescription*"/>
           </instance-parameter>
-          <parameter name="desc_to_merge"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="desc_to_merge" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the #PangoFontDescription to merge from, or %NULL</doc>
             <type name="FontDescription" c:type="const PangoFontDescription*"/>
           </parameter>
@@ -3422,8 +2863,7 @@ If @desc_to_merge is %NULL, this function performs nothing.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="merge_static"
-              c:identifier="pango_font_description_merge_static">
+      <method name="merge_static" c:identifier="pango_font_description_merge_static">
         <doc xml:space="preserve">Like pango_font_description_merge(), but only a shallow copy is made
 of the family name and other allocated fields. @desc can only be
 used until @desc_to_merge is modified or freed. This is meant
@@ -3448,9 +2888,7 @@ to be used when the merged font description is only needed temporarily.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_absolute_size"
-              c:identifier="pango_font_description_set_absolute_size"
-              version="1.8">
+      <method name="set_absolute_size" c:identifier="pango_font_description_set_absolute_size" version="1.8">
         <doc xml:space="preserve">Sets the size field of a font description, in device units. This is mutually
 exclusive with pango_font_description_set_size() which sets the font size
 in points.</doc>
@@ -3470,8 +2908,7 @@ in points.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_family"
-              c:identifier="pango_font_description_set_family">
+      <method name="set_family" c:identifier="pango_font_description_set_family">
         <doc xml:space="preserve">Sets the family name field of a font description. The family
 name represents a family of related font styles, and will
 resolve to a particular #PangoFontFamily. In some uses of
@@ -3491,8 +2928,7 @@ separated list of family names for this field.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_family_static"
-              c:identifier="pango_font_description_set_family_static">
+      <method name="set_family_static" c:identifier="pango_font_description_set_family_static">
         <doc xml:space="preserve">Like pango_font_description_set_family(), except that no
 copy of @family is made. The caller must make sure that the
 string passed in stays around until @desc has been freed
@@ -3513,9 +2949,7 @@ if @desc is only needed temporarily.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_gravity"
-              c:identifier="pango_font_description_set_gravity"
-              version="1.16">
+      <method name="set_gravity" c:identifier="pango_font_description_set_gravity" version="1.16">
         <doc xml:space="preserve">Sets the gravity field of a font description. The gravity field
 specifies how the glyphs should be rotated.  If @gravity is
 %PANGO_GRAVITY_AUTO, this actually unsets the gravity mask on
@@ -3560,8 +2994,7 @@ exclusive with pango_font_description_set_absolute_size().</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_stretch"
-              c:identifier="pango_font_description_set_stretch">
+      <method name="set_stretch" c:identifier="pango_font_description_set_stretch">
         <doc xml:space="preserve">Sets the stretch field of a font description. The stretch field
 specifies how narrow or wide the font should be.</doc>
         <return-value transfer-ownership="none">
@@ -3601,8 +3034,7 @@ if an exact match is not found.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_variant"
-              c:identifier="pango_font_description_set_variant">
+      <method name="set_variant" c:identifier="pango_font_description_set_variant">
         <doc xml:space="preserve">Sets the variant field of a font description. The #PangoVariant
 can either be %PANGO_VARIANT_NORMAL or %PANGO_VARIANT_SMALL_CAPS.</doc>
         <return-value transfer-ownership="none">
@@ -3619,8 +3051,7 @@ can either be %PANGO_VARIANT_NORMAL or %PANGO_VARIANT_SMALL_CAPS.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_weight"
-              c:identifier="pango_font_description_set_weight">
+      <method name="set_weight" c:identifier="pango_font_description_set_weight">
         <doc xml:space="preserve">Sets the weight field of a font description. The weight field
 specifies how bold or light the font should be. In addition
 to the values of the #PangoWeight enumeration, other intermediate
@@ -3639,8 +3070,7 @@ numeric values are possible.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="to_filename"
-              c:identifier="pango_font_description_to_filename">
+      <method name="to_filename" c:identifier="pango_font_description_to_filename">
         <doc xml:space="preserve">Creates a filename representation of a font description. The
 filename is identical to the result from calling
 pango_font_description_to_string(), but with underscores instead of
@@ -3673,8 +3103,7 @@ last word of the list is a valid style option.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="unset_fields"
-              c:identifier="pango_font_description_unset_fields">
+      <method name="unset_fields" c:identifier="pango_font_description_unset_fields">
         <doc xml:space="preserve">Unsets some of the fields in a #PangoFontDescription.  The unset
 fields will get back to their default values.</doc>
         <return-value transfer-ownership="none">
@@ -3691,8 +3120,7 @@ fields will get back to their default values.</doc>
           </parameter>
         </parameters>
       </method>
-      <function name="from_string"
-                c:identifier="pango_font_description_from_string">
+      <function name="from_string" c:identifier="pango_font_description_from_string">
         <doc xml:space="preserve">Creates a new font description from a string representation in the
 form "[FAMILY-LIST] [STYLE-OPTIONS] [SIZE]", where FAMILY-LIST is a
 comma separated list of families optionally terminated by a comma,
@@ -3717,14 +3145,7 @@ description will be set to 0.</doc>
         </parameters>
       </function>
     </record>
-    <class name="FontFace"
-           c:symbol-prefix="font_face"
-           c:type="PangoFontFace"
-           parent="GObject.Object"
-           abstract="1"
-           glib:type-name="PangoFontFace"
-           glib:get-type="pango_font_face_get_type"
-           glib:type-struct="FontFaceClass">
+    <class name="FontFace" c:symbol-prefix="font_face" c:type="PangoFontFace" parent="GObject.Object" abstract="1" glib:type-name="PangoFontFace" glib:get-type="pango_font_face_get_type" glib:type-struct="FontFaceClass">
       <doc xml:space="preserve">The #PangoFontFace structure is used to represent a group of fonts with
 the same family, slant, weight, width, but varying sizes.</doc>
       <virtual-method name="describe" invoker="describe">
@@ -3761,9 +3182,7 @@ for displaying to users.</doc>
           </instance-parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="is_synthesized"
-                      invoker="is_synthesized"
-                      version="1.18">
+      <virtual-method name="is_synthesized" invoker="is_synthesized" version="1.18">
         <doc xml:space="preserve">Returns whether a #PangoFontFace is synthesized by the underlying
 font rendering engine from another face, perhaps by shearing, emboldening,
 or lightening it.</doc>
@@ -3791,13 +3210,7 @@ are in Pango units and are sorted in ascending order.</doc>
             <doc xml:space="preserve">a #PangoFontFace.</doc>
             <type name="FontFace" c:type="PangoFontFace*"/>
           </instance-parameter>
-          <parameter name="sizes"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     nullable="1"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="sizes" direction="out" caller-allocates="0" transfer-ownership="full" nullable="1" optional="1" allow-none="1">
             <doc xml:space="preserve">
         location to store a pointer to an array of int. This array
         should be freed with g_free().</doc>
@@ -3805,10 +3218,7 @@ are in Pango units and are sorted in ascending order.</doc>
               <type name="gint" c:type="int*"/>
             </array>
           </parameter>
-          <parameter name="n_sizes"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="n_sizes" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store the number of elements in @sizes</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
@@ -3831,8 +3241,7 @@ will be unset.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_face_name"
-              c:identifier="pango_font_face_get_face_name">
+      <method name="get_face_name" c:identifier="pango_font_face_get_face_name">
         <doc xml:space="preserve">Gets a name representing the style of this face among the
 different faces in the #PangoFontFamily for the face. This
 name is unique among all faces in the family and is suitable
@@ -3849,9 +3258,7 @@ for displaying to users.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="is_synthesized"
-              c:identifier="pango_font_face_is_synthesized"
-              version="1.18">
+      <method name="is_synthesized" c:identifier="pango_font_face_is_synthesized" version="1.18">
         <doc xml:space="preserve">Returns whether a #PangoFontFace is synthesized by the underlying
 font rendering engine from another face, perhaps by shearing, emboldening,
 or lightening it.</doc>
@@ -3866,9 +3273,7 @@ or lightening it.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="list_sizes"
-              c:identifier="pango_font_face_list_sizes"
-              version="1.4">
+      <method name="list_sizes" c:identifier="pango_font_face_list_sizes" version="1.4">
         <doc xml:space="preserve">List the available sizes for a font. This is only applicable to bitmap
 fonts. For scalable fonts, stores %NULL at the location pointed to by
 @sizes and 0 at the location pointed to by @n_sizes. The sizes returned
@@ -3881,13 +3286,7 @@ are in Pango units and are sorted in ascending order.</doc>
             <doc xml:space="preserve">a #PangoFontFace.</doc>
             <type name="FontFace" c:type="PangoFontFace*"/>
           </instance-parameter>
-          <parameter name="sizes"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     nullable="1"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="sizes" direction="out" caller-allocates="0" transfer-ownership="full" nullable="1" optional="1" allow-none="1">
             <doc xml:space="preserve">
         location to store a pointer to an array of int. This array
         should be freed with g_free().</doc>
@@ -3895,10 +3294,7 @@ are in Pango units and are sorted in ascending order.</doc>
               <type name="gint" c:type="int*"/>
             </array>
           </parameter>
-          <parameter name="n_sizes"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="n_sizes" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store the number of elements in @sizes</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
@@ -3908,9 +3304,7 @@ are in Pango units and are sorted in ascending order.</doc>
         <type name="GObject.Object" c:type="GObject"/>
       </field>
     </class>
-    <record name="FontFaceClass"
-            c:type="PangoFontFaceClass"
-            glib:is-gtype-struct-for="FontFace">
+    <record name="FontFaceClass" c:type="PangoFontFaceClass" glib:is-gtype-struct-for="FontFace">
       <field name="parent_class">
         <type name="GObject.ObjectClass" c:type="GObjectClass"/>
       </field>
@@ -3955,13 +3349,7 @@ are in Pango units and are sorted in ascending order.</doc>
               <doc xml:space="preserve">a #PangoFontFace.</doc>
               <type name="FontFace" c:type="PangoFontFace*"/>
             </parameter>
-            <parameter name="sizes"
-                       direction="out"
-                       caller-allocates="0"
-                       transfer-ownership="full"
-                       nullable="1"
-                       optional="1"
-                       allow-none="1">
+            <parameter name="sizes" direction="out" caller-allocates="0" transfer-ownership="full" nullable="1" optional="1" allow-none="1">
               <doc xml:space="preserve">
         location to store a pointer to an array of int. This array
         should be freed with g_free().</doc>
@@ -3969,10 +3357,7 @@ are in Pango units and are sorted in ascending order.</doc>
                 <type name="gint" c:type="int*"/>
               </array>
             </parameter>
-            <parameter name="n_sizes"
-                       direction="out"
-                       caller-allocates="0"
-                       transfer-ownership="full">
+            <parameter name="n_sizes" direction="out" caller-allocates="0" transfer-ownership="full">
               <doc xml:space="preserve">location to store the number of elements in @sizes</doc>
               <type name="gint" c:type="int*"/>
             </parameter>
@@ -4008,14 +3393,7 @@ are in Pango units and are sorted in ascending order.</doc>
         </callback>
       </field>
     </record>
-    <class name="FontFamily"
-           c:symbol-prefix="font_family"
-           c:type="PangoFontFamily"
-           parent="GObject.Object"
-           abstract="1"
-           glib:type-name="PangoFontFamily"
-           glib:get-type="pango_font_family_get_type"
-           glib:type-struct="FontFamilyClass">
+    <class name="FontFamily" c:symbol-prefix="font_family" c:type="PangoFontFamily" parent="GObject.Object" abstract="1" glib:type-name="PangoFontFamily" glib:get-type="pango_font_family_get_type" glib:type-struct="FontFamilyClass">
       <doc xml:space="preserve">The #PangoFontFamily structure is used to represent a family of related
 font faces. The faces in a family share a common design, but differ in
 slant, weight, width and other aspects.</doc>
@@ -4071,12 +3449,7 @@ width and other aspects.</doc>
             <doc xml:space="preserve">a #PangoFontFamily</doc>
             <type name="FontFamily" c:type="PangoFontFamily*"/>
           </instance-parameter>
-          <parameter name="faces"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="container"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="faces" direction="out" caller-allocates="0" transfer-ownership="container" optional="1" allow-none="1">
             <doc xml:space="preserve">
   location to store an array of pointers to #PangoFontFace objects,
   or %NULL. This array should be freed with g_free() when it is no
@@ -4085,10 +3458,7 @@ width and other aspects.</doc>
               <type name="FontFace" c:type="PangoFontFace**"/>
             </array>
           </parameter>
-          <parameter name="n_faces"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="n_faces" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store number of elements in @faces.</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
@@ -4110,9 +3480,7 @@ to specify that a face from this family is desired.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="is_monospace"
-              c:identifier="pango_font_family_is_monospace"
-              version="1.4">
+      <method name="is_monospace" c:identifier="pango_font_family_is_monospace" version="1.4">
         <doc xml:space="preserve">A monospace font is a font designed for text display where the the
 characters form a regular grid. For Western languages this would
 mean that the advance width of all characters are the same, but
@@ -4148,12 +3516,7 @@ width and other aspects.</doc>
             <doc xml:space="preserve">a #PangoFontFamily</doc>
             <type name="FontFamily" c:type="PangoFontFamily*"/>
           </instance-parameter>
-          <parameter name="faces"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="container"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="faces" direction="out" caller-allocates="0" transfer-ownership="container" optional="1" allow-none="1">
             <doc xml:space="preserve">
   location to store an array of pointers to #PangoFontFace objects,
   or %NULL. This array should be freed with g_free() when it is no
@@ -4162,10 +3525,7 @@ width and other aspects.</doc>
               <type name="FontFace" c:type="PangoFontFace**"/>
             </array>
           </parameter>
-          <parameter name="n_faces"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="n_faces" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store number of elements in @faces.</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
@@ -4175,9 +3535,7 @@ width and other aspects.</doc>
         <type name="GObject.Object" c:type="GObject"/>
       </field>
     </class>
-    <record name="FontFamilyClass"
-            c:type="PangoFontFamilyClass"
-            glib:is-gtype-struct-for="FontFamily">
+    <record name="FontFamilyClass" c:type="PangoFontFamilyClass" glib:is-gtype-struct-for="FontFamily">
       <field name="parent_class">
         <type name="GObject.ObjectClass" c:type="GObjectClass"/>
       </field>
@@ -4191,12 +3549,7 @@ width and other aspects.</doc>
               <doc xml:space="preserve">a #PangoFontFamily</doc>
               <type name="FontFamily" c:type="PangoFontFamily*"/>
             </parameter>
-            <parameter name="faces"
-                       direction="out"
-                       caller-allocates="0"
-                       transfer-ownership="container"
-                       optional="1"
-                       allow-none="1">
+            <parameter name="faces" direction="out" caller-allocates="0" transfer-ownership="container" optional="1" allow-none="1">
               <doc xml:space="preserve">
   location to store an array of pointers to #PangoFontFace objects,
   or %NULL. This array should be freed with g_free() when it is no
@@ -4205,10 +3558,7 @@ width and other aspects.</doc>
                 <type name="FontFace" c:type="PangoFontFace**"/>
               </array>
             </parameter>
-            <parameter name="n_faces"
-                       direction="out"
-                       caller-allocates="0"
-                       transfer-ownership="full">
+            <parameter name="n_faces" direction="out" caller-allocates="0" transfer-ownership="full">
               <doc xml:space="preserve">location to store number of elements in @faces.</doc>
               <type name="gint" c:type="int*"/>
             </parameter>
@@ -4266,14 +3616,7 @@ width and other aspects.</doc>
         </callback>
       </field>
     </record>
-    <class name="FontMap"
-           c:symbol-prefix="font_map"
-           c:type="PangoFontMap"
-           parent="GObject.Object"
-           abstract="1"
-           glib:type-name="PangoFontMap"
-           glib:get-type="pango_font_map_get_type"
-           glib:type-struct="FontMapClass">
+    <class name="FontMap" c:symbol-prefix="font_map" c:type="PangoFontMap" parent="GObject.Object" abstract="1" glib:type-name="PangoFontMap" glib:get-type="pango_font_map_get_type" glib:type-struct="FontMapClass">
       <doc xml:space="preserve">The #PangoFontMap represents the set of fonts available for a
 particular rendering system. This is a virtual object with
 implementations being specific to particular rendering systems.  To
@@ -4336,20 +3679,14 @@ in #PangoContext.</doc>
             <doc xml:space="preserve">a #PangoFontMap</doc>
             <type name="FontMap" c:type="PangoFontMap*"/>
           </instance-parameter>
-          <parameter name="families"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="container">
+          <parameter name="families" direction="out" caller-allocates="0" transfer-ownership="container">
             <doc xml:space="preserve">location to store a pointer to an array of #PangoFontFamily *.
            This array should be freed with g_free().</doc>
             <array length="1" zero-terminated="0" c:type="PangoFontFamily***">
               <type name="FontFamily" c:type="PangoFontFamily**"/>
             </array>
           </parameter>
-          <parameter name="n_families"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="n_families" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store the number of elements in @families</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
@@ -4404,9 +3741,7 @@ a font matching @desc.</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <method name="changed"
-              c:identifier="pango_font_map_changed"
-              version="1.34">
+      <method name="changed" c:identifier="pango_font_map_changed" version="1.34">
         <doc xml:space="preserve">Forces a change in the context, which will cause any #PangoContext
 using this fontmap to change.
 
@@ -4424,9 +3759,7 @@ and such data is changed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="create_context"
-              c:identifier="pango_font_map_create_context"
-              version="1.22">
+      <method name="create_context" c:identifier="pango_font_map_create_context" version="1.22">
         <doc xml:space="preserve">Creates a #PangoContext connected to @fontmap.  This is equivalent
 to pango_context_new() followed by pango_context_set_font_map().
 
@@ -4447,9 +3780,7 @@ gtk_widget_get_pango_context().  Use those instead.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_serial"
-              c:identifier="pango_font_map_get_serial"
-              version="1.32.4">
+      <method name="get_serial" c:identifier="pango_font_map_get_serial" version="1.32.4">
         <doc xml:space="preserve">Returns the current serial number of @fontmap.  The serial number is
 initialized to an small number larger than zero when a new fontmap
 is created and is increased whenever the fontmap is changed. It may
@@ -4472,11 +3803,7 @@ in #PangoContext.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_shape_engine_type"
-              c:identifier="pango_font_map_get_shape_engine_type"
-              version="1.4"
-              deprecated="1"
-              deprecated-version="1.38">
+      <method name="get_shape_engine_type" c:identifier="pango_font_map_get_shape_engine_type" version="1.4" deprecated="1" deprecated-version="1.38">
         <doc xml:space="preserve">Returns the render ID for shape engines for this fontmap.
 See the &lt;structfield&gt;render_type&lt;/structfield&gt; field of
 #PangoEngineInfo.</doc>
@@ -4503,20 +3830,14 @@ See the &lt;structfield&gt;render_type&lt;/structfield&gt; field of
             <doc xml:space="preserve">a #PangoFontMap</doc>
             <type name="FontMap" c:type="PangoFontMap*"/>
           </instance-parameter>
-          <parameter name="families"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="container">
+          <parameter name="families" direction="out" caller-allocates="0" transfer-ownership="container">
             <doc xml:space="preserve">location to store a pointer to an array of #PangoFontFamily *.
            This array should be freed with g_free().</doc>
             <array length="1" zero-terminated="0" c:type="PangoFontFamily***">
               <type name="FontFamily" c:type="PangoFontFamily**"/>
             </array>
           </parameter>
-          <parameter name="n_families"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="n_families" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store the number of elements in @families</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
@@ -4575,9 +3896,7 @@ a font matching @desc.</doc>
         <type name="GObject.Object" c:type="GObject"/>
       </field>
     </class>
-    <record name="FontMapClass"
-            c:type="PangoFontMapClass"
-            glib:is-gtype-struct-for="FontMap">
+    <record name="FontMapClass" c:type="PangoFontMapClass" glib:is-gtype-struct-for="FontMap">
       <doc xml:space="preserve">The #PangoFontMapClass structure holds the virtual functions for
 a particular #PangoFontMap implementation.</doc>
       <field name="parent_class">
@@ -4602,8 +3921,7 @@ a particular #PangoFontMap implementation.</doc>
             </parameter>
             <parameter name="desc" transfer-ownership="none">
               <doc xml:space="preserve">a #PangoFontDescription describing the font to load</doc>
-              <type name="FontDescription"
-                    c:type="const PangoFontDescription*"/>
+              <type name="FontDescription" c:type="const PangoFontDescription*"/>
             </parameter>
           </parameters>
         </callback>
@@ -4618,22 +3936,14 @@ a particular #PangoFontMap implementation.</doc>
               <doc xml:space="preserve">a #PangoFontMap</doc>
               <type name="FontMap" c:type="PangoFontMap*"/>
             </parameter>
-            <parameter name="families"
-                       direction="out"
-                       caller-allocates="0"
-                       transfer-ownership="container">
+            <parameter name="families" direction="out" caller-allocates="0" transfer-ownership="container">
               <doc xml:space="preserve">location to store a pointer to an array of #PangoFontFamily *.
            This array should be freed with g_free().</doc>
-              <array length="2"
-                     zero-terminated="0"
-                     c:type="PangoFontFamily***">
+              <array length="2" zero-terminated="0" c:type="PangoFontFamily***">
                 <type name="FontFamily" c:type="PangoFontFamily**"/>
               </array>
             </parameter>
-            <parameter name="n_families"
-                       direction="out"
-                       caller-allocates="0"
-                       transfer-ownership="full">
+            <parameter name="n_families" direction="out" caller-allocates="0" transfer-ownership="full">
               <doc xml:space="preserve">location to store the number of elements in @families</doc>
               <type name="gint" c:type="int*"/>
             </parameter>
@@ -4658,8 +3968,7 @@ a particular #PangoFontMap implementation.</doc>
             </parameter>
             <parameter name="desc" transfer-ownership="none">
               <doc xml:space="preserve">a #PangoFontDescription describing the font to load</doc>
-              <type name="FontDescription"
-                    c:type="const PangoFontDescription*"/>
+              <type name="FontDescription" c:type="const PangoFontDescription*"/>
             </parameter>
             <parameter name="language" transfer-ownership="none">
               <doc xml:space="preserve">a #PangoLanguage the fonts will be used for</doc>
@@ -4715,60 +4024,32 @@ can handle fonts of this fonts loaded with this fontmap.</doc>
         </callback>
       </field>
     </record>
-    <bitfield name="FontMask"
-              glib:type-name="PangoFontMask"
-              glib:get-type="pango_font_mask_get_type"
-              c:type="PangoFontMask">
+    <bitfield name="FontMask" glib:type-name="PangoFontMask" glib:get-type="pango_font_mask_get_type" c:type="PangoFontMask">
       <doc xml:space="preserve">The bits in a #PangoFontMask correspond to fields in a
 #PangoFontDescription that have been set.</doc>
-      <member name="family"
-              value="1"
-              c:identifier="PANGO_FONT_MASK_FAMILY"
-              glib:nick="family">
+      <member name="family" value="1" c:identifier="PANGO_FONT_MASK_FAMILY" glib:nick="family">
         <doc xml:space="preserve">the font family is specified.</doc>
       </member>
-      <member name="style"
-              value="2"
-              c:identifier="PANGO_FONT_MASK_STYLE"
-              glib:nick="style">
+      <member name="style" value="2" c:identifier="PANGO_FONT_MASK_STYLE" glib:nick="style">
         <doc xml:space="preserve">the font style is specified.</doc>
       </member>
-      <member name="variant"
-              value="4"
-              c:identifier="PANGO_FONT_MASK_VARIANT"
-              glib:nick="variant">
+      <member name="variant" value="4" c:identifier="PANGO_FONT_MASK_VARIANT" glib:nick="variant">
         <doc xml:space="preserve">the font variant is specified.</doc>
       </member>
-      <member name="weight"
-              value="8"
-              c:identifier="PANGO_FONT_MASK_WEIGHT"
-              glib:nick="weight">
+      <member name="weight" value="8" c:identifier="PANGO_FONT_MASK_WEIGHT" glib:nick="weight">
         <doc xml:space="preserve">the font weight is specified.</doc>
       </member>
-      <member name="stretch"
-              value="16"
-              c:identifier="PANGO_FONT_MASK_STRETCH"
-              glib:nick="stretch">
+      <member name="stretch" value="16" c:identifier="PANGO_FONT_MASK_STRETCH" glib:nick="stretch">
         <doc xml:space="preserve">the font stretch is specified.</doc>
       </member>
-      <member name="size"
-              value="32"
-              c:identifier="PANGO_FONT_MASK_SIZE"
-              glib:nick="size">
+      <member name="size" value="32" c:identifier="PANGO_FONT_MASK_SIZE" glib:nick="size">
         <doc xml:space="preserve">the font size is specified.</doc>
       </member>
-      <member name="gravity"
-              value="64"
-              c:identifier="PANGO_FONT_MASK_GRAVITY"
-              glib:nick="gravity">
+      <member name="gravity" value="64" c:identifier="PANGO_FONT_MASK_GRAVITY" glib:nick="gravity">
         <doc xml:space="preserve">the font gravity is specified (Since: 1.16.)</doc>
       </member>
     </bitfield>
-    <record name="FontMetrics"
-            c:type="PangoFontMetrics"
-            glib:type-name="PangoFontMetrics"
-            glib:get-type="pango_font_metrics_get_type"
-            c:symbol-prefix="font_metrics">
+    <record name="FontMetrics" c:type="PangoFontMetrics" glib:type-name="PangoFontMetrics" glib:get-type="pango_font_metrics_get_type" c:symbol-prefix="font_metrics">
       <doc xml:space="preserve">A #PangoFontMetrics structure holds the overall metric information
 for a font (possibly restricted to a script). The fields of this
 structure are private to implementations of a font backend. See
@@ -4811,8 +4092,7 @@ to set the fields of the structure.</doc>
           <type name="FontMetrics" c:type="PangoFontMetrics*"/>
         </return-value>
       </constructor>
-      <method name="get_approximate_char_width"
-              c:identifier="pango_font_metrics_get_approximate_char_width">
+      <method name="get_approximate_char_width" c:identifier="pango_font_metrics_get_approximate_char_width">
         <doc xml:space="preserve">Gets the approximate character width for a font metrics structure.
 This is merely a representative value useful, for example, for
 determining the initial size for a window. Actual characters in
@@ -4828,8 +4108,7 @@ text will be wider and narrower than this.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_approximate_digit_width"
-              c:identifier="pango_font_metrics_get_approximate_digit_width">
+      <method name="get_approximate_digit_width" c:identifier="pango_font_metrics_get_approximate_digit_width">
         <doc xml:space="preserve">Gets the approximate digit width for a font metrics structure.
 This is merely a representative value useful, for example, for
 determining the initial size for a window. Actual digits in
@@ -4881,9 +4160,7 @@ where the ink will be.)</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_strikethrough_position"
-              c:identifier="pango_font_metrics_get_strikethrough_position"
-              version="1.6">
+      <method name="get_strikethrough_position" c:identifier="pango_font_metrics_get_strikethrough_position" version="1.6">
         <doc xml:space="preserve">Gets the suggested position to draw the strikethrough.
 The value returned is the distance &lt;emphasis&gt;above&lt;/emphasis&gt; the
 baseline of the top of the strikethrough.</doc>
@@ -4898,9 +4175,7 @@ baseline of the top of the strikethrough.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_strikethrough_thickness"
-              c:identifier="pango_font_metrics_get_strikethrough_thickness"
-              version="1.6">
+      <method name="get_strikethrough_thickness" c:identifier="pango_font_metrics_get_strikethrough_thickness" version="1.6">
         <doc xml:space="preserve">Gets the suggested thickness to draw for the strikethrough.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the suggested strikethrough thickness, in Pango units.</doc>
@@ -4913,9 +4188,7 @@ baseline of the top of the strikethrough.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_underline_position"
-              c:identifier="pango_font_metrics_get_underline_position"
-              version="1.6">
+      <method name="get_underline_position" c:identifier="pango_font_metrics_get_underline_position" version="1.6">
         <doc xml:space="preserve">Gets the suggested position to draw the underline.
 The value returned is the distance &lt;emphasis&gt;above&lt;/emphasis&gt; the
 baseline of the top of the underline. Since most fonts have
@@ -4932,9 +4205,7 @@ negative.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_underline_thickness"
-              c:identifier="pango_font_metrics_get_underline_thickness"
-              version="1.6">
+      <method name="get_underline_thickness" c:identifier="pango_font_metrics_get_underline_thickness" version="1.6">
         <doc xml:space="preserve">Gets the suggested thickness to draw for the underline.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the suggested underline thickness, in Pango units.</doc>
@@ -4954,10 +4225,7 @@ negative.</doc>
           <type name="FontMetrics" c:type="PangoFontMetrics*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="metrics"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="metrics" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoFontMetrics structure, may be %NULL</doc>
             <type name="FontMetrics" c:type="PangoFontMetrics*"/>
           </instance-parameter>
@@ -4971,24 +4239,14 @@ memory.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="metrics"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="metrics" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoFontMetrics structure, may be %NULL</doc>
             <type name="FontMetrics" c:type="PangoFontMetrics*"/>
           </instance-parameter>
         </parameters>
       </method>
     </record>
-    <class name="Fontset"
-           c:symbol-prefix="fontset"
-           c:type="PangoFontset"
-           parent="GObject.Object"
-           abstract="1"
-           glib:type-name="PangoFontset"
-           glib:get-type="pango_fontset_get_type"
-           glib:type-struct="FontsetClass">
+    <class name="Fontset" c:symbol-prefix="fontset" c:type="PangoFontset" parent="GObject.Object" abstract="1" glib:type-name="PangoFontset" glib:get-type="pango_fontset_get_type" glib:type-struct="FontsetClass">
       <doc xml:space="preserve">A #PangoFontset represents a set of #PangoFont to use
 when rendering text. It is the result of resolving a
 #PangoFontDescription against a particular #PangoContext.
@@ -5006,17 +4264,11 @@ each one. If @func returns %TRUE, that stops the iteration.</doc>
             <doc xml:space="preserve">a #PangoFontset</doc>
             <type name="Fontset" c:type="PangoFontset*"/>
           </instance-parameter>
-          <parameter name="func"
-                     transfer-ownership="none"
-                     scope="call"
-                     closure="1">
+          <parameter name="func" transfer-ownership="none" scope="call" closure="1">
             <doc xml:space="preserve">Callback function</doc>
             <type name="FontsetForeachFunc" c:type="PangoFontsetForeachFunc"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">data to pass to the callback function</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -5065,9 +4317,7 @@ Unicode character @wc.</doc>
           </instance-parameter>
         </parameters>
       </virtual-method>
-      <method name="foreach"
-              c:identifier="pango_fontset_foreach"
-              version="1.4">
+      <method name="foreach" c:identifier="pango_fontset_foreach" version="1.4">
         <doc xml:space="preserve">Iterates through all the fonts in a fontset, calling @func for
 each one. If @func returns %TRUE, that stops the iteration.</doc>
         <return-value transfer-ownership="none">
@@ -5078,17 +4328,11 @@ each one. If @func returns %TRUE, that stops the iteration.</doc>
             <doc xml:space="preserve">a #PangoFontset</doc>
             <type name="Fontset" c:type="PangoFontset*"/>
           </instance-parameter>
-          <parameter name="func"
-                     transfer-ownership="none"
-                     scope="call"
-                     closure="1">
+          <parameter name="func" transfer-ownership="none" scope="call" closure="1">
             <doc xml:space="preserve">Callback function</doc>
             <type name="FontsetForeachFunc" c:type="PangoFontsetForeachFunc"/>
           </parameter>
-          <parameter name="data"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">data to pass to the callback function</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
@@ -5131,9 +4375,7 @@ Unicode character @wc.</doc>
         <type name="GObject.Object" c:type="GObject"/>
       </field>
     </class>
-    <record name="FontsetClass"
-            c:type="PangoFontsetClass"
-            glib:is-gtype-struct-for="Fontset">
+    <record name="FontsetClass" c:type="PangoFontsetClass" glib:is-gtype-struct-for="Fontset">
       <doc xml:space="preserve">The #PangoFontsetClass structure holds the virtual functions for
 a particular #PangoFontset implementation.</doc>
       <field name="parent_class">
@@ -5196,18 +4438,11 @@ a particular #PangoFontset implementation.</doc>
               <doc xml:space="preserve">a #PangoFontset</doc>
               <type name="Fontset" c:type="PangoFontset*"/>
             </parameter>
-            <parameter name="func"
-                       transfer-ownership="none"
-                       scope="call"
-                       closure="2">
+            <parameter name="func" transfer-ownership="none" scope="call" closure="2">
               <doc xml:space="preserve">Callback function</doc>
-              <type name="FontsetForeachFunc"
-                    c:type="PangoFontsetForeachFunc"/>
+              <type name="FontsetForeachFunc" c:type="PangoFontsetForeachFunc"/>
             </parameter>
-            <parameter name="data"
-                       transfer-ownership="none"
-                       nullable="1"
-                       allow-none="1">
+            <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
               <doc xml:space="preserve">data to pass to the callback function</doc>
               <type name="gpointer" c:type="gpointer"/>
             </parameter>
@@ -5243,9 +4478,7 @@ a particular #PangoFontset implementation.</doc>
         </callback>
       </field>
     </record>
-    <callback name="FontsetForeachFunc"
-              c:type="PangoFontsetForeachFunc"
-              version="1.4">
+    <callback name="FontsetForeachFunc" c:type="PangoFontsetForeachFunc" version="1.4">
       <doc xml:space="preserve">A callback function used by pango_fontset_foreach() when enumerating
 the fonts in a fontset.</doc>
       <return-value transfer-ownership="none">
@@ -5261,23 +4494,13 @@ the fonts in a fontset.</doc>
           <doc xml:space="preserve">a font from @fontset</doc>
           <type name="Font" c:type="PangoFont*"/>
         </parameter>
-        <parameter name="user_data"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1"
-                   closure="2">
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="2">
           <doc xml:space="preserve">callback data</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
       </parameters>
     </callback>
-    <class name="FontsetSimple"
-           c:symbol-prefix="fontset_simple"
-           c:type="PangoFontsetSimple"
-           parent="Fontset"
-           glib:type-name="PangoFontsetSimple"
-           glib:get-type="pango_fontset_simple_get_type"
-           glib:type-struct="FontsetSimpleClass">
+    <class name="FontsetSimple" c:symbol-prefix="fontset_simple" c:type="PangoFontsetSimple" parent="Fontset" glib:type-name="PangoFontsetSimple" glib:get-type="pango_fontset_simple_get_type" glib:type-struct="FontsetSimpleClass">
       <doc xml:space="preserve">#PangoFontsetSimple is a implementation of the abstract
 #PangoFontset base class in terms of an array of fonts,
 which the creator provides when constructing the
@@ -5326,10 +4549,7 @@ which the creator provides when constructing the
         </parameters>
       </method>
     </class>
-    <record name="FontsetSimpleClass"
-            c:type="PangoFontsetSimpleClass"
-            disguised="1"
-            glib:is-gtype-struct-for="FontsetSimple">
+    <record name="FontsetSimpleClass" c:type="PangoFontsetSimpleClass" disguised="1" glib:is-gtype-struct-for="FontsetSimple">
     </record>
     <constant name="GLYPH_EMPTY" value="268435455" c:type="PANGO_GLYPH_EMPTY">
       <doc xml:space="preserve">The %PANGO_GLYPH_EMPTY macro represents a #PangoGlyph value that has a
@@ -5338,10 +4558,7 @@ example in shaper modules, to use as the glyph for various zero-width
 Unicode characters (those passing pango_is_zero_width()).</doc>
       <type name="Glyph" c:type="PangoGlyph"/>
     </constant>
-    <constant name="GLYPH_INVALID_INPUT"
-              value="4294967295"
-              c:type="PANGO_GLYPH_INVALID_INPUT"
-              version="1.20">
+    <constant name="GLYPH_INVALID_INPUT" value="4294967295" c:type="PANGO_GLYPH_INVALID_INPUT" version="1.20">
       <doc xml:space="preserve">The %PANGO_GLYPH_INVALID_INPUT macro represents a #PangoGlyph value that has a
 special meaning of invalid input.  #PangoLayout produces one such glyph
 per invalid input UTF-8 byte and such a glyph is rendered as a crossed
@@ -5351,9 +4568,7 @@ Note that this value is defined such that it has the %PANGO_GLYPH_UNKNOWN_FLAG
 on.</doc>
       <type name="Glyph" c:type="PangoGlyph"/>
     </constant>
-    <constant name="GLYPH_UNKNOWN_FLAG"
-              value="268435456"
-              c:type="PANGO_GLYPH_UNKNOWN_FLAG">
+    <constant name="GLYPH_UNKNOWN_FLAG" value="268435456" c:type="PANGO_GLYPH_UNKNOWN_FLAG">
       <doc xml:space="preserve">The %PANGO_GLYPH_UNKNOWN_FLAG macro is a flag value that can be added to
 a #gunichar value of a valid Unicode character, to produce a #PangoGlyph
 value, representing an unknown-character glyph for the respective #gunichar.</doc>
@@ -5392,11 +4607,7 @@ It contains the following fields.</doc>
         <type name="GlyphVisAttr" c:type="PangoGlyphVisAttr"/>
       </field>
     </record>
-    <record name="GlyphItem"
-            c:type="PangoGlyphItem"
-            glib:type-name="PangoGlyphItem"
-            glib:get-type="pango_glyph_item_get_type"
-            c:symbol-prefix="glyph_item">
+    <record name="GlyphItem" c:type="PangoGlyphItem" glib:type-name="PangoGlyphItem" glib:get-type="pango_glyph_item_get_type" c:symbol-prefix="glyph_item">
       <doc xml:space="preserve">A #PangoGlyphItem is a pair of a #PangoItem and the glyphs
 resulting from shaping the text corresponding to an item.
 As an example of the usage of #PangoGlyphItem, the results
@@ -5410,9 +4621,7 @@ each of which contains a list of #PangoGlyphItem.</doc>
         <doc xml:space="preserve">corresponding #PangoGlyphString.</doc>
         <type name="GlyphString" c:type="PangoGlyphString*"/>
       </field>
-      <method name="apply_attrs"
-              c:identifier="pango_glyph_item_apply_attrs"
-              version="1.2">
+      <method name="apply_attrs" c:identifier="pango_glyph_item_apply_attrs" version="1.2">
         <doc xml:space="preserve">Splits a shaped item (PangoGlyphItem) into multiple items based
 on an attribute list. The idea is that if you have attributes
 that don't affect shaping, such as color or underline, to avoid
@@ -5462,10 +4671,7 @@ as one of the elements in the list.</doc>
           <type name="GlyphItem" c:type="PangoGlyphItem*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="orig"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="orig" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoGlyphItem, may be %NULL</doc>
             <type name="GlyphItem" c:type="PangoGlyphItem*"/>
           </instance-parameter>
@@ -5477,18 +4683,13 @@ as one of the elements in the list.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="glyph_item"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="glyph_item" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoGlyphItem, may be %NULL</doc>
             <type name="GlyphItem" c:type="PangoGlyphItem*"/>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_logical_widths"
-              c:identifier="pango_glyph_item_get_logical_widths"
-              version="1.26">
+      <method name="get_logical_widths" c:identifier="pango_glyph_item_get_logical_widths" version="1.26">
         <doc xml:space="preserve">Given a #PangoGlyphItem and the corresponding
 text, determine the screen width corresponding to each character. When
 multiple characters compose a single cluster, the width of the entire
@@ -5520,9 +4721,7 @@ See also pango_glyph_string_get_logical_widths().</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="letter_space"
-              c:identifier="pango_glyph_item_letter_space"
-              version="1.6">
+      <method name="letter_space" c:identifier="pango_glyph_item_letter_space" version="1.6">
         <doc xml:space="preserve">Adds spacing between the graphemes of @glyph_item to
 give the effect of typographic letter spacing.</doc>
         <return-value transfer-ownership="none">
@@ -5588,12 +4787,7 @@ it internally.)</doc>
         </parameters>
       </method>
     </record>
-    <record name="GlyphItemIter"
-            c:type="PangoGlyphItemIter"
-            version="1.22"
-            glib:type-name="PangoGlyphItemIter"
-            glib:get-type="pango_glyph_item_iter_get_type"
-            c:symbol-prefix="glyph_item_iter">
+    <record name="GlyphItemIter" c:type="PangoGlyphItemIter" version="1.22" glib:type-name="PangoGlyphItemIter" glib:get-type="pango_glyph_item_iter_get_type" c:symbol-prefix="glyph_item_iter">
       <doc xml:space="preserve">A #PangoGlyphItemIter is an iterator over the clusters in a
 #PangoGlyphItem.  The &lt;firstterm&gt;forward direction&lt;/firstterm&gt; of the
 iterator is the logical direction of text.  That is, with increasing
@@ -5655,9 +4849,7 @@ None of the members of a #PangoGlyphItemIter should be modified manually.</doc>
       <field name="end_char" writable="1">
         <type name="gint" c:type="int"/>
       </field>
-      <method name="copy"
-              c:identifier="pango_glyph_item_iter_copy"
-              version="1.22">
+      <method name="copy" c:identifier="pango_glyph_item_iter_copy" version="1.22">
         <doc xml:space="preserve">Make a shallow copy of an existing #PangoGlyphItemIter structure.</doc>
         <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">the newly allocated #PangoGlyphItemIter, which should
@@ -5666,35 +4858,25 @@ None of the members of a #PangoGlyphItemIter should be modified manually.</doc>
           <type name="GlyphItemIter" c:type="PangoGlyphItemIter*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="orig"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="orig" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoGlyphItemIter, may be %NULL</doc>
             <type name="GlyphItemIter" c:type="PangoGlyphItemIter*"/>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="free"
-              c:identifier="pango_glyph_item_iter_free"
-              version="1.22">
+      <method name="free" c:identifier="pango_glyph_item_iter_free" version="1.22">
         <doc xml:space="preserve">Frees a #PangoGlyphItemIter created by pango_glyph_item_iter_copy().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="iter"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="iter" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoGlyphItemIter, may be %NULL</doc>
             <type name="GlyphItemIter" c:type="PangoGlyphItemIter*"/>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="init_end"
-              c:identifier="pango_glyph_item_iter_init_end"
-              version="1.22">
+      <method name="init_end" c:identifier="pango_glyph_item_iter_init_end" version="1.22">
         <doc xml:space="preserve">Initializes a #PangoGlyphItemIter structure to point to the
 last cluster in a glyph item.
 See #PangoGlyphItemIter for details of cluster orders.</doc>
@@ -5717,9 +4899,7 @@ See #PangoGlyphItemIter for details of cluster orders.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="init_start"
-              c:identifier="pango_glyph_item_iter_init_start"
-              version="1.22">
+      <method name="init_start" c:identifier="pango_glyph_item_iter_init_start" version="1.22">
         <doc xml:space="preserve">Initializes a #PangoGlyphItemIter structure to point to the
 first cluster in a glyph item.
 See #PangoGlyphItemIter for details of cluster orders.</doc>
@@ -5742,9 +4922,7 @@ See #PangoGlyphItemIter for details of cluster orders.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="next_cluster"
-              c:identifier="pango_glyph_item_iter_next_cluster"
-              version="1.22">
+      <method name="next_cluster" c:identifier="pango_glyph_item_iter_next_cluster" version="1.22">
         <doc xml:space="preserve">Advances the iterator to the next cluster in the glyph item.
 See #PangoGlyphItemIter for details of cluster orders.</doc>
         <return-value transfer-ownership="none">
@@ -5759,9 +4937,7 @@ See #PangoGlyphItemIter for details of cluster orders.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="prev_cluster"
-              c:identifier="pango_glyph_item_iter_prev_cluster"
-              version="1.22">
+      <method name="prev_cluster" c:identifier="pango_glyph_item_iter_prev_cluster" version="1.22">
         <doc xml:space="preserve">Moves the iterator to the preceding cluster in the glyph item.
 See #PangoGlyphItemIter for details of cluster orders.</doc>
         <return-value transfer-ownership="none">
@@ -5777,11 +4953,7 @@ See #PangoGlyphItemIter for details of cluster orders.</doc>
         </parameters>
       </method>
     </record>
-    <record name="GlyphString"
-            c:type="PangoGlyphString"
-            glib:type-name="PangoGlyphString"
-            glib:get-type="pango_glyph_string_get_type"
-            c:symbol-prefix="glyph_string">
+    <record name="GlyphString" c:type="PangoGlyphString" glib:type-name="PangoGlyphString" glib:get-type="pango_glyph_string_get_type" c:symbol-prefix="glyph_string">
       <doc xml:space="preserve">The #PangoGlyphString structure is used to store strings
 of glyphs with geometry and visual attribute information.
 The storage for the glyph information is owned
@@ -5822,10 +4994,7 @@ by the structure which simplifies memory management.</doc>
           <type name="GlyphString" c:type="PangoGlyphString*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="string"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="string" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoGlyphString, may be %NULL</doc>
             <type name="GlyphString" c:type="PangoGlyphString*"/>
           </instance-parameter>
@@ -5847,30 +5016,19 @@ of the rectangles.</doc>
             <doc xml:space="preserve">a #PangoFont</doc>
             <type name="Font" c:type="PangoFont*"/>
           </parameter>
-          <parameter name="ink_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="ink_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to store the extents of the glyph string
            as drawn or %NULL to indicate that the result is not needed.</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
-          <parameter name="logical_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="logical_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to store the logical extents of the
            glyph string or %NULL to indicate that the result is not needed.</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="extents_range"
-              c:identifier="pango_glyph_string_extents_range">
+      <method name="extents_range" c:identifier="pango_glyph_string_extents_range">
         <doc xml:space="preserve">Computes the extents of a sub-portion of a glyph string. The extents are
 relative to the start of the glyph string range (the origin of their
 coordinate system is at the start of the range, not at the start of the entire
@@ -5896,23 +5054,13 @@ glyph string).</doc>
             <doc xml:space="preserve">a #PangoFont</doc>
             <type name="Font" c:type="PangoFont*"/>
           </parameter>
-          <parameter name="ink_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="ink_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to
            store the extents of the glyph string range as drawn or
            %NULL to indicate that the result is not needed.</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
-          <parameter name="logical_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="logical_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to
            store the logical extents of the glyph string range or
            %NULL to indicate that the result is not needed.</doc>
@@ -5926,17 +5074,13 @@ glyph string).</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="string"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="string" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoGlyphString, may be %NULL</doc>
             <type name="GlyphString" c:type="PangoGlyphString*"/>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_logical_widths"
-              c:identifier="pango_glyph_string_get_logical_widths">
+      <method name="get_logical_widths" c:identifier="pango_glyph_string_get_logical_widths">
         <doc xml:space="preserve">Given a #PangoGlyphString resulting from pango_shape() and the corresponding
 text, determine the screen width corresponding to each character. When
 multiple characters compose a single cluster, the width of the entire
@@ -5974,9 +5118,7 @@ See also pango_glyph_item_get_logical_widths().</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_width"
-              c:identifier="pango_glyph_string_get_width"
-              version="1.14">
+      <method name="get_width" c:identifier="pango_glyph_string_get_width" version="1.14">
         <doc xml:space="preserve">Computes the logical width of the glyph string as can also be computed
 using pango_glyph_string_extents().  However, since this only computes the
 width, it's much faster.  This is in fact only a convenience function that
@@ -6025,10 +5167,7 @@ are computed by dividing up each cluster into equal portions.</doc>
             or end (%TRUE) of the character.</doc>
             <type name="gboolean" c:type="gboolean"/>
           </parameter>
-          <parameter name="x_pos"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="x_pos" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store result</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
@@ -6081,17 +5220,11 @@ attributes for the text to compute the valid cursor position.</doc>
             <doc xml:space="preserve">the x offset (in Pango units)</doc>
             <type name="gint" c:type="int"/>
           </parameter>
-          <parameter name="index_"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="index_" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store calculated byte index within @text</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
-          <parameter name="trailing"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="trailing" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store a boolean indicating
             whether the user clicked on the leading or trailing
             edge of the character.</doc>
@@ -6113,11 +5246,7 @@ follow the glyphs for the base character.)</doc>
         <type name="guint" c:type="guint"/>
       </field>
     </record>
-    <enumeration name="Gravity"
-                 version="1.16"
-                 glib:type-name="PangoGravity"
-                 glib:get-type="pango_gravity_get_type"
-                 c:type="PangoGravity">
+    <enumeration name="Gravity" version="1.16" glib:type-name="PangoGravity" glib:get-type="pango_gravity_get_type" c:type="PangoGravity">
       <doc xml:space="preserve">The #PangoGravity type represents the orientation of glyphs in a segment
 of text.  This is useful when rendering vertical text layouts.  In
 those situations, the layout is rotated using a non-identity PangoMatrix,
@@ -6128,39 +5257,22 @@ pango_context_set_base_gravity() and can only be returned by
 pango_context_get_base_gravity().
 
 See also: #PangoGravityHint</doc>
-      <member name="south"
-              value="0"
-              c:identifier="PANGO_GRAVITY_SOUTH"
-              glib:nick="south">
+      <member name="south" value="0" c:identifier="PANGO_GRAVITY_SOUTH" glib:nick="south">
         <doc xml:space="preserve">Glyphs stand upright (default)</doc>
       </member>
-      <member name="east"
-              value="1"
-              c:identifier="PANGO_GRAVITY_EAST"
-              glib:nick="east">
+      <member name="east" value="1" c:identifier="PANGO_GRAVITY_EAST" glib:nick="east">
         <doc xml:space="preserve">Glyphs are rotated 90 degrees clockwise</doc>
       </member>
-      <member name="north"
-              value="2"
-              c:identifier="PANGO_GRAVITY_NORTH"
-              glib:nick="north">
+      <member name="north" value="2" c:identifier="PANGO_GRAVITY_NORTH" glib:nick="north">
         <doc xml:space="preserve">Glyphs are upside-down</doc>
       </member>
-      <member name="west"
-              value="3"
-              c:identifier="PANGO_GRAVITY_WEST"
-              glib:nick="west">
+      <member name="west" value="3" c:identifier="PANGO_GRAVITY_WEST" glib:nick="west">
         <doc xml:space="preserve">Glyphs are rotated 90 degrees counter-clockwise</doc>
       </member>
-      <member name="auto"
-              value="4"
-              c:identifier="PANGO_GRAVITY_AUTO"
-              glib:nick="auto">
+      <member name="auto" value="4" c:identifier="PANGO_GRAVITY_AUTO" glib:nick="auto">
         <doc xml:space="preserve">Gravity is resolved from the context matrix</doc>
       </member>
-      <function name="get_for_matrix"
-                c:identifier="pango_gravity_get_for_matrix"
-                version="1.16">
+      <function name="get_for_matrix" c:identifier="pango_gravity_get_for_matrix" version="1.16">
         <doc xml:space="preserve">Finds the gravity that best matches the rotation component
 in a #PangoMatrix.</doc>
         <return-value transfer-ownership="none">
@@ -6169,18 +5281,13 @@ in a #PangoMatrix.</doc>
           <type name="Gravity" c:type="PangoGravity"/>
         </return-value>
         <parameters>
-          <parameter name="matrix"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="matrix" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoMatrix</doc>
             <type name="Matrix" c:type="const PangoMatrix*"/>
           </parameter>
         </parameters>
       </function>
-      <function name="get_for_script"
-                c:identifier="pango_gravity_get_for_script"
-                version="1.16">
+      <function name="get_for_script" c:identifier="pango_gravity_get_for_script" version="1.16">
         <doc xml:space="preserve">Based on the script, base gravity, and hint, returns actual gravity
 to use in laying out a single #PangoItem.
 
@@ -6207,9 +5314,7 @@ with @script.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="get_for_script_and_width"
-                c:identifier="pango_gravity_get_for_script_and_width"
-                version="1.26">
+      <function name="get_for_script_and_width" c:identifier="pango_gravity_get_for_script_and_width" version="1.26">
         <doc xml:space="preserve">Based on the script, East Asian width, base gravity, and hint,
 returns actual gravity to use in laying out a single character
 or #PangoItem.
@@ -6247,9 +5352,7 @@ with @script and @wide.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="to_rotation"
-                c:identifier="pango_gravity_to_rotation"
-                version="1.16">
+      <function name="to_rotation" c:identifier="pango_gravity_to_rotation" version="1.16">
         <doc xml:space="preserve">Converts a #PangoGravity value to its natural rotation in radians.
 @gravity should not be %PANGO_GRAVITY_AUTO.
 
@@ -6268,44 +5371,28 @@ you should multiply it by (180. / G_PI).</doc>
         </parameters>
       </function>
     </enumeration>
-    <enumeration name="GravityHint"
-                 version="1.16"
-                 glib:type-name="PangoGravityHint"
-                 glib:get-type="pango_gravity_hint_get_type"
-                 c:type="PangoGravityHint">
+    <enumeration name="GravityHint" version="1.16" glib:type-name="PangoGravityHint" glib:get-type="pango_gravity_hint_get_type" c:type="PangoGravityHint">
       <doc xml:space="preserve">The #PangoGravityHint defines how horizontal scripts should behave in a
 vertical context.  That is, English excerpt in a vertical paragraph for
 example.
 
 See #PangoGravity.</doc>
-      <member name="natural"
-              value="0"
-              c:identifier="PANGO_GRAVITY_HINT_NATURAL"
-              glib:nick="natural">
+      <member name="natural" value="0" c:identifier="PANGO_GRAVITY_HINT_NATURAL" glib:nick="natural">
         <doc xml:space="preserve">scripts will take their natural gravity based
 on the base gravity and the script.  This is the default.</doc>
       </member>
-      <member name="strong"
-              value="1"
-              c:identifier="PANGO_GRAVITY_HINT_STRONG"
-              glib:nick="strong">
+      <member name="strong" value="1" c:identifier="PANGO_GRAVITY_HINT_STRONG" glib:nick="strong">
         <doc xml:space="preserve">always use the base gravity set, regardless of
 the script.</doc>
       </member>
-      <member name="line"
-              value="2"
-              c:identifier="PANGO_GRAVITY_HINT_LINE"
-              glib:nick="line">
+      <member name="line" value="2" c:identifier="PANGO_GRAVITY_HINT_LINE" glib:nick="line">
         <doc xml:space="preserve">for scripts not in their natural direction (eg.
 Latin in East gravity), choose per-script gravity such that every script
 respects the line progression.  This means, Latin and Arabic will take
 opposite gravities and both flow top-to-bottom for example.</doc>
       </member>
     </enumeration>
-    <record name="IncludedModule"
-            c:type="PangoIncludedModule"
-            deprecated="1"
-            deprecated-version="1.38">
+    <record name="IncludedModule" c:type="PangoIncludedModule" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">The #PangoIncludedModule structure for a statically linked module
 contains the functions that would otherwise be loaded from a dynamically
 loaded module.</doc>
@@ -6356,11 +5443,7 @@ loaded module.</doc>
         </callback>
       </field>
     </record>
-    <record name="Item"
-            c:type="PangoItem"
-            glib:type-name="PangoItem"
-            glib:get-type="pango_item_get_type"
-            c:symbol-prefix="item">
+    <record name="Item" c:type="PangoItem" glib:type-name="PangoItem" glib:get-type="pango_item_get_type" c:symbol-prefix="item">
       <doc xml:space="preserve">The #PangoItem structure stores information about a segment of text.</doc>
       <field name="offset" writable="1">
         <doc xml:space="preserve">byte offset of the start of this item in text.</doc>
@@ -6395,10 +5478,7 @@ loaded module.</doc>
           <type name="Item" c:type="PangoItem*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="item"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="item" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoItem, may be %NULL</doc>
             <type name="Item" c:type="PangoItem*"/>
           </instance-parameter>
@@ -6410,10 +5490,7 @@ loaded module.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="item"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="item" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoItem, may be %NULL</doc>
             <type name="Item" c:type="PangoItem*"/>
           </instance-parameter>
@@ -6451,18 +5528,13 @@ length of the split items itself.</doc>
         </parameters>
       </method>
     </record>
-    <record name="Language"
-            c:type="PangoLanguage"
-            glib:type-name="PangoLanguage"
-            glib:get-type="pango_language_get_type"
-            c:symbol-prefix="language">
+    <record name="Language" c:type="PangoLanguage" glib:type-name="PangoLanguage" glib:get-type="pango_language_get_type" c:symbol-prefix="language">
       <doc xml:space="preserve">The #PangoLanguage structure is used to
 represent a language.
 
 #PangoLanguage pointers can be efficiently
 copied and compared with each other.</doc>
-      <method name="get_sample_string"
-              c:identifier="pango_language_get_sample_string">
+      <method name="get_sample_string" c:identifier="pango_language_get_sample_string">
         <doc xml:space="preserve">Get a string that is representative of the characters needed to
 render a particular language.
 
@@ -6487,18 +5559,13 @@ pango_language_get_sample_string (pango_language_from_string ("xx"))
           <type name="utf8" c:type="const char*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="language"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="language" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoLanguage, or %NULL</doc>
             <type name="Language" c:type="PangoLanguage*"/>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_scripts"
-              c:identifier="pango_language_get_scripts"
-              version="1.22">
+      <method name="get_scripts" c:identifier="pango_language_get_scripts" version="1.22">
         <doc xml:space="preserve">Determines the scripts used to to write @language.
 If nothing is known about the language tag @language,
 or if @language is %NULL, then %NULL is returned.
@@ -6529,28 +5596,18 @@ modified or freed.</doc>
           </array>
         </return-value>
         <parameters>
-          <instance-parameter name="language"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="language" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoLanguage, or %NULL</doc>
             <type name="Language" c:type="PangoLanguage*"/>
           </instance-parameter>
-          <parameter name="num_scripts"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="num_scripts" direction="out" caller-allocates="1" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to return number of scripts,
            or %NULL</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="includes_script"
-              c:identifier="pango_language_includes_script"
-              version="1.4">
+      <method name="includes_script" c:identifier="pango_language_includes_script" version="1.4">
         <doc xml:space="preserve">Determines if @script is one of the scripts used to
 write @language. The returned value is conservative;
 if nothing is known about the language tag @language,
@@ -6571,10 +5628,7 @@ to write @language or if nothing is known about @language
           <type name="gboolean" c:type="gboolean"/>
         </return-value>
         <parameters>
-          <instance-parameter name="language"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="language" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoLanguage, or %NULL</doc>
             <type name="Language" c:type="PangoLanguage*"/>
           </instance-parameter>
@@ -6595,10 +5649,7 @@ in the tag is '-'.</doc>
           <type name="gboolean" c:type="gboolean"/>
         </return-value>
         <parameters>
-          <instance-parameter name="language"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="language" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a language tag (see pango_language_from_string()),
            %NULL is allowed and matches nothing but '*'</doc>
             <type name="Language" c:type="PangoLanguage*"/>
@@ -6646,18 +5697,13 @@ the current locale of the process.</doc>
           <type name="Language" c:type="PangoLanguage*"/>
         </return-value>
         <parameters>
-          <parameter name="language"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="language" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a string representing a language tag, or %NULL</doc>
             <type name="utf8" c:type="const char*"/>
           </parameter>
         </parameters>
       </function>
-      <function name="get_default"
-                c:identifier="pango_language_get_default"
-                version="1.16">
+      <function name="get_default" c:identifier="pango_language_get_default" version="1.16">
         <doc xml:space="preserve">Returns the #PangoLanguage for the current locale of the process.
 Note that this can change over the life of an application.
 
@@ -6691,13 +5737,7 @@ See &lt;literal&gt;man setlocale&lt;/literal&gt; for more details.</doc>
         </return-value>
       </function>
     </record>
-    <class name="Layout"
-           c:symbol-prefix="layout"
-           c:type="PangoLayout"
-           parent="GObject.Object"
-           glib:type-name="PangoLayout"
-           glib:get-type="pango_layout_get_type"
-           glib:type-struct="LayoutClass">
+    <class name="Layout" c:symbol-prefix="layout" c:type="PangoLayout" parent="GObject.Object" glib:type-name="PangoLayout" glib:get-type="pango_layout_get_type" glib:type-struct="LayoutClass">
       <doc xml:space="preserve">The #PangoLayout structure represents an entire paragraph
 of text. It is initialized with a #PangoContext, UTF-8 string
 and set of attributes for that string. Once that is done, the
@@ -6734,8 +5774,7 @@ default values for a particular #PangoContext.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <method name="context_changed"
-              c:identifier="pango_layout_context_changed">
+      <method name="context_changed" c:identifier="pango_layout_context_changed">
         <doc xml:space="preserve">Forces recomputation of any state in the #PangoLayout that
 might depend on the layout's context. This function should
 be called if you make changes to the context subsequent
@@ -6794,9 +5833,7 @@ positioned within the horizontal space available.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_auto_dir"
-              c:identifier="pango_layout_get_auto_dir"
-              version="1.4">
+      <method name="get_auto_dir" c:identifier="pango_layout_get_auto_dir" version="1.4">
         <doc xml:space="preserve">Gets whether to calculate the bidirectional base direction
 for the layout according to the contents of the layout.
 See pango_layout_set_auto_dir().</doc>
@@ -6812,9 +5849,7 @@ See pango_layout_set_auto_dir().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_baseline"
-              c:identifier="pango_layout_get_baseline"
-              version="1.22">
+      <method name="get_baseline" c:identifier="pango_layout_get_baseline" version="1.22">
         <doc xml:space="preserve">Gets the Y position of baseline of the first line in @layout.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">baseline of first line, from top of @layout.</doc>
@@ -6827,9 +5862,7 @@ See pango_layout_set_auto_dir().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_character_count"
-              c:identifier="pango_layout_get_character_count"
-              version="1.30">
+      <method name="get_character_count" c:identifier="pango_layout_get_character_count" version="1.30">
         <doc xml:space="preserve">Returns the number of Unicode characters in the
 the text of @layout.</doc>
         <return-value transfer-ownership="none">
@@ -6880,30 +5913,18 @@ direction of the layout are inserted.</doc>
             <doc xml:space="preserve">the byte index of the cursor</doc>
             <type name="gint" c:type="int"/>
           </parameter>
-          <parameter name="strong_pos"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="strong_pos" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store the strong cursor position
                     (may be %NULL)</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
-          <parameter name="weak_pos"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="weak_pos" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store the weak cursor position (may be %NULL)</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="get_ellipsize"
-              c:identifier="pango_layout_get_ellipsize"
-              version="1.6">
+      <method name="get_ellipsize" c:identifier="pango_layout_get_ellipsize" version="1.6">
         <doc xml:space="preserve">Gets the type of ellipsization being performed for @layout.
 See pango_layout_set_ellipsize()</doc>
         <return-value transfer-ownership="none">
@@ -6938,23 +5959,13 @@ coordinates begin at the top left corner of the layout.</doc>
             <doc xml:space="preserve">a #PangoLayout</doc>
             <type name="Layout" c:type="PangoLayout*"/>
           </instance-parameter>
-          <parameter name="ink_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="ink_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to store the extents of the
                   layout as drawn or %NULL to indicate that the result is
                   not needed.</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
-          <parameter name="logical_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="logical_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to store the logical
                      extents of the layout or %NULL to indicate that the
                      result is not needed.</doc>
@@ -6962,9 +5973,7 @@ coordinates begin at the top left corner of the layout.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_font_description"
-              c:identifier="pango_layout_get_font_description"
-              version="1.8">
+      <method name="get_font_description" c:identifier="pango_layout_get_font_description" version="1.8">
         <doc xml:space="preserve">Gets the font description for the layout, if any.</doc>
         <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">a pointer to the layout's font
@@ -6980,9 +5989,7 @@ coordinates begin at the top left corner of the layout.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_height"
-              c:identifier="pango_layout_get_height"
-              version="1.20">
+      <method name="get_height" c:identifier="pango_layout_get_height" version="1.20">
         <doc xml:space="preserve">Gets the height of layout used for ellipsization.  See
 pango_layout_set_height() for details.</doc>
         <return-value transfer-ownership="none">
@@ -7077,9 +6084,7 @@ to modify the contents of the line (glyphs, glyph widths, etc.).</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_line_readonly"
-              c:identifier="pango_layout_get_line_readonly"
-              version="1.16">
+      <method name="get_line_readonly" c:identifier="pango_layout_get_line_readonly" version="1.16">
         <doc xml:space="preserve">Retrieves a particular line from a #PangoLayout.
 
 This is a faster alternative to pango_layout_get_line(),
@@ -7126,9 +6131,7 @@ text or properties.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_lines_readonly"
-              c:identifier="pango_layout_get_lines_readonly"
-              version="1.16">
+      <method name="get_lines_readonly" c:identifier="pango_layout_get_lines_readonly" version="1.16">
         <doc xml:space="preserve">Returns the lines of the @layout as a list.
 
 This is a faster alternative to pango_layout_get_lines(),
@@ -7161,10 +6164,7 @@ the @layout.</doc>
             <doc xml:space="preserve">a #PangoLayout</doc>
             <type name="Layout" c:type="PangoLayout*"/>
           </instance-parameter>
-          <parameter name="attrs"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="container">
+          <parameter name="attrs" direction="out" caller-allocates="0" transfer-ownership="container">
             <doc xml:space="preserve">
         location to store a pointer to an array of logical attributes
         This value must be freed with g_free().</doc>
@@ -7172,10 +6172,7 @@ the @layout.</doc>
               <type name="LogAttr" c:type="PangoLogAttr*"/>
             </array>
           </parameter>
-          <parameter name="n_attrs"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="n_attrs" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store the number of the attributes in the
           array. (The stored value will be one more than the total number
           of characters in the layout, since there need to be attributes
@@ -7185,9 +6182,7 @@ the @layout.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_log_attrs_readonly"
-              c:identifier="pango_layout_get_log_attrs_readonly"
-              version="1.30">
+      <method name="get_log_attrs_readonly" c:identifier="pango_layout_get_log_attrs_readonly" version="1.30">
         <doc xml:space="preserve">Retrieves an array of logical attributes for each character in
 the @layout.
 
@@ -7210,18 +6205,14 @@ the first character and the position after the last character.</doc>
             <doc xml:space="preserve">a #PangoLayout</doc>
             <type name="Layout" c:type="PangoLayout*"/>
           </instance-parameter>
-          <parameter name="n_attrs"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="n_attrs" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store the number of the attributes in
   the array</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="get_pixel_extents"
-              c:identifier="pango_layout_get_pixel_extents">
+      <method name="get_pixel_extents" c:identifier="pango_layout_get_pixel_extents">
         <doc xml:space="preserve">Computes the logical and ink extents of @layout in device units.
 This function just calls pango_layout_get_extents() followed by
 two pango_extents_to_pixels() calls, rounding @ink_rect and @logical_rect
@@ -7235,23 +6226,13 @@ passes them as first argument to pango_extents_to_pixels()).</doc>
             <doc xml:space="preserve">a #PangoLayout</doc>
             <type name="Layout" c:type="PangoLayout*"/>
           </instance-parameter>
-          <parameter name="ink_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="ink_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to store the extents of the
                   layout as drawn or %NULL to indicate that the result is
                   not needed.</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
-          <parameter name="logical_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="logical_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to store the logical
                       extents of the layout or %NULL to indicate that the
                       result is not needed.</doc>
@@ -7273,29 +6254,17 @@ pango_layout_get_pixel_extents().</doc>
             <doc xml:space="preserve">a #PangoLayout</doc>
             <type name="Layout" c:type="PangoLayout*"/>
           </instance-parameter>
-          <parameter name="width"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="width" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store the logical width, or %NULL</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
-          <parameter name="height"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="height" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store the logical height, or %NULL</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="get_serial"
-              c:identifier="pango_layout_get_serial"
-              version="1.32.4">
+      <method name="get_serial" c:identifier="pango_layout_get_serial" version="1.32.4">
         <doc xml:space="preserve">Returns the current serial number of @layout.  The serial number is
 initialized to an small number  larger than zero when a new layout
 is created and is increased whenever the layout is changed using any
@@ -7317,8 +6286,7 @@ To force the serial to be increased, use pango_layout_context_changed().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_single_paragraph_mode"
-              c:identifier="pango_layout_get_single_paragraph_mode">
+      <method name="get_single_paragraph_mode" c:identifier="pango_layout_get_single_paragraph_mode">
         <doc xml:space="preserve">Obtains the value set by pango_layout_set_single_paragraph_mode().</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE if the layout does not break paragraphs at
@@ -7344,21 +6312,11 @@ is simply a convenience function around pango_layout_get_extents().</doc>
             <doc xml:space="preserve">a #PangoLayout</doc>
             <type name="Layout" c:type="PangoLayout*"/>
           </instance-parameter>
-          <parameter name="width"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="width" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store the logical width, or %NULL</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
-          <parameter name="height"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="height" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store the logical height, or %NULL</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
@@ -7408,9 +6366,7 @@ be freed or modified.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_unknown_glyphs_count"
-              c:identifier="pango_layout_get_unknown_glyphs_count"
-              version="1.16">
+      <method name="get_unknown_glyphs_count" c:identifier="pango_layout_get_unknown_glyphs_count" version="1.16">
         <doc xml:space="preserve">Counts the number unknown glyphs in @layout.  That is, zero if
 glyphs for all characters in the layout text were found, or more
 than zero otherwise.
@@ -7459,8 +6415,7 @@ were actually wrapped.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="index_to_line_x"
-              c:identifier="pango_layout_index_to_line_x">
+      <method name="index_to_line_x" c:identifier="pango_layout_index_to_line_x">
         <doc xml:space="preserve">Converts from byte @index_ within the @layout to line and X position.
 (X position is measured from the left edge of the line)</doc>
         <return-value transfer-ownership="none">
@@ -7481,22 +6436,12 @@ were actually wrapped.</doc>
             the leading of the grapheme.</doc>
             <type name="gboolean" c:type="gboolean"/>
           </parameter>
-          <parameter name="line"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="line" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store resulting line index. (which will
               between 0 and pango_layout_get_line_count(layout) - 1), or %NULL</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
-          <parameter name="x_pos"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="x_pos" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store resulting position within line
              (%PANGO_SCALE units per device unit), or %NULL</doc>
             <type name="gint" c:type="int*"/>
@@ -7522,18 +6467,13 @@ then &lt;literal&gt;pos-&gt;width&lt;/literal&gt; will be negative.</doc>
             <doc xml:space="preserve">byte index within @layout</doc>
             <type name="gint" c:type="int"/>
           </parameter>
-          <parameter name="pos"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none">
+          <parameter name="pos" direction="out" caller-allocates="1" transfer-ownership="none">
             <doc xml:space="preserve">rectangle in which to store the position of the grapheme</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="is_ellipsized"
-              c:identifier="pango_layout_is_ellipsized"
-              version="1.16">
+      <method name="is_ellipsized" c:identifier="pango_layout_is_ellipsized" version="1.16">
         <doc xml:space="preserve">Queries whether the layout had to ellipsize any paragraphs.
 
 This returns %TRUE if the ellipsization mode for @layout
@@ -7552,9 +6492,7 @@ otherwise.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="is_wrapped"
-              c:identifier="pango_layout_is_wrapped"
-              version="1.16">
+      <method name="is_wrapped" c:identifier="pango_layout_is_wrapped" version="1.16">
         <doc xml:space="preserve">Queries whether the layout had to wrap any paragraphs.
 
 This returns %TRUE if a positive width is set on @layout,
@@ -7573,8 +6511,7 @@ otherwise.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="move_cursor_visually"
-              c:identifier="pango_layout_move_cursor_visually">
+      <method name="move_cursor_visually" c:identifier="pango_layout_move_cursor_visually">
         <doc xml:space="preserve">Computes a new cursor position from an old position and
 a count of positions to move visually. If @direction is positive,
 then the new strong cursor position will be one position
@@ -7620,20 +6557,14 @@ to form a single grapheme.</doc>
                value indicates motion to the left.</doc>
             <type name="gint" c:type="int"/>
           </parameter>
-          <parameter name="new_index"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="new_index" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store the new cursor byte index. A value of -1
                indicates that the cursor has been moved off the beginning
                of the layout. A value of %G_MAXINT indicates that
                the cursor has been moved off the end of the layout.</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
-          <parameter name="new_trailing"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="new_trailing" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">number of characters to move forward from the
                location returned for @new_index to get the position
                where the cursor should be displayed. This allows
@@ -7673,18 +6604,13 @@ References @attrs, so the caller can unref its reference.</doc>
             <doc xml:space="preserve">a #PangoLayout</doc>
             <type name="Layout" c:type="PangoLayout*"/>
           </instance-parameter>
-          <parameter name="attrs"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="attrs" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoAttrList, can be %NULL</doc>
             <type name="AttrList" c:type="PangoAttrList*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="set_auto_dir"
-              c:identifier="pango_layout_set_auto_dir"
-              version="1.4">
+      <method name="set_auto_dir" c:identifier="pango_layout_set_auto_dir" version="1.4">
         <doc xml:space="preserve">Sets whether to calculate the bidirectional base direction
 for the layout according to the contents of the layout;
 when this flag is on (the default), then paragraphs in
@@ -7716,9 +6642,7 @@ base direction of the context, the interpretation of
           </parameter>
         </parameters>
       </method>
-      <method name="set_ellipsize"
-              c:identifier="pango_layout_set_ellipsize"
-              version="1.6">
+      <method name="set_ellipsize" c:identifier="pango_layout_set_ellipsize" version="1.6">
         <doc xml:space="preserve">Sets the type of ellipsization being performed for @layout.
 Depending on the ellipsization mode @ellipsize text is
 removed from the start, middle, or end of text so they
@@ -7744,8 +6668,7 @@ See pango_layout_set_height() for details.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_font_description"
-              c:identifier="pango_layout_set_font_description">
+      <method name="set_font_description" c:identifier="pango_layout_set_font_description">
         <doc xml:space="preserve">Sets the default font description for the layout. If no font
 description is set on the layout, the font description from
 the layout's context is used.</doc>
@@ -7757,19 +6680,14 @@ the layout's context is used.</doc>
             <doc xml:space="preserve">a #PangoLayout</doc>
             <type name="Layout" c:type="PangoLayout*"/>
           </instance-parameter>
-          <parameter name="desc"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="desc" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the new #PangoFontDescription, or %NULL to unset the
        current font description</doc>
             <type name="FontDescription" c:type="const PangoFontDescription*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="set_height"
-              c:identifier="pango_layout_set_height"
-              version="1.20">
+      <method name="set_height" c:identifier="pango_layout_set_height" version="1.20">
         <doc xml:space="preserve">Sets the height to which the #PangoLayout should be ellipsized at.  There
 are two different behaviors, based on whether @height is positive or
 negative.
@@ -7876,8 +6794,7 @@ the markup text isn't scanned for accelerators.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_markup_with_accel"
-              c:identifier="pango_layout_set_markup_with_accel">
+      <method name="set_markup_with_accel" c:identifier="pango_layout_set_markup_with_accel">
         <doc xml:space="preserve">Sets the layout text and attribute list from marked-up text (see
 &lt;link linkend="PangoMarkupFormat"&gt;markup format&lt;/link&gt;). Replaces
 the current text and attribute list.
@@ -7911,20 +6828,14 @@ literal @accel_marker character.</doc>
             <doc xml:space="preserve">marker for accelerators in the text</doc>
             <type name="gunichar" c:type="gunichar"/>
           </parameter>
-          <parameter name="accel_char"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="accel_char" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">return location
                    for first located accelerator, or %NULL</doc>
             <type name="gunichar" c:type="gunichar*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="set_single_paragraph_mode"
-              c:identifier="pango_layout_set_single_paragraph_mode">
+      <method name="set_single_paragraph_mode" c:identifier="pango_layout_set_single_paragraph_mode">
         <doc xml:space="preserve">If @setting is %TRUE, do not treat newlines and similar characters
 as paragraph separators; instead, keep all text in a single paragraph,
 and display a glyph for paragraph separator characters. Used when
@@ -7973,10 +6884,7 @@ free your copy of @tabs yourself.</doc>
             <doc xml:space="preserve">a #PangoLayout</doc>
             <type name="Layout" c:type="PangoLayout*"/>
           </instance-parameter>
-          <parameter name="tabs"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="tabs" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoTabArray, or %NULL</doc>
             <type name="TabArray" c:type="PangoTabArray*"/>
           </parameter>
@@ -8076,17 +6984,11 @@ function returns %FALSE; on an exact hit, it returns %TRUE.</doc>
             from the top edge of the layout</doc>
             <type name="gint" c:type="int"/>
           </parameter>
-          <parameter name="index_"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="index_" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store calculated byte index</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
-          <parameter name="trailing"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="trailing" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store a integer indicating where
             in the grapheme the user clicked. It will either
             be zero, or the number of characters in the
@@ -8096,23 +6998,15 @@ function returns %FALSE; on an exact hit, it returns %TRUE.</doc>
         </parameters>
       </method>
     </class>
-    <record name="LayoutClass"
-            c:type="PangoLayoutClass"
-            disguised="1"
-            glib:is-gtype-struct-for="Layout">
+    <record name="LayoutClass" c:type="PangoLayoutClass" disguised="1" glib:is-gtype-struct-for="Layout">
     </record>
-    <record name="LayoutIter"
-            c:type="PangoLayoutIter"
-            glib:type-name="PangoLayoutIter"
-            glib:get-type="pango_layout_iter_get_type"
-            c:symbol-prefix="layout_iter">
+    <record name="LayoutIter" c:type="PangoLayoutIter" glib:type-name="PangoLayoutIter" glib:get-type="pango_layout_iter_get_type" c:symbol-prefix="layout_iter">
       <doc xml:space="preserve">A #PangoLayoutIter structure can be used to
 iterate over the visual extents of a #PangoLayout.
 
 The #PangoLayoutIter structure is opaque, and
 has no user-visible fields.</doc>
-      <method name="at_last_line"
-              c:identifier="pango_layout_iter_at_last_line">
+      <method name="at_last_line" c:identifier="pango_layout_iter_at_last_line">
         <doc xml:space="preserve">Determines whether @iter is on the last line of the layout.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE if @iter is on the last line.</doc>
@@ -8134,10 +7028,7 @@ has no user-visible fields.</doc>
           <type name="LayoutIter" c:type="PangoLayoutIter*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="iter"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="iter" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoLayoutIter, may be %NULL</doc>
             <type name="LayoutIter" c:type="PangoLayoutIter*"/>
           </instance-parameter>
@@ -8149,17 +7040,13 @@ has no user-visible fields.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="iter"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="iter" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoLayoutIter, may be %NULL</doc>
             <type name="LayoutIter" c:type="PangoLayoutIter*"/>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_baseline"
-              c:identifier="pango_layout_iter_get_baseline">
+      <method name="get_baseline" c:identifier="pango_layout_iter_get_baseline">
         <doc xml:space="preserve">Gets the Y position of the current line's baseline, in layout
 coordinates (origin at top left of the entire layout).</doc>
         <return-value transfer-ownership="none">
@@ -8173,8 +7060,7 @@ coordinates (origin at top left of the entire layout).</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_char_extents"
-              c:identifier="pango_layout_iter_get_char_extents">
+      <method name="get_char_extents" c:identifier="pango_layout_iter_get_char_extents">
         <doc xml:space="preserve">Gets the extents of the current character, in layout coordinates
 (origin is the top left of the entire layout). Only logical extents
 can sensibly be obtained for characters; ink extents make sense only
@@ -8187,18 +7073,14 @@ down to the level of clusters.</doc>
             <doc xml:space="preserve">a #PangoLayoutIter</doc>
             <type name="LayoutIter" c:type="PangoLayoutIter*"/>
           </instance-parameter>
-          <parameter name="logical_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none">
+          <parameter name="logical_rect" direction="out" caller-allocates="1" transfer-ownership="none">
             <doc xml:space="preserve">rectangle to fill with
   logical extents</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="get_cluster_extents"
-              c:identifier="pango_layout_iter_get_cluster_extents">
+      <method name="get_cluster_extents" c:identifier="pango_layout_iter_get_cluster_extents">
         <doc xml:space="preserve">Gets the extents of the current cluster, in layout coordinates
 (origin is the top left of the entire layout).</doc>
         <return-value transfer-ownership="none">
@@ -8209,21 +7091,11 @@ down to the level of clusters.</doc>
             <doc xml:space="preserve">a #PangoLayoutIter</doc>
             <type name="LayoutIter" c:type="PangoLayoutIter*"/>
           </instance-parameter>
-          <parameter name="ink_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="ink_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle to fill with ink extents, or %NULL</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
-          <parameter name="logical_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="logical_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle to fill with logical extents, or %NULL</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
@@ -8245,9 +7117,7 @@ in the layout, if on the %NULL run (see pango_layout_iter_get_run()).</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_layout"
-              c:identifier="pango_layout_iter_get_layout"
-              version="1.20">
+      <method name="get_layout" c:identifier="pango_layout_iter_get_layout" version="1.20">
         <doc xml:space="preserve">Gets the layout associated with a #PangoLayoutIter.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the layout associated with @iter.</doc>
@@ -8260,8 +7130,7 @@ in the layout, if on the %NULL run (see pango_layout_iter_get_run()).</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_layout_extents"
-              c:identifier="pango_layout_iter_get_layout_extents">
+      <method name="get_layout_extents" c:identifier="pango_layout_iter_get_layout_extents">
         <doc xml:space="preserve">Obtains the extents of the #PangoLayout being iterated
 over. @ink_rect or @logical_rect can be %NULL if you
 aren't interested in them.</doc>
@@ -8273,22 +7142,12 @@ aren't interested in them.</doc>
             <doc xml:space="preserve">a #PangoLayoutIter</doc>
             <type name="LayoutIter" c:type="PangoLayoutIter*"/>
           </instance-parameter>
-          <parameter name="ink_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="ink_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle to fill with ink extents,
            or %NULL</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
-          <parameter name="logical_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="logical_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle to fill with logical
                extents, or %NULL</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
@@ -8311,8 +7170,7 @@ to modify the contents of the line (glyphs, glyph widths, etc.).</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_line_extents"
-              c:identifier="pango_layout_iter_get_line_extents">
+      <method name="get_line_extents" c:identifier="pango_layout_iter_get_line_extents">
         <doc xml:space="preserve">Obtains the extents of the current line. @ink_rect or @logical_rect
 can be %NULL if you aren't interested in them. Extents are in layout
 coordinates (origin is the top-left corner of the entire
@@ -8327,29 +7185,17 @@ returned from pango_layout_line_get_extents().</doc>
             <doc xml:space="preserve">a #PangoLayoutIter</doc>
             <type name="LayoutIter" c:type="PangoLayoutIter*"/>
           </instance-parameter>
-          <parameter name="ink_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="ink_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle to fill with ink extents, or %NULL</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
-          <parameter name="logical_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="logical_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle to fill with logical extents, or %NULL</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="get_line_readonly"
-              c:identifier="pango_layout_iter_get_line_readonly"
-              version="1.16">
+      <method name="get_line_readonly" c:identifier="pango_layout_iter_get_line_readonly" version="1.16">
         <doc xml:space="preserve">Gets the current line for read-only access.
 
 This is a faster alternative to pango_layout_iter_get_line(),
@@ -8367,8 +7213,7 @@ modified.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_line_yrange"
-              c:identifier="pango_layout_iter_get_line_yrange">
+      <method name="get_line_yrange" c:identifier="pango_layout_iter_get_line_yrange">
         <doc xml:space="preserve">Divides the vertical space in the #PangoLayout being iterated over
 between the lines in the layout, and returns the space belonging to
 the current line.  A line's range includes the line's logical
@@ -8384,21 +7229,11 @@ entire layout).</doc>
             <doc xml:space="preserve">a #PangoLayoutIter</doc>
             <type name="LayoutIter" c:type="PangoLayoutIter*"/>
           </instance-parameter>
-          <parameter name="y0_"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="y0_" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">start of line, or %NULL</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
-          <parameter name="y1_"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="y1_" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">end of line, or %NULL</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
@@ -8423,8 +7258,7 @@ to modify the contents of the run (glyphs, glyph widths, etc.).</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_run_extents"
-              c:identifier="pango_layout_iter_get_run_extents">
+      <method name="get_run_extents" c:identifier="pango_layout_iter_get_run_extents">
         <doc xml:space="preserve">Gets the extents of the current run in layout coordinates
 (origin is the top left of the entire layout).</doc>
         <return-value transfer-ownership="none">
@@ -8435,29 +7269,17 @@ to modify the contents of the run (glyphs, glyph widths, etc.).</doc>
             <doc xml:space="preserve">a #PangoLayoutIter</doc>
             <type name="LayoutIter" c:type="PangoLayoutIter*"/>
           </instance-parameter>
-          <parameter name="ink_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="ink_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle to fill with ink extents, or %NULL</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
-          <parameter name="logical_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="logical_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle to fill with logical extents, or %NULL</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="get_run_readonly"
-              c:identifier="pango_layout_iter_get_run_readonly"
-              version="1.16">
+      <method name="get_run_readonly" c:identifier="pango_layout_iter_get_run_readonly" version="1.16">
         <doc xml:space="preserve">Gets the current run. When iterating by run, at the end of each
 line, there's a position with a %NULL run, so this function can return
 %NULL. The %NULL run at the end of each line ensures that all lines have
@@ -8492,8 +7314,7 @@ the end of the layout, returns %FALSE.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="next_cluster"
-              c:identifier="pango_layout_iter_next_cluster">
+      <method name="next_cluster" c:identifier="pango_layout_iter_next_cluster">
         <doc xml:space="preserve">Moves @iter forward to the next cluster in visual order. If @iter
 was already at the end of the layout, returns %FALSE.</doc>
         <return-value transfer-ownership="none">
@@ -8536,11 +7357,7 @@ already at the end of the layout, returns %FALSE.</doc>
         </parameters>
       </method>
     </record>
-    <record name="LayoutLine"
-            c:type="PangoLayoutLine"
-            glib:type-name="PangoLayoutLine"
-            glib:get-type="pango_layout_line_get_type"
-            c:symbol-prefix="layout_line">
+    <record name="LayoutLine" c:type="PangoLayoutLine" glib:type-name="PangoLayoutLine" glib:get-type="pango_layout_line_get_type" c:symbol-prefix="layout_line">
       <doc xml:space="preserve">The #PangoLayoutLine structure represents one of the lines resulting
 from laying out a paragraph via #PangoLayout. #PangoLayoutLine
 structures are obtained by calling pango_layout_get_line() and
@@ -8588,30 +7405,19 @@ of the rectangles.</doc>
             <doc xml:space="preserve">a #PangoLayoutLine</doc>
             <type name="LayoutLine" c:type="PangoLayoutLine*"/>
           </instance-parameter>
-          <parameter name="ink_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="ink_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to store the extents of
            the glyph string as drawn, or %NULL</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
-          <parameter name="logical_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="logical_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to store the logical
                extents of the glyph string, or %NULL</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="get_pixel_extents"
-              c:identifier="pango_layout_line_get_pixel_extents">
+      <method name="get_pixel_extents" c:identifier="pango_layout_line_get_pixel_extents">
         <doc xml:space="preserve">Computes the logical and ink extents of @layout_line in device units.
 This function just calls pango_layout_line_get_extents() followed by
 two pango_extents_to_pixels() calls, rounding @ink_rect and @logical_rect
@@ -8625,30 +7431,19 @@ passes them as first argument to pango_extents_to_pixels()).</doc>
             <doc xml:space="preserve">a #PangoLayoutLine</doc>
             <type name="LayoutLine" c:type="PangoLayoutLine*"/>
           </instance-parameter>
-          <parameter name="ink_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="ink_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to store the extents of
                   the glyph string as drawn, or %NULL</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
-          <parameter name="logical_rect"
-                     direction="out"
-                     caller-allocates="1"
-                     transfer-ownership="none"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="logical_rect" direction="out" caller-allocates="1" transfer-ownership="none" optional="1" allow-none="1">
             <doc xml:space="preserve">rectangle used to store the logical
                       extents of the glyph string, or %NULL</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="get_x_ranges"
-              c:identifier="pango_layout_line_get_x_ranges">
+      <method name="get_x_ranges" c:identifier="pango_layout_line_get_x_ranges">
         <doc xml:space="preserve">Gets a list of visual ranges corresponding to a given logical range.
 This list is not necessarily minimal - there may be consecutive
 ranges which are adjacent. The ranges will be sorted from left to
@@ -8678,10 +7473,7 @@ layout, not with respect to the line.</doc>
               trailing edge of the last character.</doc>
             <type name="gint" c:type="int"/>
           </parameter>
-          <parameter name="ranges"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="ranges" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">
               location to store a pointer to an array of ranges.
               The array will be of length &lt;literal&gt;2*n_ranges&lt;/literal&gt;,
@@ -8693,10 +7485,7 @@ layout, not with respect to the line.</doc>
               <type name="gint" c:type="int*"/>
             </array>
           </parameter>
-          <parameter name="n_ranges"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="n_ranges" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">The number of ranges stored in @ranges.</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
@@ -8722,10 +7511,7 @@ layout, not with respect to the line.</doc>
            if 0, the leading of the grapheme.</doc>
             <type name="gboolean" c:type="gboolean"/>
           </parameter>
-          <parameter name="x_pos"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="x_pos" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store the x_offset (in Pango unit)</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
@@ -8738,10 +7524,7 @@ layout, not with respect to the line.</doc>
           <type name="LayoutLine" c:type="PangoLayoutLine*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="line"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="line" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoLayoutLine, may be %NULL</doc>
             <type name="LayoutLine" c:type="PangoLayoutLine*"/>
           </instance-parameter>
@@ -8786,18 +7569,12 @@ in that grapheme. The reverse is true for a left-to-right line.</doc>
             from the left edge of the line.</doc>
             <type name="gint" c:type="int"/>
           </parameter>
-          <parameter name="index_"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="index_" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store calculated byte index for
                   the grapheme in which the user clicked.</doc>
             <type name="gint" c:type="int*"/>
           </parameter>
-          <parameter name="trailing"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="trailing" direction="out" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">location to store an integer indicating where
                   in the grapheme the user clicked. It will either
                   be zero, or the number of characters in the
@@ -8898,11 +7675,7 @@ Boundaries&lt;/ulink&gt; semantics. (Since: 1.22)</doc>
       </field>
     </record>
     <record name="Map" c:type="PangoMap" disguised="1">
-      <method name="get_engine"
-              c:identifier="pango_map_get_engine"
-              introspectable="0"
-              deprecated="1"
-              deprecated-version="1.38">
+      <method name="get_engine" c:identifier="pango_map_get_engine" introspectable="0" deprecated="1" deprecated-version="1.38">
         <doc xml:space="preserve">Do not use.  Does not do anything.</doc>
         <return-value>
           <doc xml:space="preserve">%NULL.</doc>
@@ -8919,12 +7692,7 @@ Boundaries&lt;/ulink&gt; semantics. (Since: 1.22)</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_engines"
-              c:identifier="pango_map_get_engines"
-              version="1.4"
-              introspectable="0"
-              deprecated="1"
-              deprecated-version="1.38">
+      <method name="get_engines" c:identifier="pango_map_get_engines" version="1.4" introspectable="0" deprecated="1" deprecated-version="1.38">
         <doc xml:space="preserve">Do not use.  Does not do anything.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -8957,12 +7725,7 @@ Boundaries&lt;/ulink&gt; semantics. (Since: 1.22)</doc>
     </record>
     <record name="MapEntry" c:type="PangoMapEntry" disguised="1">
     </record>
-    <record name="Matrix"
-            c:type="PangoMatrix"
-            version="1.6"
-            glib:type-name="PangoMatrix"
-            glib:get-type="pango_matrix_get_type"
-            c:symbol-prefix="matrix">
+    <record name="Matrix" c:type="PangoMatrix" version="1.6" glib:type-name="PangoMatrix" glib:get-type="pango_matrix_get_type" c:symbol-prefix="matrix">
       <doc xml:space="preserve">A structure specifying a transformation between user-space
 coordinates and device coordinates. The transformation
 is given by
@@ -9022,10 +7785,7 @@ given by @new_matrix then applying the original transformation.</doc>
           <type name="Matrix" c:type="PangoMatrix*"/>
         </return-value>
         <parameters>
-          <instance-parameter name="matrix"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="matrix" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoMatrix, may be %NULL</doc>
             <type name="Matrix" c:type="const PangoMatrix*"/>
           </instance-parameter>
@@ -9037,18 +7797,13 @@ given by @new_matrix then applying the original transformation.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="matrix"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="matrix" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoMatrix, may be %NULL</doc>
             <type name="Matrix" c:type="PangoMatrix*"/>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_font_scale_factor"
-              c:identifier="pango_matrix_get_font_scale_factor"
-              version="1.12">
+      <method name="get_font_scale_factor" c:identifier="pango_matrix_get_font_scale_factor" version="1.12">
         <doc xml:space="preserve">Returns the scale factor of a matrix on the height of the font.
 That is, the scale factor in the direction perpendicular to the
 vector that the X coordinate is mapped to.  If the scale in the X
@@ -9059,18 +7814,13 @@ or 1.0 if @matrix is %NULL.</doc>
           <type name="gdouble" c:type="double"/>
         </return-value>
         <parameters>
-          <instance-parameter name="matrix"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="matrix" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoMatrix, may be %NULL</doc>
             <type name="Matrix" c:type="const PangoMatrix*"/>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_font_scale_factors"
-              c:identifier="pango_matrix_get_font_scale_factors"
-              version="1.38">
+      <method name="get_font_scale_factors" c:identifier="pango_matrix_get_font_scale_factors" version="1.38">
         <doc xml:space="preserve">Calculates the scale factor of a matrix on the width and height of the font.
 That is, @xscale is the scale factor in the direction of the X coordinate,
 and @yscale is the scale factor in the direction perpendicular to the
@@ -9081,28 +7831,15 @@ Note that output numbers will always be non-negative.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="matrix"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="matrix" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoMatrix, or %NULL</doc>
             <type name="Matrix" c:type="const PangoMatrix*"/>
           </instance-parameter>
-          <parameter name="xscale"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="xscale" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">output scale factor in the x direction, or %NULL</doc>
             <type name="gdouble" c:type="double*"/>
           </parameter>
-          <parameter name="yscale"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="yscale" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">output scale factor perpendicular to the x direction, or %NULL</doc>
             <type name="gdouble" c:type="double*"/>
           </parameter>
@@ -9149,9 +7886,7 @@ transformation.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="transform_distance"
-              c:identifier="pango_matrix_transform_distance"
-              version="1.16">
+      <method name="transform_distance" c:identifier="pango_matrix_transform_distance" version="1.16">
         <doc xml:space="preserve">Transforms the distance vector (@dx,@dy) by @matrix. This is
 similar to pango_matrix_transform_point() except that the translation
 components of the transformation are ignored. The calculation of
@@ -9170,32 +7905,21 @@ to (@x2,@y2) then (@x1+@dx1,@y1+@dy1) will transform to
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="matrix"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="matrix" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoMatrix, or %NULL</doc>
             <type name="Matrix" c:type="const PangoMatrix*"/>
           </instance-parameter>
-          <parameter name="dx"
-                     direction="inout"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="dx" direction="inout" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">in/out X component of a distance vector</doc>
             <type name="gdouble" c:type="double*"/>
           </parameter>
-          <parameter name="dy"
-                     direction="inout"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="dy" direction="inout" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">in/out Y component of a distance vector</doc>
             <type name="gdouble" c:type="double*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="transform_pixel_rectangle"
-              c:identifier="pango_matrix_transform_pixel_rectangle"
-              version="1.16">
+      <method name="transform_pixel_rectangle" c:identifier="pango_matrix_transform_pixel_rectangle" version="1.16">
         <doc xml:space="preserve">First transforms the @rect using @matrix, then calculates the bounding box
 of the transformed rectangle.  The rectangle should be in device units
 (pixels).
@@ -9211,58 +7935,37 @@ using pango_extents_to_pixels()'s first argument.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="matrix"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="matrix" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoMatrix, or %NULL</doc>
             <type name="Matrix" c:type="const PangoMatrix*"/>
           </instance-parameter>
-          <parameter name="rect"
-                     direction="inout"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="rect" direction="inout" caller-allocates="0" transfer-ownership="full" nullable="1" allow-none="1">
             <doc xml:space="preserve">in/out bounding box in device units, or %NULL</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="transform_point"
-              c:identifier="pango_matrix_transform_point"
-              version="1.16">
+      <method name="transform_point" c:identifier="pango_matrix_transform_point" version="1.16">
         <doc xml:space="preserve">Transforms the point (@x, @y) by @matrix.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="matrix"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="matrix" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoMatrix, or %NULL</doc>
             <type name="Matrix" c:type="const PangoMatrix*"/>
           </instance-parameter>
-          <parameter name="x"
-                     direction="inout"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="x" direction="inout" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">in/out X position</doc>
             <type name="gdouble" c:type="double*"/>
           </parameter>
-          <parameter name="y"
-                     direction="inout"
-                     caller-allocates="0"
-                     transfer-ownership="full">
+          <parameter name="y" direction="inout" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">in/out Y position</doc>
             <type name="gdouble" c:type="double*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="transform_rectangle"
-              c:identifier="pango_matrix_transform_rectangle"
-              version="1.16">
+      <method name="transform_rectangle" c:identifier="pango_matrix_transform_rectangle" version="1.16">
         <doc xml:space="preserve">First transforms @rect using @matrix, then calculates the bounding box
 of the transformed rectangle.  The rectangle should be in Pango units.
 
@@ -9285,27 +7988,17 @@ example).</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="matrix"
-                              transfer-ownership="none"
-                              nullable="1"
-                              allow-none="1">
+          <instance-parameter name="matrix" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoMatrix, or %NULL</doc>
             <type name="Matrix" c:type="const PangoMatrix*"/>
           </instance-parameter>
-          <parameter name="rect"
-                     direction="inout"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="rect" direction="inout" caller-allocates="0" transfer-ownership="full" nullable="1" allow-none="1">
             <doc xml:space="preserve">in/out bounding box in Pango units, or %NULL</doc>
             <type name="Rectangle" c:type="PangoRectangle*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="translate"
-              c:identifier="pango_matrix_translate"
-              version="1.6">
+      <method name="translate" c:identifier="pango_matrix_translate" version="1.6">
         <doc xml:space="preserve">Changes the transformation represented by @matrix to be the
 transformation given by first translating by (@tx, @ty)
 then applying the original transformation.</doc>
@@ -9328,11 +8021,7 @@ then applying the original transformation.</doc>
         </parameters>
       </method>
     </record>
-    <constant name="RENDER_TYPE_NONE"
-              value="PangoRenderNone"
-              c:type="PANGO_RENDER_TYPE_NONE"
-              deprecated="1"
-              deprecated-version="1.38">
+    <constant name="RENDER_TYPE_NONE" value="PangoRenderNone" c:type="PANGO_RENDER_TYPE_NONE" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">A string constant defining the render type
 for engines that are not rendering-system specific.</doc>
       <type name="utf8" c:type="gchar*"/>
@@ -9358,47 +8047,23 @@ of text. (See, for instance, pango_font_get_glyph_extents())</doc>
         <type name="gint" c:type="int"/>
       </field>
     </record>
-    <enumeration name="RenderPart"
-                 version="1.8"
-                 glib:type-name="PangoRenderPart"
-                 glib:get-type="pango_render_part_get_type"
-                 c:type="PangoRenderPart">
+    <enumeration name="RenderPart" version="1.8" glib:type-name="PangoRenderPart" glib:get-type="pango_render_part_get_type" c:type="PangoRenderPart">
       <doc xml:space="preserve">#PangoRenderPart defines different items to render for such
 purposes as setting colors.</doc>
-      <member name="foreground"
-              value="0"
-              c:identifier="PANGO_RENDER_PART_FOREGROUND"
-              glib:nick="foreground">
+      <member name="foreground" value="0" c:identifier="PANGO_RENDER_PART_FOREGROUND" glib:nick="foreground">
         <doc xml:space="preserve">the text itself</doc>
       </member>
-      <member name="background"
-              value="1"
-              c:identifier="PANGO_RENDER_PART_BACKGROUND"
-              glib:nick="background">
+      <member name="background" value="1" c:identifier="PANGO_RENDER_PART_BACKGROUND" glib:nick="background">
         <doc xml:space="preserve">the area behind the text</doc>
       </member>
-      <member name="underline"
-              value="2"
-              c:identifier="PANGO_RENDER_PART_UNDERLINE"
-              glib:nick="underline">
+      <member name="underline" value="2" c:identifier="PANGO_RENDER_PART_UNDERLINE" glib:nick="underline">
         <doc xml:space="preserve">underlines</doc>
       </member>
-      <member name="strikethrough"
-              value="3"
-              c:identifier="PANGO_RENDER_PART_STRIKETHROUGH"
-              glib:nick="strikethrough">
+      <member name="strikethrough" value="3" c:identifier="PANGO_RENDER_PART_STRIKETHROUGH" glib:nick="strikethrough">
         <doc xml:space="preserve">strikethrough lines</doc>
       </member>
     </enumeration>
-    <class name="Renderer"
-           c:symbol-prefix="renderer"
-           c:type="PangoRenderer"
-           version="1.8"
-           parent="GObject.Object"
-           abstract="1"
-           glib:type-name="PangoRenderer"
-           glib:get-type="pango_renderer_get_type"
-           glib:type-struct="RendererClass">
+    <class name="Renderer" c:symbol-prefix="renderer" c:type="PangoRenderer" version="1.8" parent="GObject.Object" abstract="1" glib:type-name="PangoRenderer" glib:get-type="pango_renderer_get_type" glib:type-struct="RendererClass">
       <doc xml:space="preserve">#PangoRenderer is a base class for objects that are used to
 render Pango objects such as #PangoGlyphString and
 #PangoLayout.</doc>
@@ -9412,9 +8077,7 @@ render Pango objects such as #PangoGlyphString and
           </instance-parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="draw_error_underline"
-                      invoker="draw_error_underline"
-                      version="1.8">
+      <virtual-method name="draw_error_underline" invoker="draw_error_underline" version="1.8">
         <doc xml:space="preserve">Draw a squiggly line that approximately covers the given rectangle
 in the style of an underline used to indicate a spelling error.
 (The width of the underline is rounded to an integer number
@@ -9477,9 +8140,7 @@ pango_renderer_activate() to activate a renderer.</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="draw_glyph_item"
-                      invoker="draw_glyph_item"
-                      version="1.22">
+      <virtual-method name="draw_glyph_item" invoker="draw_glyph_item" version="1.22">
         <doc xml:space="preserve">Draws the glyphs in @glyph_item with the specified #PangoRenderer,
 embedding the text associated with the glyphs in the output if the
 output format supports it (PDF for example).
@@ -9499,10 +8160,7 @@ pango_renderer_draw_glyphs().</doc>
             <doc xml:space="preserve">a #PangoRenderer</doc>
             <type name="Renderer" c:type="PangoRenderer*"/>
           </instance-parameter>
-          <parameter name="text"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="text" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the UTF-8 text that @glyph_item refers to, or %NULL</doc>
             <type name="utf8" c:type="const char*"/>
           </parameter>
@@ -9552,9 +8210,7 @@ pango_renderer_draw_glyphs().</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="draw_rectangle"
-                      invoker="draw_rectangle"
-                      version="1.8">
+      <virtual-method name="draw_rectangle" invoker="draw_rectangle" version="1.8">
         <doc xml:space="preserve">Draws an axis-aligned rectangle in user space coordinates with the
 specified #PangoRenderer.
 
@@ -9609,9 +8265,7 @@ pango_renderer_activate() to activate a renderer.</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="draw_trapezoid"
-                      invoker="draw_trapezoid"
-                      version="1.8">
+      <virtual-method name="draw_trapezoid" invoker="draw_trapezoid" version="1.8">
         <doc xml:space="preserve">Draws a trapezoid with the parallel sides aligned with the X axis
 using the given #PangoRenderer; coordinates are in device space.</doc>
         <return-value transfer-ownership="none">
@@ -9703,9 +8357,7 @@ changes to colors. (See pango_renderer_set_color())</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <method name="activate"
-              c:identifier="pango_renderer_activate"
-              version="1.8">
+      <method name="activate" c:identifier="pango_renderer_activate" version="1.8">
         <doc xml:space="preserve">Does initial setup before rendering operations on @renderer.
 pango_renderer_deactivate() should be called when done drawing.
 Calls such as pango_renderer_draw_layout() automatically
@@ -9723,9 +8375,7 @@ deinitialized once.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="deactivate"
-              c:identifier="pango_renderer_deactivate"
-              version="1.8">
+      <method name="deactivate" c:identifier="pango_renderer_deactivate" version="1.8">
         <doc xml:space="preserve">Cleans up after rendering operations on @renderer. See
 docs for pango_renderer_activate().</doc>
         <return-value transfer-ownership="none">
@@ -9738,9 +8388,7 @@ docs for pango_renderer_activate().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="draw_error_underline"
-              c:identifier="pango_renderer_draw_error_underline"
-              version="1.8">
+      <method name="draw_error_underline" c:identifier="pango_renderer_draw_error_underline" version="1.8">
         <doc xml:space="preserve">Draw a squiggly line that approximately covers the given rectangle
 in the style of an underline used to indicate a spelling error.
 (The width of the underline is rounded to an integer number
@@ -9775,9 +8423,7 @@ pango_renderer_activate() to activate a renderer.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="draw_glyph"
-              c:identifier="pango_renderer_draw_glyph"
-              version="1.8">
+      <method name="draw_glyph" c:identifier="pango_renderer_draw_glyph" version="1.8">
         <doc xml:space="preserve">Draws a single glyph with coordinates in device space.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -9805,9 +8451,7 @@ pango_renderer_activate() to activate a renderer.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="draw_glyph_item"
-              c:identifier="pango_renderer_draw_glyph_item"
-              version="1.22">
+      <method name="draw_glyph_item" c:identifier="pango_renderer_draw_glyph_item" version="1.22">
         <doc xml:space="preserve">Draws the glyphs in @glyph_item with the specified #PangoRenderer,
 embedding the text associated with the glyphs in the output if the
 output format supports it (PDF for example).
@@ -9827,10 +8471,7 @@ pango_renderer_draw_glyphs().</doc>
             <doc xml:space="preserve">a #PangoRenderer</doc>
             <type name="Renderer" c:type="PangoRenderer*"/>
           </instance-parameter>
-          <parameter name="text"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="text" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the UTF-8 text that @glyph_item refers to, or %NULL</doc>
             <type name="utf8" c:type="const char*"/>
           </parameter>
@@ -9850,9 +8491,7 @@ pango_renderer_draw_glyphs().</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="draw_glyphs"
-              c:identifier="pango_renderer_draw_glyphs"
-              version="1.8">
+      <method name="draw_glyphs" c:identifier="pango_renderer_draw_glyphs" version="1.8">
         <doc xml:space="preserve">Draws the glyphs in @glyphs with the specified #PangoRenderer.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -9882,9 +8521,7 @@ pango_renderer_draw_glyphs().</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="draw_layout"
-              c:identifier="pango_renderer_draw_layout"
-              version="1.8">
+      <method name="draw_layout" c:identifier="pango_renderer_draw_layout" version="1.8">
         <doc xml:space="preserve">Draws @layout with the specified #PangoRenderer.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -9910,9 +8547,7 @@ pango_renderer_draw_glyphs().</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="draw_layout_line"
-              c:identifier="pango_renderer_draw_layout_line"
-              version="1.8">
+      <method name="draw_layout_line" c:identifier="pango_renderer_draw_layout_line" version="1.8">
         <doc xml:space="preserve">Draws @line with the specified #PangoRenderer.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -9938,9 +8573,7 @@ pango_renderer_draw_glyphs().</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="draw_rectangle"
-              c:identifier="pango_renderer_draw_rectangle"
-              version="1.8">
+      <method name="draw_rectangle" c:identifier="pango_renderer_draw_rectangle" version="1.8">
         <doc xml:space="preserve">Draws an axis-aligned rectangle in user space coordinates with the
 specified #PangoRenderer.
 
@@ -9976,9 +8609,7 @@ pango_renderer_activate() to activate a renderer.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="draw_trapezoid"
-              c:identifier="pango_renderer_draw_trapezoid"
-              version="1.8">
+      <method name="draw_trapezoid" c:identifier="pango_renderer_draw_trapezoid" version="1.8">
         <doc xml:space="preserve">Draws a trapezoid with the parallel sides aligned with the X axis
 using the given #PangoRenderer; coordinates are in device space.</doc>
         <return-value transfer-ownership="none">
@@ -10019,9 +8650,7 @@ using the given #PangoRenderer; coordinates are in device space.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_alpha"
-              c:identifier="pango_renderer_get_alpha"
-              version="1.38">
+      <method name="get_alpha" c:identifier="pango_renderer_get_alpha" version="1.38">
         <doc xml:space="preserve">Gets the current alpha for the specified part.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the alpha for the specified part,
@@ -10040,9 +8669,7 @@ using the given #PangoRenderer; coordinates are in device space.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_color"
-              c:identifier="pango_renderer_get_color"
-              version="1.8">
+      <method name="get_color" c:identifier="pango_renderer_get_color" version="1.8">
         <doc xml:space="preserve">Gets the current rendering color for the specified part.</doc>
         <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">the color for the
@@ -10061,9 +8688,7 @@ using the given #PangoRenderer; coordinates are in device space.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_layout"
-              c:identifier="pango_renderer_get_layout"
-              version="1.20">
+      <method name="get_layout" c:identifier="pango_renderer_get_layout" version="1.20">
         <doc xml:space="preserve">Gets the layout currently being rendered using @renderer.
 Calling this function only makes sense from inside a subclass's
 methods, like in its draw_shape&lt;!----&gt;() for example.
@@ -10082,9 +8707,7 @@ rendered.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_layout_line"
-              c:identifier="pango_renderer_get_layout_line"
-              version="1.20">
+      <method name="get_layout_line" c:identifier="pango_renderer_get_layout_line" version="1.20">
         <doc xml:space="preserve">Gets the layout line currently being rendered using @renderer.
 Calling this function only makes sense from inside a subclass's
 methods, like in its draw_shape&lt;!----&gt;() for example.
@@ -10103,9 +8726,7 @@ rendered.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_matrix"
-              c:identifier="pango_renderer_get_matrix"
-              version="1.8">
+      <method name="get_matrix" c:identifier="pango_renderer_get_matrix" version="1.8">
         <doc xml:space="preserve">Gets the transformation matrix that will be applied when
 rendering. See pango_renderer_set_matrix().</doc>
         <return-value transfer-ownership="none" nullable="1">
@@ -10121,9 +8742,7 @@ rendering. See pango_renderer_set_matrix().</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="part_changed"
-              c:identifier="pango_renderer_part_changed"
-              version="1.8">
+      <method name="part_changed" c:identifier="pango_renderer_part_changed" version="1.8">
         <doc xml:space="preserve">Informs Pango that the way that the rendering is done
 for @part has changed in a way that would prevent multiple
 pieces being joined together into one drawing call. For
@@ -10151,9 +8770,7 @@ changes to colors. (See pango_renderer_set_color())</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_alpha"
-              c:identifier="pango_renderer_set_alpha"
-              version="1.38">
+      <method name="set_alpha" c:identifier="pango_renderer_set_alpha" version="1.38">
         <doc xml:space="preserve">Sets the alpha for part of the rendering.
 Note that the alpha may only be used if a color is
 specified for @part as well.</doc>
@@ -10175,9 +8792,7 @@ specified for @part as well.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_color"
-              c:identifier="pango_renderer_set_color"
-              version="1.8">
+      <method name="set_color" c:identifier="pango_renderer_set_color" version="1.8">
         <doc xml:space="preserve">Sets the color for part of the rendering.
 Also see pango_renderer_set_alpha().</doc>
         <return-value transfer-ownership="none">
@@ -10192,18 +8807,13 @@ Also see pango_renderer_set_alpha().</doc>
             <doc xml:space="preserve">the part to change the color of</doc>
             <type name="RenderPart" c:type="PangoRenderPart"/>
           </parameter>
-          <parameter name="color"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="color" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the new color or %NULL to unset the current color</doc>
             <type name="Color" c:type="const PangoColor*"/>
           </parameter>
         </parameters>
       </method>
-      <method name="set_matrix"
-              c:identifier="pango_renderer_set_matrix"
-              version="1.8">
+      <method name="set_matrix" c:identifier="pango_renderer_set_matrix" version="1.8">
         <doc xml:space="preserve">Sets the transformation matrix that will be applied when rendering.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -10213,10 +8823,7 @@ Also see pango_renderer_set_alpha().</doc>
             <doc xml:space="preserve">a #PangoRenderer</doc>
             <type name="Renderer" c:type="PangoRenderer*"/>
           </instance-parameter>
-          <parameter name="matrix"
-                     transfer-ownership="none"
-                     nullable="1"
-                     allow-none="1">
+          <parameter name="matrix" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a #PangoMatrix, or %NULL to unset any existing matrix.
  (No matrix set is the same as setting the identity matrix.)</doc>
             <type name="Matrix" c:type="const PangoMatrix*"/>
@@ -10245,10 +8852,7 @@ Also see pango_renderer_set_alpha().</doc>
         <type name="RendererPrivate" c:type="PangoRendererPrivate*"/>
       </field>
     </class>
-    <record name="RendererClass"
-            c:type="PangoRendererClass"
-            glib:is-gtype-struct-for="Renderer"
-            version="1.8">
+    <record name="RendererClass" c:type="PangoRendererClass" glib:is-gtype-struct-for="Renderer" version="1.8">
       <doc xml:space="preserve">Class structure for #PangoRenderer.</doc>
       <field name="parent_class" readable="0" private="1">
         <type name="GObject.ObjectClass" c:type="GObjectClass"/>
@@ -10503,10 +9107,7 @@ Also see pango_renderer_set_alpha().</doc>
               <doc xml:space="preserve">a #PangoRenderer</doc>
               <type name="Renderer" c:type="PangoRenderer*"/>
             </parameter>
-            <parameter name="text"
-                       transfer-ownership="none"
-                       nullable="1"
-                       allow-none="1">
+            <parameter name="text" transfer-ownership="none" nullable="1" allow-none="1">
               <doc xml:space="preserve">the UTF-8 text that @glyph_item refers to, or %NULL</doc>
               <type name="utf8" c:type="const char*"/>
             </parameter>
@@ -10562,10 +9163,7 @@ When setting font sizes, device units are always considered to be
 points (as in "12 point font"), rather than pixels.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <enumeration name="Script"
-                 glib:type-name="PangoScript"
-                 glib:get-type="pango_script_get_type"
-                 c:type="PangoScript">
+    <enumeration name="Script" glib:type-name="PangoScript" glib:get-type="pango_script_get_type" c:type="PangoScript">
       <doc xml:space="preserve">The #PangoScript enumeration identifies different writing
 systems. The values correspond to the names as defined in the
 Unicode standard.
@@ -10574,718 +9172,362 @@ to handle unknown values.  This enumeration is interchangeable with
 #GUnicodeScript.  See &lt;ulink
 url="http://www.unicode.org/reports/tr24/"&gt;Unicode Standard Annex
 #24: Script names&lt;/ulink&gt;.</doc>
-      <member name="invalid_code"
-              value="-1"
-              c:identifier="PANGO_SCRIPT_INVALID_CODE"
-              glib:nick="invalid-code">
+      <member name="invalid_code" value="-1" c:identifier="PANGO_SCRIPT_INVALID_CODE" glib:nick="invalid-code">
         <doc xml:space="preserve">a value never returned from pango_script_for_unichar()</doc>
       </member>
-      <member name="common"
-              value="0"
-              c:identifier="PANGO_SCRIPT_COMMON"
-              glib:nick="common">
+      <member name="common" value="0" c:identifier="PANGO_SCRIPT_COMMON" glib:nick="common">
         <doc xml:space="preserve">a character used by multiple different scripts</doc>
       </member>
-      <member name="inherited"
-              value="1"
-              c:identifier="PANGO_SCRIPT_INHERITED"
-              glib:nick="inherited">
+      <member name="inherited" value="1" c:identifier="PANGO_SCRIPT_INHERITED" glib:nick="inherited">
         <doc xml:space="preserve">a mark glyph that takes its script from the
 base glyph to which it is attached</doc>
       </member>
-      <member name="arabic"
-              value="2"
-              c:identifier="PANGO_SCRIPT_ARABIC"
-              glib:nick="arabic">
+      <member name="arabic" value="2" c:identifier="PANGO_SCRIPT_ARABIC" glib:nick="arabic">
         <doc xml:space="preserve">Arabic</doc>
       </member>
-      <member name="armenian"
-              value="3"
-              c:identifier="PANGO_SCRIPT_ARMENIAN"
-              glib:nick="armenian">
+      <member name="armenian" value="3" c:identifier="PANGO_SCRIPT_ARMENIAN" glib:nick="armenian">
         <doc xml:space="preserve">Armenian</doc>
       </member>
-      <member name="bengali"
-              value="4"
-              c:identifier="PANGO_SCRIPT_BENGALI"
-              glib:nick="bengali">
+      <member name="bengali" value="4" c:identifier="PANGO_SCRIPT_BENGALI" glib:nick="bengali">
         <doc xml:space="preserve">Bengali</doc>
       </member>
-      <member name="bopomofo"
-              value="5"
-              c:identifier="PANGO_SCRIPT_BOPOMOFO"
-              glib:nick="bopomofo">
+      <member name="bopomofo" value="5" c:identifier="PANGO_SCRIPT_BOPOMOFO" glib:nick="bopomofo">
         <doc xml:space="preserve">Bopomofo</doc>
       </member>
-      <member name="cherokee"
-              value="6"
-              c:identifier="PANGO_SCRIPT_CHEROKEE"
-              glib:nick="cherokee">
+      <member name="cherokee" value="6" c:identifier="PANGO_SCRIPT_CHEROKEE" glib:nick="cherokee">
         <doc xml:space="preserve">Cherokee</doc>
       </member>
-      <member name="coptic"
-              value="7"
-              c:identifier="PANGO_SCRIPT_COPTIC"
-              glib:nick="coptic">
+      <member name="coptic" value="7" c:identifier="PANGO_SCRIPT_COPTIC" glib:nick="coptic">
         <doc xml:space="preserve">Coptic</doc>
       </member>
-      <member name="cyrillic"
-              value="8"
-              c:identifier="PANGO_SCRIPT_CYRILLIC"
-              glib:nick="cyrillic">
+      <member name="cyrillic" value="8" c:identifier="PANGO_SCRIPT_CYRILLIC" glib:nick="cyrillic">
         <doc xml:space="preserve">Cyrillic</doc>
       </member>
-      <member name="deseret"
-              value="9"
-              c:identifier="PANGO_SCRIPT_DESERET"
-              glib:nick="deseret">
+      <member name="deseret" value="9" c:identifier="PANGO_SCRIPT_DESERET" glib:nick="deseret">
         <doc xml:space="preserve">Deseret</doc>
       </member>
-      <member name="devanagari"
-              value="10"
-              c:identifier="PANGO_SCRIPT_DEVANAGARI"
-              glib:nick="devanagari">
+      <member name="devanagari" value="10" c:identifier="PANGO_SCRIPT_DEVANAGARI" glib:nick="devanagari">
         <doc xml:space="preserve">Devanagari</doc>
       </member>
-      <member name="ethiopic"
-              value="11"
-              c:identifier="PANGO_SCRIPT_ETHIOPIC"
-              glib:nick="ethiopic">
+      <member name="ethiopic" value="11" c:identifier="PANGO_SCRIPT_ETHIOPIC" glib:nick="ethiopic">
         <doc xml:space="preserve">Ethiopic</doc>
       </member>
-      <member name="georgian"
-              value="12"
-              c:identifier="PANGO_SCRIPT_GEORGIAN"
-              glib:nick="georgian">
+      <member name="georgian" value="12" c:identifier="PANGO_SCRIPT_GEORGIAN" glib:nick="georgian">
         <doc xml:space="preserve">Georgian</doc>
       </member>
-      <member name="gothic"
-              value="13"
-              c:identifier="PANGO_SCRIPT_GOTHIC"
-              glib:nick="gothic">
+      <member name="gothic" value="13" c:identifier="PANGO_SCRIPT_GOTHIC" glib:nick="gothic">
         <doc xml:space="preserve">Gothic</doc>
       </member>
-      <member name="greek"
-              value="14"
-              c:identifier="PANGO_SCRIPT_GREEK"
-              glib:nick="greek">
+      <member name="greek" value="14" c:identifier="PANGO_SCRIPT_GREEK" glib:nick="greek">
         <doc xml:space="preserve">Greek</doc>
       </member>
-      <member name="gujarati"
-              value="15"
-              c:identifier="PANGO_SCRIPT_GUJARATI"
-              glib:nick="gujarati">
+      <member name="gujarati" value="15" c:identifier="PANGO_SCRIPT_GUJARATI" glib:nick="gujarati">
         <doc xml:space="preserve">Gujarati</doc>
       </member>
-      <member name="gurmukhi"
-              value="16"
-              c:identifier="PANGO_SCRIPT_GURMUKHI"
-              glib:nick="gurmukhi">
+      <member name="gurmukhi" value="16" c:identifier="PANGO_SCRIPT_GURMUKHI" glib:nick="gurmukhi">
         <doc xml:space="preserve">Gurmukhi</doc>
       </member>
-      <member name="han"
-              value="17"
-              c:identifier="PANGO_SCRIPT_HAN"
-              glib:nick="han">
+      <member name="han" value="17" c:identifier="PANGO_SCRIPT_HAN" glib:nick="han">
         <doc xml:space="preserve">Han</doc>
       </member>
-      <member name="hangul"
-              value="18"
-              c:identifier="PANGO_SCRIPT_HANGUL"
-              glib:nick="hangul">
+      <member name="hangul" value="18" c:identifier="PANGO_SCRIPT_HANGUL" glib:nick="hangul">
         <doc xml:space="preserve">Hangul</doc>
       </member>
-      <member name="hebrew"
-              value="19"
-              c:identifier="PANGO_SCRIPT_HEBREW"
-              glib:nick="hebrew">
+      <member name="hebrew" value="19" c:identifier="PANGO_SCRIPT_HEBREW" glib:nick="hebrew">
         <doc xml:space="preserve">Hebrew</doc>
       </member>
-      <member name="hiragana"
-              value="20"
-              c:identifier="PANGO_SCRIPT_HIRAGANA"
-              glib:nick="hiragana">
+      <member name="hiragana" value="20" c:identifier="PANGO_SCRIPT_HIRAGANA" glib:nick="hiragana">
         <doc xml:space="preserve">Hiragana</doc>
       </member>
-      <member name="kannada"
-              value="21"
-              c:identifier="PANGO_SCRIPT_KANNADA"
-              glib:nick="kannada">
+      <member name="kannada" value="21" c:identifier="PANGO_SCRIPT_KANNADA" glib:nick="kannada">
         <doc xml:space="preserve">Kannada</doc>
       </member>
-      <member name="katakana"
-              value="22"
-              c:identifier="PANGO_SCRIPT_KATAKANA"
-              glib:nick="katakana">
+      <member name="katakana" value="22" c:identifier="PANGO_SCRIPT_KATAKANA" glib:nick="katakana">
         <doc xml:space="preserve">Katakana</doc>
       </member>
-      <member name="khmer"
-              value="23"
-              c:identifier="PANGO_SCRIPT_KHMER"
-              glib:nick="khmer">
+      <member name="khmer" value="23" c:identifier="PANGO_SCRIPT_KHMER" glib:nick="khmer">
         <doc xml:space="preserve">Khmer</doc>
       </member>
-      <member name="lao"
-              value="24"
-              c:identifier="PANGO_SCRIPT_LAO"
-              glib:nick="lao">
+      <member name="lao" value="24" c:identifier="PANGO_SCRIPT_LAO" glib:nick="lao">
         <doc xml:space="preserve">Lao</doc>
       </member>
-      <member name="latin"
-              value="25"
-              c:identifier="PANGO_SCRIPT_LATIN"
-              glib:nick="latin">
+      <member name="latin" value="25" c:identifier="PANGO_SCRIPT_LATIN" glib:nick="latin">
         <doc xml:space="preserve">Latin</doc>
       </member>
-      <member name="malayalam"
-              value="26"
-              c:identifier="PANGO_SCRIPT_MALAYALAM"
-              glib:nick="malayalam">
+      <member name="malayalam" value="26" c:identifier="PANGO_SCRIPT_MALAYALAM" glib:nick="malayalam">
         <doc xml:space="preserve">Malayalam</doc>
       </member>
-      <member name="mongolian"
-              value="27"
-              c:identifier="PANGO_SCRIPT_MONGOLIAN"
-              glib:nick="mongolian">
+      <member name="mongolian" value="27" c:identifier="PANGO_SCRIPT_MONGOLIAN" glib:nick="mongolian">
         <doc xml:space="preserve">Mongolian</doc>
       </member>
-      <member name="myanmar"
-              value="28"
-              c:identifier="PANGO_SCRIPT_MYANMAR"
-              glib:nick="myanmar">
+      <member name="myanmar" value="28" c:identifier="PANGO_SCRIPT_MYANMAR" glib:nick="myanmar">
         <doc xml:space="preserve">Myanmar</doc>
       </member>
-      <member name="ogham"
-              value="29"
-              c:identifier="PANGO_SCRIPT_OGHAM"
-              glib:nick="ogham">
+      <member name="ogham" value="29" c:identifier="PANGO_SCRIPT_OGHAM" glib:nick="ogham">
         <doc xml:space="preserve">Ogham</doc>
       </member>
-      <member name="old_italic"
-              value="30"
-              c:identifier="PANGO_SCRIPT_OLD_ITALIC"
-              glib:nick="old-italic">
+      <member name="old_italic" value="30" c:identifier="PANGO_SCRIPT_OLD_ITALIC" glib:nick="old-italic">
         <doc xml:space="preserve">Old Italic</doc>
       </member>
-      <member name="oriya"
-              value="31"
-              c:identifier="PANGO_SCRIPT_ORIYA"
-              glib:nick="oriya">
+      <member name="oriya" value="31" c:identifier="PANGO_SCRIPT_ORIYA" glib:nick="oriya">
         <doc xml:space="preserve">Oriya</doc>
       </member>
-      <member name="runic"
-              value="32"
-              c:identifier="PANGO_SCRIPT_RUNIC"
-              glib:nick="runic">
+      <member name="runic" value="32" c:identifier="PANGO_SCRIPT_RUNIC" glib:nick="runic">
         <doc xml:space="preserve">Runic</doc>
       </member>
-      <member name="sinhala"
-              value="33"
-              c:identifier="PANGO_SCRIPT_SINHALA"
-              glib:nick="sinhala">
+      <member name="sinhala" value="33" c:identifier="PANGO_SCRIPT_SINHALA" glib:nick="sinhala">
         <doc xml:space="preserve">Sinhala</doc>
       </member>
-      <member name="syriac"
-              value="34"
-              c:identifier="PANGO_SCRIPT_SYRIAC"
-              glib:nick="syriac">
+      <member name="syriac" value="34" c:identifier="PANGO_SCRIPT_SYRIAC" glib:nick="syriac">
         <doc xml:space="preserve">Syriac</doc>
       </member>
-      <member name="tamil"
-              value="35"
-              c:identifier="PANGO_SCRIPT_TAMIL"
-              glib:nick="tamil">
+      <member name="tamil" value="35" c:identifier="PANGO_SCRIPT_TAMIL" glib:nick="tamil">
         <doc xml:space="preserve">Tamil</doc>
       </member>
-      <member name="telugu"
-              value="36"
-              c:identifier="PANGO_SCRIPT_TELUGU"
-              glib:nick="telugu">
+      <member name="telugu" value="36" c:identifier="PANGO_SCRIPT_TELUGU" glib:nick="telugu">
         <doc xml:space="preserve">Telugu</doc>
       </member>
-      <member name="thaana"
-              value="37"
-              c:identifier="PANGO_SCRIPT_THAANA"
-              glib:nick="thaana">
+      <member name="thaana" value="37" c:identifier="PANGO_SCRIPT_THAANA" glib:nick="thaana">
         <doc xml:space="preserve">Thaana</doc>
       </member>
-      <member name="thai"
-              value="38"
-              c:identifier="PANGO_SCRIPT_THAI"
-              glib:nick="thai">
+      <member name="thai" value="38" c:identifier="PANGO_SCRIPT_THAI" glib:nick="thai">
         <doc xml:space="preserve">Thai</doc>
       </member>
-      <member name="tibetan"
-              value="39"
-              c:identifier="PANGO_SCRIPT_TIBETAN"
-              glib:nick="tibetan">
+      <member name="tibetan" value="39" c:identifier="PANGO_SCRIPT_TIBETAN" glib:nick="tibetan">
         <doc xml:space="preserve">Tibetan</doc>
       </member>
-      <member name="canadian_aboriginal"
-              value="40"
-              c:identifier="PANGO_SCRIPT_CANADIAN_ABORIGINAL"
-              glib:nick="canadian-aboriginal">
+      <member name="canadian_aboriginal" value="40" c:identifier="PANGO_SCRIPT_CANADIAN_ABORIGINAL" glib:nick="canadian-aboriginal">
         <doc xml:space="preserve">Canadian Aboriginal</doc>
       </member>
-      <member name="yi"
-              value="41"
-              c:identifier="PANGO_SCRIPT_YI"
-              glib:nick="yi">
+      <member name="yi" value="41" c:identifier="PANGO_SCRIPT_YI" glib:nick="yi">
         <doc xml:space="preserve">Yi</doc>
       </member>
-      <member name="tagalog"
-              value="42"
-              c:identifier="PANGO_SCRIPT_TAGALOG"
-              glib:nick="tagalog">
+      <member name="tagalog" value="42" c:identifier="PANGO_SCRIPT_TAGALOG" glib:nick="tagalog">
         <doc xml:space="preserve">Tagalog</doc>
       </member>
-      <member name="hanunoo"
-              value="43"
-              c:identifier="PANGO_SCRIPT_HANUNOO"
-              glib:nick="hanunoo">
+      <member name="hanunoo" value="43" c:identifier="PANGO_SCRIPT_HANUNOO" glib:nick="hanunoo">
         <doc xml:space="preserve">Hanunoo</doc>
       </member>
-      <member name="buhid"
-              value="44"
-              c:identifier="PANGO_SCRIPT_BUHID"
-              glib:nick="buhid">
+      <member name="buhid" value="44" c:identifier="PANGO_SCRIPT_BUHID" glib:nick="buhid">
         <doc xml:space="preserve">Buhid</doc>
       </member>
-      <member name="tagbanwa"
-              value="45"
-              c:identifier="PANGO_SCRIPT_TAGBANWA"
-              glib:nick="tagbanwa">
+      <member name="tagbanwa" value="45" c:identifier="PANGO_SCRIPT_TAGBANWA" glib:nick="tagbanwa">
         <doc xml:space="preserve">Tagbanwa</doc>
       </member>
-      <member name="braille"
-              value="46"
-              c:identifier="PANGO_SCRIPT_BRAILLE"
-              glib:nick="braille">
+      <member name="braille" value="46" c:identifier="PANGO_SCRIPT_BRAILLE" glib:nick="braille">
         <doc xml:space="preserve">Braille</doc>
       </member>
-      <member name="cypriot"
-              value="47"
-              c:identifier="PANGO_SCRIPT_CYPRIOT"
-              glib:nick="cypriot">
+      <member name="cypriot" value="47" c:identifier="PANGO_SCRIPT_CYPRIOT" glib:nick="cypriot">
         <doc xml:space="preserve">Cypriot</doc>
       </member>
-      <member name="limbu"
-              value="48"
-              c:identifier="PANGO_SCRIPT_LIMBU"
-              glib:nick="limbu">
+      <member name="limbu" value="48" c:identifier="PANGO_SCRIPT_LIMBU" glib:nick="limbu">
         <doc xml:space="preserve">Limbu</doc>
       </member>
-      <member name="osmanya"
-              value="49"
-              c:identifier="PANGO_SCRIPT_OSMANYA"
-              glib:nick="osmanya">
+      <member name="osmanya" value="49" c:identifier="PANGO_SCRIPT_OSMANYA" glib:nick="osmanya">
         <doc xml:space="preserve">Osmanya</doc>
       </member>
-      <member name="shavian"
-              value="50"
-              c:identifier="PANGO_SCRIPT_SHAVIAN"
-              glib:nick="shavian">
+      <member name="shavian" value="50" c:identifier="PANGO_SCRIPT_SHAVIAN" glib:nick="shavian">
         <doc xml:space="preserve">Shavian</doc>
       </member>
-      <member name="linear_b"
-              value="51"
-              c:identifier="PANGO_SCRIPT_LINEAR_B"
-              glib:nick="linear-b">
+      <member name="linear_b" value="51" c:identifier="PANGO_SCRIPT_LINEAR_B" glib:nick="linear-b">
         <doc xml:space="preserve">Linear B</doc>
       </member>
-      <member name="tai_le"
-              value="52"
-              c:identifier="PANGO_SCRIPT_TAI_LE"
-              glib:nick="tai-le">
+      <member name="tai_le" value="52" c:identifier="PANGO_SCRIPT_TAI_LE" glib:nick="tai-le">
         <doc xml:space="preserve">Tai Le</doc>
       </member>
-      <member name="ugaritic"
-              value="53"
-              c:identifier="PANGO_SCRIPT_UGARITIC"
-              glib:nick="ugaritic">
+      <member name="ugaritic" value="53" c:identifier="PANGO_SCRIPT_UGARITIC" glib:nick="ugaritic">
         <doc xml:space="preserve">Ugaritic</doc>
       </member>
-      <member name="new_tai_lue"
-              value="54"
-              c:identifier="PANGO_SCRIPT_NEW_TAI_LUE"
-              glib:nick="new-tai-lue">
+      <member name="new_tai_lue" value="54" c:identifier="PANGO_SCRIPT_NEW_TAI_LUE" glib:nick="new-tai-lue">
         <doc xml:space="preserve">New Tai Lue. Since 1.10</doc>
       </member>
-      <member name="buginese"
-              value="55"
-              c:identifier="PANGO_SCRIPT_BUGINESE"
-              glib:nick="buginese">
+      <member name="buginese" value="55" c:identifier="PANGO_SCRIPT_BUGINESE" glib:nick="buginese">
         <doc xml:space="preserve">Buginese. Since 1.10</doc>
       </member>
-      <member name="glagolitic"
-              value="56"
-              c:identifier="PANGO_SCRIPT_GLAGOLITIC"
-              glib:nick="glagolitic">
+      <member name="glagolitic" value="56" c:identifier="PANGO_SCRIPT_GLAGOLITIC" glib:nick="glagolitic">
         <doc xml:space="preserve">Glagolitic. Since 1.10</doc>
       </member>
-      <member name="tifinagh"
-              value="57"
-              c:identifier="PANGO_SCRIPT_TIFINAGH"
-              glib:nick="tifinagh">
+      <member name="tifinagh" value="57" c:identifier="PANGO_SCRIPT_TIFINAGH" glib:nick="tifinagh">
         <doc xml:space="preserve">Tifinagh. Since 1.10</doc>
       </member>
-      <member name="syloti_nagri"
-              value="58"
-              c:identifier="PANGO_SCRIPT_SYLOTI_NAGRI"
-              glib:nick="syloti-nagri">
+      <member name="syloti_nagri" value="58" c:identifier="PANGO_SCRIPT_SYLOTI_NAGRI" glib:nick="syloti-nagri">
         <doc xml:space="preserve">Syloti Nagri. Since 1.10</doc>
       </member>
-      <member name="old_persian"
-              value="59"
-              c:identifier="PANGO_SCRIPT_OLD_PERSIAN"
-              glib:nick="old-persian">
+      <member name="old_persian" value="59" c:identifier="PANGO_SCRIPT_OLD_PERSIAN" glib:nick="old-persian">
         <doc xml:space="preserve">Old Persian. Since 1.10</doc>
       </member>
-      <member name="kharoshthi"
-              value="60"
-              c:identifier="PANGO_SCRIPT_KHAROSHTHI"
-              glib:nick="kharoshthi">
+      <member name="kharoshthi" value="60" c:identifier="PANGO_SCRIPT_KHAROSHTHI" glib:nick="kharoshthi">
         <doc xml:space="preserve">Kharoshthi. Since 1.10</doc>
       </member>
-      <member name="unknown"
-              value="61"
-              c:identifier="PANGO_SCRIPT_UNKNOWN"
-              glib:nick="unknown">
+      <member name="unknown" value="61" c:identifier="PANGO_SCRIPT_UNKNOWN" glib:nick="unknown">
         <doc xml:space="preserve">an unassigned code point. Since 1.14</doc>
       </member>
-      <member name="balinese"
-              value="62"
-              c:identifier="PANGO_SCRIPT_BALINESE"
-              glib:nick="balinese">
+      <member name="balinese" value="62" c:identifier="PANGO_SCRIPT_BALINESE" glib:nick="balinese">
         <doc xml:space="preserve">Balinese. Since 1.14</doc>
       </member>
-      <member name="cuneiform"
-              value="63"
-              c:identifier="PANGO_SCRIPT_CUNEIFORM"
-              glib:nick="cuneiform">
+      <member name="cuneiform" value="63" c:identifier="PANGO_SCRIPT_CUNEIFORM" glib:nick="cuneiform">
         <doc xml:space="preserve">Cuneiform. Since 1.14</doc>
       </member>
-      <member name="phoenician"
-              value="64"
-              c:identifier="PANGO_SCRIPT_PHOENICIAN"
-              glib:nick="phoenician">
+      <member name="phoenician" value="64" c:identifier="PANGO_SCRIPT_PHOENICIAN" glib:nick="phoenician">
         <doc xml:space="preserve">Phoenician. Since 1.14</doc>
       </member>
-      <member name="phags_pa"
-              value="65"
-              c:identifier="PANGO_SCRIPT_PHAGS_PA"
-              glib:nick="phags-pa">
+      <member name="phags_pa" value="65" c:identifier="PANGO_SCRIPT_PHAGS_PA" glib:nick="phags-pa">
         <doc xml:space="preserve">Phags-pa. Since 1.14</doc>
       </member>
-      <member name="nko"
-              value="66"
-              c:identifier="PANGO_SCRIPT_NKO"
-              glib:nick="nko">
+      <member name="nko" value="66" c:identifier="PANGO_SCRIPT_NKO" glib:nick="nko">
         <doc xml:space="preserve">N'Ko. Since 1.14</doc>
       </member>
-      <member name="kayah_li"
-              value="67"
-              c:identifier="PANGO_SCRIPT_KAYAH_LI"
-              glib:nick="kayah-li">
+      <member name="kayah_li" value="67" c:identifier="PANGO_SCRIPT_KAYAH_LI" glib:nick="kayah-li">
         <doc xml:space="preserve">Kayah Li. Since 1.20.1</doc>
       </member>
-      <member name="lepcha"
-              value="68"
-              c:identifier="PANGO_SCRIPT_LEPCHA"
-              glib:nick="lepcha">
+      <member name="lepcha" value="68" c:identifier="PANGO_SCRIPT_LEPCHA" glib:nick="lepcha">
         <doc xml:space="preserve">Lepcha. Since 1.20.1</doc>
       </member>
-      <member name="rejang"
-              value="69"
-              c:identifier="PANGO_SCRIPT_REJANG"
-              glib:nick="rejang">
+      <member name="rejang" value="69" c:identifier="PANGO_SCRIPT_REJANG" glib:nick="rejang">
         <doc xml:space="preserve">Rejang. Since 1.20.1</doc>
       </member>
-      <member name="sundanese"
-              value="70"
-              c:identifier="PANGO_SCRIPT_SUNDANESE"
-              glib:nick="sundanese">
+      <member name="sundanese" value="70" c:identifier="PANGO_SCRIPT_SUNDANESE" glib:nick="sundanese">
         <doc xml:space="preserve">Sundanese. Since 1.20.1</doc>
       </member>
-      <member name="saurashtra"
-              value="71"
-              c:identifier="PANGO_SCRIPT_SAURASHTRA"
-              glib:nick="saurashtra">
+      <member name="saurashtra" value="71" c:identifier="PANGO_SCRIPT_SAURASHTRA" glib:nick="saurashtra">
         <doc xml:space="preserve">Saurashtra. Since 1.20.1</doc>
       </member>
-      <member name="cham"
-              value="72"
-              c:identifier="PANGO_SCRIPT_CHAM"
-              glib:nick="cham">
+      <member name="cham" value="72" c:identifier="PANGO_SCRIPT_CHAM" glib:nick="cham">
         <doc xml:space="preserve">Cham. Since 1.20.1</doc>
       </member>
-      <member name="ol_chiki"
-              value="73"
-              c:identifier="PANGO_SCRIPT_OL_CHIKI"
-              glib:nick="ol-chiki">
+      <member name="ol_chiki" value="73" c:identifier="PANGO_SCRIPT_OL_CHIKI" glib:nick="ol-chiki">
         <doc xml:space="preserve">Ol Chiki. Since 1.20.1</doc>
       </member>
-      <member name="vai"
-              value="74"
-              c:identifier="PANGO_SCRIPT_VAI"
-              glib:nick="vai">
+      <member name="vai" value="74" c:identifier="PANGO_SCRIPT_VAI" glib:nick="vai">
         <doc xml:space="preserve">Vai. Since 1.20.1</doc>
       </member>
-      <member name="carian"
-              value="75"
-              c:identifier="PANGO_SCRIPT_CARIAN"
-              glib:nick="carian">
+      <member name="carian" value="75" c:identifier="PANGO_SCRIPT_CARIAN" glib:nick="carian">
         <doc xml:space="preserve">Carian. Since 1.20.1</doc>
       </member>
-      <member name="lycian"
-              value="76"
-              c:identifier="PANGO_SCRIPT_LYCIAN"
-              glib:nick="lycian">
+      <member name="lycian" value="76" c:identifier="PANGO_SCRIPT_LYCIAN" glib:nick="lycian">
         <doc xml:space="preserve">Lycian. Since 1.20.1</doc>
       </member>
-      <member name="lydian"
-              value="77"
-              c:identifier="PANGO_SCRIPT_LYDIAN"
-              glib:nick="lydian">
+      <member name="lydian" value="77" c:identifier="PANGO_SCRIPT_LYDIAN" glib:nick="lydian">
         <doc xml:space="preserve">Lydian. Since 1.20.1</doc>
       </member>
-      <member name="batak"
-              value="78"
-              c:identifier="PANGO_SCRIPT_BATAK"
-              glib:nick="batak">
+      <member name="batak" value="78" c:identifier="PANGO_SCRIPT_BATAK" glib:nick="batak">
         <doc xml:space="preserve">Batak. Since 1.32</doc>
       </member>
-      <member name="brahmi"
-              value="79"
-              c:identifier="PANGO_SCRIPT_BRAHMI"
-              glib:nick="brahmi">
+      <member name="brahmi" value="79" c:identifier="PANGO_SCRIPT_BRAHMI" glib:nick="brahmi">
         <doc xml:space="preserve">Brahmi. Since 1.32</doc>
       </member>
-      <member name="mandaic"
-              value="80"
-              c:identifier="PANGO_SCRIPT_MANDAIC"
-              glib:nick="mandaic">
+      <member name="mandaic" value="80" c:identifier="PANGO_SCRIPT_MANDAIC" glib:nick="mandaic">
         <doc xml:space="preserve">Mandaic. Since 1.32</doc>
       </member>
-      <member name="chakma"
-              value="81"
-              c:identifier="PANGO_SCRIPT_CHAKMA"
-              glib:nick="chakma">
+      <member name="chakma" value="81" c:identifier="PANGO_SCRIPT_CHAKMA" glib:nick="chakma">
         <doc xml:space="preserve">Chakma. Since: 1.32</doc>
       </member>
-      <member name="meroitic_cursive"
-              value="82"
-              c:identifier="PANGO_SCRIPT_MEROITIC_CURSIVE"
-              glib:nick="meroitic-cursive">
+      <member name="meroitic_cursive" value="82" c:identifier="PANGO_SCRIPT_MEROITIC_CURSIVE" glib:nick="meroitic-cursive">
         <doc xml:space="preserve">Meroitic Cursive. Since: 1.32</doc>
       </member>
-      <member name="meroitic_hieroglyphs"
-              value="83"
-              c:identifier="PANGO_SCRIPT_MEROITIC_HIEROGLYPHS"
-              glib:nick="meroitic-hieroglyphs">
+      <member name="meroitic_hieroglyphs" value="83" c:identifier="PANGO_SCRIPT_MEROITIC_HIEROGLYPHS" glib:nick="meroitic-hieroglyphs">
         <doc xml:space="preserve">Meroitic Hieroglyphs. Since: 1.32</doc>
       </member>
-      <member name="miao"
-              value="84"
-              c:identifier="PANGO_SCRIPT_MIAO"
-              glib:nick="miao">
+      <member name="miao" value="84" c:identifier="PANGO_SCRIPT_MIAO" glib:nick="miao">
         <doc xml:space="preserve">Miao. Since: 1.32</doc>
       </member>
-      <member name="sharada"
-              value="85"
-              c:identifier="PANGO_SCRIPT_SHARADA"
-              glib:nick="sharada">
+      <member name="sharada" value="85" c:identifier="PANGO_SCRIPT_SHARADA" glib:nick="sharada">
         <doc xml:space="preserve">Sharada. Since: 1.32</doc>
       </member>
-      <member name="sora_sompeng"
-              value="86"
-              c:identifier="PANGO_SCRIPT_SORA_SOMPENG"
-              glib:nick="sora-sompeng">
+      <member name="sora_sompeng" value="86" c:identifier="PANGO_SCRIPT_SORA_SOMPENG" glib:nick="sora-sompeng">
         <doc xml:space="preserve">Sora Sompeng. Since: 1.32</doc>
       </member>
-      <member name="takri"
-              value="87"
-              c:identifier="PANGO_SCRIPT_TAKRI"
-              glib:nick="takri">
+      <member name="takri" value="87" c:identifier="PANGO_SCRIPT_TAKRI" glib:nick="takri">
         <doc xml:space="preserve">Takri. Since: 1.32</doc>
       </member>
-      <member name="bassa_vah"
-              value="88"
-              c:identifier="PANGO_SCRIPT_BASSA_VAH"
-              glib:nick="bassa-vah">
+      <member name="bassa_vah" value="88" c:identifier="PANGO_SCRIPT_BASSA_VAH" glib:nick="bassa-vah">
         <doc xml:space="preserve">Bassa. Since: 1.40</doc>
       </member>
-      <member name="caucasian_albanian"
-              value="89"
-              c:identifier="PANGO_SCRIPT_CAUCASIAN_ALBANIAN"
-              glib:nick="caucasian-albanian">
+      <member name="caucasian_albanian" value="89" c:identifier="PANGO_SCRIPT_CAUCASIAN_ALBANIAN" glib:nick="caucasian-albanian">
         <doc xml:space="preserve">Caucasian Albanian. Since: 1.40</doc>
       </member>
-      <member name="duployan"
-              value="90"
-              c:identifier="PANGO_SCRIPT_DUPLOYAN"
-              glib:nick="duployan">
+      <member name="duployan" value="90" c:identifier="PANGO_SCRIPT_DUPLOYAN" glib:nick="duployan">
         <doc xml:space="preserve">Duployan. Since: 1.40</doc>
       </member>
-      <member name="elbasan"
-              value="91"
-              c:identifier="PANGO_SCRIPT_ELBASAN"
-              glib:nick="elbasan">
+      <member name="elbasan" value="91" c:identifier="PANGO_SCRIPT_ELBASAN" glib:nick="elbasan">
         <doc xml:space="preserve">Elbasan. Since: 1.40</doc>
       </member>
-      <member name="grantha"
-              value="92"
-              c:identifier="PANGO_SCRIPT_GRANTHA"
-              glib:nick="grantha">
+      <member name="grantha" value="92" c:identifier="PANGO_SCRIPT_GRANTHA" glib:nick="grantha">
         <doc xml:space="preserve">Grantha. Since: 1.40</doc>
       </member>
-      <member name="khojki"
-              value="93"
-              c:identifier="PANGO_SCRIPT_KHOJKI"
-              glib:nick="khojki">
+      <member name="khojki" value="93" c:identifier="PANGO_SCRIPT_KHOJKI" glib:nick="khojki">
         <doc xml:space="preserve">Kjohki. Since: 1.40</doc>
       </member>
-      <member name="khudawadi"
-              value="94"
-              c:identifier="PANGO_SCRIPT_KHUDAWADI"
-              glib:nick="khudawadi">
+      <member name="khudawadi" value="94" c:identifier="PANGO_SCRIPT_KHUDAWADI" glib:nick="khudawadi">
         <doc xml:space="preserve">Khudawadi, Sindhi. Since: 1.40</doc>
       </member>
-      <member name="linear_a"
-              value="95"
-              c:identifier="PANGO_SCRIPT_LINEAR_A"
-              glib:nick="linear-a">
+      <member name="linear_a" value="95" c:identifier="PANGO_SCRIPT_LINEAR_A" glib:nick="linear-a">
         <doc xml:space="preserve">Linear A. Since: 1.40</doc>
       </member>
-      <member name="mahajani"
-              value="96"
-              c:identifier="PANGO_SCRIPT_MAHAJANI"
-              glib:nick="mahajani">
+      <member name="mahajani" value="96" c:identifier="PANGO_SCRIPT_MAHAJANI" glib:nick="mahajani">
         <doc xml:space="preserve">Mahajani. Since: 1.40</doc>
       </member>
-      <member name="manichaean"
-              value="97"
-              c:identifier="PANGO_SCRIPT_MANICHAEAN"
-              glib:nick="manichaean">
+      <member name="manichaean" value="97" c:identifier="PANGO_SCRIPT_MANICHAEAN" glib:nick="manichaean">
         <doc xml:space="preserve">Manichaean. Since: 1.40</doc>
       </member>
-      <member name="mende_kikakui"
-              value="98"
-              c:identifier="PANGO_SCRIPT_MENDE_KIKAKUI"
-              glib:nick="mende-kikakui">
+      <member name="mende_kikakui" value="98" c:identifier="PANGO_SCRIPT_MENDE_KIKAKUI" glib:nick="mende-kikakui">
         <doc xml:space="preserve">Mende Kikakui. Since: 1.40</doc>
       </member>
-      <member name="modi"
-              value="99"
-              c:identifier="PANGO_SCRIPT_MODI"
-              glib:nick="modi">
+      <member name="modi" value="99" c:identifier="PANGO_SCRIPT_MODI" glib:nick="modi">
         <doc xml:space="preserve">Modi. Since: 1.40</doc>
       </member>
-      <member name="mro"
-              value="100"
-              c:identifier="PANGO_SCRIPT_MRO"
-              glib:nick="mro">
+      <member name="mro" value="100" c:identifier="PANGO_SCRIPT_MRO" glib:nick="mro">
         <doc xml:space="preserve">Mro. Since: 1.40</doc>
       </member>
-      <member name="nabataean"
-              value="101"
-              c:identifier="PANGO_SCRIPT_NABATAEAN"
-              glib:nick="nabataean">
+      <member name="nabataean" value="101" c:identifier="PANGO_SCRIPT_NABATAEAN" glib:nick="nabataean">
         <doc xml:space="preserve">Nabataean. Since: 1.40</doc>
       </member>
-      <member name="old_north_arabian"
-              value="102"
-              c:identifier="PANGO_SCRIPT_OLD_NORTH_ARABIAN"
-              glib:nick="old-north-arabian">
+      <member name="old_north_arabian" value="102" c:identifier="PANGO_SCRIPT_OLD_NORTH_ARABIAN" glib:nick="old-north-arabian">
         <doc xml:space="preserve">Old North Arabian. Since: 1.40</doc>
       </member>
-      <member name="old_permic"
-              value="103"
-              c:identifier="PANGO_SCRIPT_OLD_PERMIC"
-              glib:nick="old-permic">
+      <member name="old_permic" value="103" c:identifier="PANGO_SCRIPT_OLD_PERMIC" glib:nick="old-permic">
         <doc xml:space="preserve">Old Permic. Since: 1.40</doc>
       </member>
-      <member name="pahawh_hmong"
-              value="104"
-              c:identifier="PANGO_SCRIPT_PAHAWH_HMONG"
-              glib:nick="pahawh-hmong">
+      <member name="pahawh_hmong" value="104" c:identifier="PANGO_SCRIPT_PAHAWH_HMONG" glib:nick="pahawh-hmong">
         <doc xml:space="preserve">Pahawh Hmong. Since: 1.40</doc>
       </member>
-      <member name="palmyrene"
-              value="105"
-              c:identifier="PANGO_SCRIPT_PALMYRENE"
-              glib:nick="palmyrene">
+      <member name="palmyrene" value="105" c:identifier="PANGO_SCRIPT_PALMYRENE" glib:nick="palmyrene">
         <doc xml:space="preserve">Palmyrene. Since: 1.40</doc>
       </member>
-      <member name="pau_cin_hau"
-              value="106"
-              c:identifier="PANGO_SCRIPT_PAU_CIN_HAU"
-              glib:nick="pau-cin-hau">
+      <member name="pau_cin_hau" value="106" c:identifier="PANGO_SCRIPT_PAU_CIN_HAU" glib:nick="pau-cin-hau">
         <doc xml:space="preserve">Pau Cin Hau. Since: 1.40</doc>
       </member>
-      <member name="psalter_pahlavi"
-              value="107"
-              c:identifier="PANGO_SCRIPT_PSALTER_PAHLAVI"
-              glib:nick="psalter-pahlavi">
+      <member name="psalter_pahlavi" value="107" c:identifier="PANGO_SCRIPT_PSALTER_PAHLAVI" glib:nick="psalter-pahlavi">
         <doc xml:space="preserve">Psalter Pahlavi. Since: 1.40</doc>
       </member>
-      <member name="siddham"
-              value="108"
-              c:identifier="PANGO_SCRIPT_SIDDHAM"
-              glib:nick="siddham">
+      <member name="siddham" value="108" c:identifier="PANGO_SCRIPT_SIDDHAM" glib:nick="siddham">
         <doc xml:space="preserve">Siddham. Since: 1.40</doc>
       </member>
-      <member name="tirhuta"
-              value="109"
-              c:identifier="PANGO_SCRIPT_TIRHUTA"
-              glib:nick="tirhuta">
+      <member name="tirhuta" value="109" c:identifier="PANGO_SCRIPT_TIRHUTA" glib:nick="tirhuta">
         <doc xml:space="preserve">Tirhuta. Since: 1.40</doc>
       </member>
-      <member name="warang_citi"
-              value="110"
-              c:identifier="PANGO_SCRIPT_WARANG_CITI"
-              glib:nick="warang-citi">
+      <member name="warang_citi" value="110" c:identifier="PANGO_SCRIPT_WARANG_CITI" glib:nick="warang-citi">
         <doc xml:space="preserve">Warang Citi. Since: 1.40</doc>
       </member>
-      <member name="ahom"
-              value="111"
-              c:identifier="PANGO_SCRIPT_AHOM"
-              glib:nick="ahom">
+      <member name="ahom" value="111" c:identifier="PANGO_SCRIPT_AHOM" glib:nick="ahom">
         <doc xml:space="preserve">Ahom. Since: 1.40</doc>
       </member>
-      <member name="anatolian_hieroglyphs"
-              value="112"
-              c:identifier="PANGO_SCRIPT_ANATOLIAN_HIEROGLYPHS"
-              glib:nick="anatolian-hieroglyphs">
+      <member name="anatolian_hieroglyphs" value="112" c:identifier="PANGO_SCRIPT_ANATOLIAN_HIEROGLYPHS" glib:nick="anatolian-hieroglyphs">
         <doc xml:space="preserve">Anatolian Hieroglyphs. Since: 1.40</doc>
       </member>
-      <member name="hatran"
-              value="113"
-              c:identifier="PANGO_SCRIPT_HATRAN"
-              glib:nick="hatran">
+      <member name="hatran" value="113" c:identifier="PANGO_SCRIPT_HATRAN" glib:nick="hatran">
         <doc xml:space="preserve">Hatran. Since: 1.40</doc>
       </member>
-      <member name="multani"
-              value="114"
-              c:identifier="PANGO_SCRIPT_MULTANI"
-              glib:nick="multani">
+      <member name="multani" value="114" c:identifier="PANGO_SCRIPT_MULTANI" glib:nick="multani">
         <doc xml:space="preserve">Multani. Since: 1.40</doc>
       </member>
-      <member name="old_hungarian"
-              value="115"
-              c:identifier="PANGO_SCRIPT_OLD_HUNGARIAN"
-              glib:nick="old-hungarian">
+      <member name="old_hungarian" value="115" c:identifier="PANGO_SCRIPT_OLD_HUNGARIAN" glib:nick="old-hungarian">
         <doc xml:space="preserve">Old Hungarian. Since: 1.40</doc>
       </member>
-      <member name="signwriting"
-              value="116"
-              c:identifier="PANGO_SCRIPT_SIGNWRITING"
-              glib:nick="signwriting">
+      <member name="signwriting" value="116" c:identifier="PANGO_SCRIPT_SIGNWRITING" glib:nick="signwriting">
         <doc xml:space="preserve">Signwriting. Since: 1.40</doc>
       </member>
-      <function name="for_unichar"
-                c:identifier="pango_script_for_unichar"
-                version="1.4">
+      <function name="for_unichar" c:identifier="pango_script_for_unichar" version="1.4">
         <doc xml:space="preserve">Looks up the #PangoScript for a particular character (as defined by
 Unicode Standard Annex \#24). No check is made for @ch being a
 valid Unicode character; if you pass in invalid character, the
@@ -11304,9 +9546,7 @@ g_unichar_get_script().</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="get_sample_language"
-                c:identifier="pango_script_get_sample_language"
-                version="1.4">
+      <function name="get_sample_language" c:identifier="pango_script_get_sample_language" version="1.4">
         <doc xml:space="preserve">Given a script, finds a language tag that is reasonably
 representative of that script. This will usually be the
 most widely spoken or used language written in that script:
@@ -11377,9 +9617,7 @@ and identify ranges in different scripts.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_range"
-              c:identifier="pango_script_iter_get_range"
-              version="1.4">
+      <method name="get_range" c:identifier="pango_script_iter_get_range" version="1.4">
         <doc xml:space="preserve">Gets information about the range to which @iter currently points.
 The range is the set of locations p where *start &lt;= p &lt; *end.
 (That is, it doesn't include the character stored at *end)</doc>
@@ -11391,30 +9629,15 @@ The range is the set of locations p where *start &lt;= p &lt; *end.
             <doc xml:space="preserve">a #PangoScriptIter</doc>
             <type name="ScriptIter" c:type="PangoScriptIter*"/>
           </instance-parameter>
-          <parameter name="start"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="start" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store start position of the range, or %NULL</doc>
             <type name="utf8" c:type="const char**"/>
           </parameter>
-          <parameter name="end"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="end" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store end position of the range, or %NULL</doc>
             <type name="utf8" c:type="const char**"/>
           </parameter>
-          <parameter name="script"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="script" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store script for range, or %NULL</doc>
             <type name="Script" c:type="PangoScript*"/>
           </parameter>
@@ -11435,10 +9658,7 @@ is returned.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <function name="new"
-                c:identifier="pango_script_iter_new"
-                version="1.4"
-                introspectable="0">
+      <function name="new" c:identifier="pango_script_iter_new" version="1.4" introspectable="0">
         <doc xml:space="preserve">Create a new #PangoScriptIter, used to break a string of
 Unicode text into runs by Unicode script. No copy is made of
 @text, so the caller needs to make sure it remains valid until
@@ -11462,108 +9682,56 @@ the iterator is freed with pango_script_iter_free().</doc>
         </parameters>
       </function>
     </record>
-    <enumeration name="Stretch"
-                 glib:type-name="PangoStretch"
-                 glib:get-type="pango_stretch_get_type"
-                 c:type="PangoStretch">
+    <enumeration name="Stretch" glib:type-name="PangoStretch" glib:get-type="pango_stretch_get_type" c:type="PangoStretch">
       <doc xml:space="preserve">An enumeration specifying the width of the font relative to other designs
 within a family.</doc>
-      <member name="ultra_condensed"
-              value="0"
-              c:identifier="PANGO_STRETCH_ULTRA_CONDENSED"
-              glib:nick="ultra-condensed">
+      <member name="ultra_condensed" value="0" c:identifier="PANGO_STRETCH_ULTRA_CONDENSED" glib:nick="ultra-condensed">
         <doc xml:space="preserve">ultra condensed width</doc>
       </member>
-      <member name="extra_condensed"
-              value="1"
-              c:identifier="PANGO_STRETCH_EXTRA_CONDENSED"
-              glib:nick="extra-condensed">
+      <member name="extra_condensed" value="1" c:identifier="PANGO_STRETCH_EXTRA_CONDENSED" glib:nick="extra-condensed">
         <doc xml:space="preserve">extra condensed width</doc>
       </member>
-      <member name="condensed"
-              value="2"
-              c:identifier="PANGO_STRETCH_CONDENSED"
-              glib:nick="condensed">
+      <member name="condensed" value="2" c:identifier="PANGO_STRETCH_CONDENSED" glib:nick="condensed">
         <doc xml:space="preserve">condensed width</doc>
       </member>
-      <member name="semi_condensed"
-              value="3"
-              c:identifier="PANGO_STRETCH_SEMI_CONDENSED"
-              glib:nick="semi-condensed">
+      <member name="semi_condensed" value="3" c:identifier="PANGO_STRETCH_SEMI_CONDENSED" glib:nick="semi-condensed">
         <doc xml:space="preserve">semi condensed width</doc>
       </member>
-      <member name="normal"
-              value="4"
-              c:identifier="PANGO_STRETCH_NORMAL"
-              glib:nick="normal">
+      <member name="normal" value="4" c:identifier="PANGO_STRETCH_NORMAL" glib:nick="normal">
         <doc xml:space="preserve">the normal width</doc>
       </member>
-      <member name="semi_expanded"
-              value="5"
-              c:identifier="PANGO_STRETCH_SEMI_EXPANDED"
-              glib:nick="semi-expanded">
+      <member name="semi_expanded" value="5" c:identifier="PANGO_STRETCH_SEMI_EXPANDED" glib:nick="semi-expanded">
         <doc xml:space="preserve">semi expanded width</doc>
       </member>
-      <member name="expanded"
-              value="6"
-              c:identifier="PANGO_STRETCH_EXPANDED"
-              glib:nick="expanded">
+      <member name="expanded" value="6" c:identifier="PANGO_STRETCH_EXPANDED" glib:nick="expanded">
         <doc xml:space="preserve">expanded width</doc>
       </member>
-      <member name="extra_expanded"
-              value="7"
-              c:identifier="PANGO_STRETCH_EXTRA_EXPANDED"
-              glib:nick="extra-expanded">
+      <member name="extra_expanded" value="7" c:identifier="PANGO_STRETCH_EXTRA_EXPANDED" glib:nick="extra-expanded">
         <doc xml:space="preserve">extra expanded width</doc>
       </member>
-      <member name="ultra_expanded"
-              value="8"
-              c:identifier="PANGO_STRETCH_ULTRA_EXPANDED"
-              glib:nick="ultra-expanded">
+      <member name="ultra_expanded" value="8" c:identifier="PANGO_STRETCH_ULTRA_EXPANDED" glib:nick="ultra-expanded">
         <doc xml:space="preserve">ultra expanded width</doc>
       </member>
     </enumeration>
-    <enumeration name="Style"
-                 glib:type-name="PangoStyle"
-                 glib:get-type="pango_style_get_type"
-                 c:type="PangoStyle">
+    <enumeration name="Style" glib:type-name="PangoStyle" glib:get-type="pango_style_get_type" c:type="PangoStyle">
       <doc xml:space="preserve">An enumeration specifying the various slant styles possible for a font.</doc>
-      <member name="normal"
-              value="0"
-              c:identifier="PANGO_STYLE_NORMAL"
-              glib:nick="normal">
+      <member name="normal" value="0" c:identifier="PANGO_STYLE_NORMAL" glib:nick="normal">
         <doc xml:space="preserve">the font is upright.</doc>
       </member>
-      <member name="oblique"
-              value="1"
-              c:identifier="PANGO_STYLE_OBLIQUE"
-              glib:nick="oblique">
+      <member name="oblique" value="1" c:identifier="PANGO_STYLE_OBLIQUE" glib:nick="oblique">
         <doc xml:space="preserve">the font is slanted, but in a roman style.</doc>
       </member>
-      <member name="italic"
-              value="2"
-              c:identifier="PANGO_STYLE_ITALIC"
-              glib:nick="italic">
+      <member name="italic" value="2" c:identifier="PANGO_STYLE_ITALIC" glib:nick="italic">
         <doc xml:space="preserve">the font is slanted in an italic style.</doc>
       </member>
     </enumeration>
-    <enumeration name="TabAlign"
-                 glib:type-name="PangoTabAlign"
-                 glib:get-type="pango_tab_align_get_type"
-                 c:type="PangoTabAlign">
+    <enumeration name="TabAlign" glib:type-name="PangoTabAlign" glib:get-type="pango_tab_align_get_type" c:type="PangoTabAlign">
       <doc xml:space="preserve">A #PangoTabAlign specifies where a tab stop appears relative to the text.</doc>
-      <member name="left"
-              value="0"
-              c:identifier="PANGO_TAB_LEFT"
-              glib:nick="left">
+      <member name="left" value="0" c:identifier="PANGO_TAB_LEFT" glib:nick="left">
         <doc xml:space="preserve">the tab stop appears to the left of the text.</doc>
       </member>
     </enumeration>
-    <record name="TabArray"
-            c:type="PangoTabArray"
-            glib:type-name="PangoTabArray"
-            glib:get-type="pango_tab_array_get_type"
-            c:symbol-prefix="tab_array">
+    <record name="TabArray" c:type="PangoTabArray" glib:type-name="PangoTabArray" glib:get-type="pango_tab_array_get_type" c:symbol-prefix="tab_array">
       <doc xml:space="preserve">A #PangoTabArray struct contains an array
 of tab stops. Each tab stop has an alignment and a position.</doc>
       <constructor name="new" c:identifier="pango_tab_array_new">
@@ -11586,9 +9754,7 @@ units. All stops are initially at position 0.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_with_positions"
-                   c:identifier="pango_tab_array_new_with_positions"
-                   introspectable="0">
+      <constructor name="new_with_positions" c:identifier="pango_tab_array_new_with_positions" introspectable="0">
         <doc xml:space="preserve">This is a convenience function that creates a #PangoTabArray
 and allows you to specify the alignment and position of each
 tab stop. You &lt;emphasis&gt;must&lt;/emphasis&gt; provide an alignment
@@ -11647,8 +9813,7 @@ and position for @size tab stops.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_positions_in_pixels"
-              c:identifier="pango_tab_array_get_positions_in_pixels">
+      <method name="get_positions_in_pixels" c:identifier="pango_tab_array_get_positions_in_pixels">
         <doc xml:space="preserve">Returns %TRUE if the tab positions are in pixels, %FALSE if they are
 in Pango units.</doc>
         <return-value transfer-ownership="none">
@@ -11689,21 +9854,11 @@ in Pango units.</doc>
             <doc xml:space="preserve">tab stop index</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
-          <parameter name="alignment"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="alignment" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store alignment, or %NULL</doc>
             <type name="TabAlign" c:type="PangoTabAlign*"/>
           </parameter>
-          <parameter name="location"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="location" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store tab position, or %NULL</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
@@ -11721,22 +9876,12 @@ returned array.</doc>
             <doc xml:space="preserve">a #PangoTabArray</doc>
             <type name="TabArray" c:type="PangoTabArray*"/>
           </instance-parameter>
-          <parameter name="alignments"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="alignments" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store an array of tab
   stop alignments, or %NULL</doc>
             <type name="TabAlign" c:type="PangoTabAlign**"/>
           </parameter>
-          <parameter name="locations"
-                     direction="out"
-                     caller-allocates="0"
-                     transfer-ownership="full"
-                     optional="1"
-                     allow-none="1">
+          <parameter name="locations" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">location to store an array
   of tab positions, or %NULL</doc>
             <array zero-terminated="0" c:type="gint**">
@@ -11789,45 +9934,26 @@ implementation.</doc>
         </parameters>
       </method>
     </record>
-    <constant name="UNKNOWN_GLYPH_HEIGHT"
-              value="14"
-              c:type="PANGO_UNKNOWN_GLYPH_HEIGHT">
+    <constant name="UNKNOWN_GLYPH_HEIGHT" value="14" c:type="PANGO_UNKNOWN_GLYPH_HEIGHT">
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="UNKNOWN_GLYPH_WIDTH"
-              value="10"
-              c:type="PANGO_UNKNOWN_GLYPH_WIDTH">
+    <constant name="UNKNOWN_GLYPH_WIDTH" value="10" c:type="PANGO_UNKNOWN_GLYPH_WIDTH">
       <type name="gint" c:type="gint"/>
     </constant>
-    <enumeration name="Underline"
-                 glib:type-name="PangoUnderline"
-                 glib:get-type="pango_underline_get_type"
-                 c:type="PangoUnderline">
+    <enumeration name="Underline" glib:type-name="PangoUnderline" glib:get-type="pango_underline_get_type" c:type="PangoUnderline">
       <doc xml:space="preserve">The #PangoUnderline enumeration is used to specify
 whether text should be underlined, and if so, the type
 of underlining.</doc>
-      <member name="none"
-              value="0"
-              c:identifier="PANGO_UNDERLINE_NONE"
-              glib:nick="none">
+      <member name="none" value="0" c:identifier="PANGO_UNDERLINE_NONE" glib:nick="none">
         <doc xml:space="preserve">no underline should be drawn</doc>
       </member>
-      <member name="single"
-              value="1"
-              c:identifier="PANGO_UNDERLINE_SINGLE"
-              glib:nick="single">
+      <member name="single" value="1" c:identifier="PANGO_UNDERLINE_SINGLE" glib:nick="single">
         <doc xml:space="preserve">a single underline should be drawn</doc>
       </member>
-      <member name="double"
-              value="2"
-              c:identifier="PANGO_UNDERLINE_DOUBLE"
-              glib:nick="double">
+      <member name="double" value="2" c:identifier="PANGO_UNDERLINE_DOUBLE" glib:nick="double">
         <doc xml:space="preserve">a double underline should be drawn</doc>
       </member>
-      <member name="low"
-              value="3"
-              c:identifier="PANGO_UNDERLINE_LOW"
-              glib:nick="low">
+      <member name="low" value="3" c:identifier="PANGO_UNDERLINE_LOW" glib:nick="low">
         <doc xml:space="preserve">a single underline should be drawn at a position
 beneath the ink extents of the text being
 underlined. This should be used only for underlining
@@ -11835,10 +9961,7 @@ single characters, such as for keyboard
 accelerators. %PANGO_UNDERLINE_SINGLE should
 be used for extended portions of text.</doc>
       </member>
-      <member name="error"
-              value="4"
-              c:identifier="PANGO_UNDERLINE_ERROR"
-              glib:nick="error">
+      <member name="error" value="4" c:identifier="PANGO_UNDERLINE_ERROR" glib:nick="error">
         <doc xml:space="preserve">a wavy underline should be drawn below.
 This underline is typically used to indicate
 an error such as a possilble mispelling; in some
@@ -11846,10 +9969,7 @@ cases a contrasting color may automatically
 be used. This type of underlining is available since Pango 1.4.</doc>
       </member>
     </enumeration>
-    <constant name="VERSION_MIN_REQUIRED"
-              value="2"
-              c:type="PANGO_VERSION_MIN_REQUIRED"
-              version="1.42">
+    <constant name="VERSION_MIN_REQUIRED" value="2" c:type="PANGO_VERSION_MIN_REQUIRED" version="1.42">
       <doc xml:space="preserve">A macro that should be defined by the user prior to including
 the pango.h header.
 The definition should be one of the predefined Pango version
@@ -11864,133 +9984,70 @@ functions, then using functions that were deprecated in version
 using functions deprecated in later releases will not).</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <enumeration name="Variant"
-                 glib:type-name="PangoVariant"
-                 glib:get-type="pango_variant_get_type"
-                 c:type="PangoVariant">
+    <enumeration name="Variant" glib:type-name="PangoVariant" glib:get-type="pango_variant_get_type" c:type="PangoVariant">
       <doc xml:space="preserve">An enumeration specifying capitalization variant of the font.</doc>
-      <member name="normal"
-              value="0"
-              c:identifier="PANGO_VARIANT_NORMAL"
-              glib:nick="normal">
+      <member name="normal" value="0" c:identifier="PANGO_VARIANT_NORMAL" glib:nick="normal">
         <doc xml:space="preserve">A normal font.</doc>
       </member>
-      <member name="small_caps"
-              value="1"
-              c:identifier="PANGO_VARIANT_SMALL_CAPS"
-              glib:nick="small-caps">
+      <member name="small_caps" value="1" c:identifier="PANGO_VARIANT_SMALL_CAPS" glib:nick="small-caps">
         <doc xml:space="preserve">A font with the lower case characters
 replaced by smaller variants of the capital characters.</doc>
       </member>
     </enumeration>
-    <enumeration name="Weight"
-                 glib:type-name="PangoWeight"
-                 glib:get-type="pango_weight_get_type"
-                 c:type="PangoWeight">
+    <enumeration name="Weight" glib:type-name="PangoWeight" glib:get-type="pango_weight_get_type" c:type="PangoWeight">
       <doc xml:space="preserve">An enumeration specifying the weight (boldness) of a font. This is a numerical
 value ranging from 100 to 1000, but there are some predefined values:</doc>
-      <member name="thin"
-              value="100"
-              c:identifier="PANGO_WEIGHT_THIN"
-              glib:nick="thin">
+      <member name="thin" value="100" c:identifier="PANGO_WEIGHT_THIN" glib:nick="thin">
         <doc xml:space="preserve">the thin weight (= 100; Since: 1.24)</doc>
       </member>
-      <member name="ultralight"
-              value="200"
-              c:identifier="PANGO_WEIGHT_ULTRALIGHT"
-              glib:nick="ultralight">
+      <member name="ultralight" value="200" c:identifier="PANGO_WEIGHT_ULTRALIGHT" glib:nick="ultralight">
         <doc xml:space="preserve">the ultralight weight (= 200)</doc>
       </member>
-      <member name="light"
-              value="300"
-              c:identifier="PANGO_WEIGHT_LIGHT"
-              glib:nick="light">
+      <member name="light" value="300" c:identifier="PANGO_WEIGHT_LIGHT" glib:nick="light">
         <doc xml:space="preserve">the light weight (= 300)</doc>
       </member>
-      <member name="semilight"
-              value="350"
-              c:identifier="PANGO_WEIGHT_SEMILIGHT"
-              glib:nick="semilight">
+      <member name="semilight" value="350" c:identifier="PANGO_WEIGHT_SEMILIGHT" glib:nick="semilight">
         <doc xml:space="preserve">the semilight weight (= 350; Since: 1.36.7)</doc>
       </member>
-      <member name="book"
-              value="380"
-              c:identifier="PANGO_WEIGHT_BOOK"
-              glib:nick="book">
+      <member name="book" value="380" c:identifier="PANGO_WEIGHT_BOOK" glib:nick="book">
         <doc xml:space="preserve">the book weight (= 380; Since: 1.24)</doc>
       </member>
-      <member name="normal"
-              value="400"
-              c:identifier="PANGO_WEIGHT_NORMAL"
-              glib:nick="normal">
+      <member name="normal" value="400" c:identifier="PANGO_WEIGHT_NORMAL" glib:nick="normal">
         <doc xml:space="preserve">the default weight (= 400)</doc>
       </member>
-      <member name="medium"
-              value="500"
-              c:identifier="PANGO_WEIGHT_MEDIUM"
-              glib:nick="medium">
+      <member name="medium" value="500" c:identifier="PANGO_WEIGHT_MEDIUM" glib:nick="medium">
         <doc xml:space="preserve">the normal weight (= 500; Since: 1.24)</doc>
       </member>
-      <member name="semibold"
-              value="600"
-              c:identifier="PANGO_WEIGHT_SEMIBOLD"
-              glib:nick="semibold">
+      <member name="semibold" value="600" c:identifier="PANGO_WEIGHT_SEMIBOLD" glib:nick="semibold">
         <doc xml:space="preserve">the semibold weight (= 600)</doc>
       </member>
-      <member name="bold"
-              value="700"
-              c:identifier="PANGO_WEIGHT_BOLD"
-              glib:nick="bold">
+      <member name="bold" value="700" c:identifier="PANGO_WEIGHT_BOLD" glib:nick="bold">
         <doc xml:space="preserve">the bold weight (= 700)</doc>
       </member>
-      <member name="ultrabold"
-              value="800"
-              c:identifier="PANGO_WEIGHT_ULTRABOLD"
-              glib:nick="ultrabold">
+      <member name="ultrabold" value="800" c:identifier="PANGO_WEIGHT_ULTRABOLD" glib:nick="ultrabold">
         <doc xml:space="preserve">the ultrabold weight (= 800)</doc>
       </member>
-      <member name="heavy"
-              value="900"
-              c:identifier="PANGO_WEIGHT_HEAVY"
-              glib:nick="heavy">
+      <member name="heavy" value="900" c:identifier="PANGO_WEIGHT_HEAVY" glib:nick="heavy">
         <doc xml:space="preserve">the heavy weight (= 900)</doc>
       </member>
-      <member name="ultraheavy"
-              value="1000"
-              c:identifier="PANGO_WEIGHT_ULTRAHEAVY"
-              glib:nick="ultraheavy">
+      <member name="ultraheavy" value="1000" c:identifier="PANGO_WEIGHT_ULTRAHEAVY" glib:nick="ultraheavy">
         <doc xml:space="preserve">the ultraheavy weight (= 1000; Since: 1.24)</doc>
       </member>
     </enumeration>
-    <enumeration name="WrapMode"
-                 glib:type-name="PangoWrapMode"
-                 glib:get-type="pango_wrap_mode_get_type"
-                 c:type="PangoWrapMode">
+    <enumeration name="WrapMode" glib:type-name="PangoWrapMode" glib:get-type="pango_wrap_mode_get_type" c:type="PangoWrapMode">
       <doc xml:space="preserve">A #PangoWrapMode describes how to wrap the lines of a #PangoLayout to the desired width.</doc>
-      <member name="word"
-              value="0"
-              c:identifier="PANGO_WRAP_WORD"
-              glib:nick="word">
+      <member name="word" value="0" c:identifier="PANGO_WRAP_WORD" glib:nick="word">
         <doc xml:space="preserve">wrap lines at word boundaries.</doc>
       </member>
-      <member name="char"
-              value="1"
-              c:identifier="PANGO_WRAP_CHAR"
-              glib:nick="char">
+      <member name="char" value="1" c:identifier="PANGO_WRAP_CHAR" glib:nick="char">
         <doc xml:space="preserve">wrap lines at character boundaries.</doc>
       </member>
-      <member name="word_char"
-              value="2"
-              c:identifier="PANGO_WRAP_WORD_CHAR"
-              glib:nick="word-char">
+      <member name="word_char" value="2" c:identifier="PANGO_WRAP_WORD_CHAR" glib:nick="word-char">
         <doc xml:space="preserve">wrap lines at word boundaries, but fall back to character boundaries if there is not
 enough space for a full word.</doc>
       </member>
     </enumeration>
-    <function name="attr_background_alpha_new"
-              c:identifier="pango_attr_background_alpha_new"
-              version="1.38"
-              introspectable="0">
+    <function name="attr_background_alpha_new" c:identifier="pango_attr_background_alpha_new" version="1.38" introspectable="0">
       <doc xml:space="preserve">Create a new background alpha attribute.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the new allocated #PangoAttribute,
@@ -12004,9 +10061,7 @@ enough space for a full word.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_background_new"
-              c:identifier="pango_attr_background_new"
-              introspectable="0">
+    <function name="attr_background_new" c:identifier="pango_attr_background_new" introspectable="0">
       <doc xml:space="preserve">Create a new background color attribute.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -12028,10 +10083,7 @@ enough space for a full word.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_fallback_new"
-              c:identifier="pango_attr_fallback_new"
-              version="1.4"
-              introspectable="0">
+    <function name="attr_fallback_new" c:identifier="pango_attr_fallback_new" version="1.4" introspectable="0">
       <doc xml:space="preserve">Create a new font fallback attribute.
 
 If fallback is disabled, characters will only be used from the
@@ -12051,9 +10103,7 @@ text.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_family_new"
-              c:identifier="pango_attr_family_new"
-              introspectable="0">
+    <function name="attr_family_new" c:identifier="pango_attr_family_new" introspectable="0">
       <doc xml:space="preserve">Create a new font family attribute.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -12067,10 +10117,7 @@ text.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_foreground_alpha_new"
-              c:identifier="pango_attr_foreground_alpha_new"
-              version="1.38"
-              introspectable="0">
+    <function name="attr_foreground_alpha_new" c:identifier="pango_attr_foreground_alpha_new" version="1.38" introspectable="0">
       <doc xml:space="preserve">Create a new foreground alpha attribute.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the new allocated #PangoAttribute,
@@ -12084,9 +10131,7 @@ text.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_foreground_new"
-              c:identifier="pango_attr_foreground_new"
-              introspectable="0">
+    <function name="attr_foreground_new" c:identifier="pango_attr_foreground_new" introspectable="0">
       <doc xml:space="preserve">Create a new foreground color attribute.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -12108,10 +10153,7 @@ text.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_gravity_hint_new"
-              c:identifier="pango_attr_gravity_hint_new"
-              version="1.16"
-              introspectable="0">
+    <function name="attr_gravity_hint_new" c:identifier="pango_attr_gravity_hint_new" version="1.16" introspectable="0">
       <doc xml:space="preserve">Create a new gravity hint attribute.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -12125,10 +10167,7 @@ text.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_gravity_new"
-              c:identifier="pango_attr_gravity_new"
-              version="1.16"
-              introspectable="0">
+    <function name="attr_gravity_new" c:identifier="pango_attr_gravity_new" version="1.16" introspectable="0">
       <doc xml:space="preserve">Create a new gravity attribute.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -12142,10 +10181,7 @@ text.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_letter_spacing_new"
-              c:identifier="pango_attr_letter_spacing_new"
-              version="1.6"
-              introspectable="0">
+    <function name="attr_letter_spacing_new" c:identifier="pango_attr_letter_spacing_new" version="1.6" introspectable="0">
       <doc xml:space="preserve">Create a new letter-spacing attribute.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -12160,9 +10196,7 @@ text.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_rise_new"
-              c:identifier="pango_attr_rise_new"
-              introspectable="0">
+    <function name="attr_rise_new" c:identifier="pango_attr_rise_new" introspectable="0">
       <doc xml:space="preserve">Create a new baseline displacement attribute.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -12177,9 +10211,7 @@ text.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_scale_new"
-              c:identifier="pango_attr_scale_new"
-              introspectable="0">
+    <function name="attr_scale_new" c:identifier="pango_attr_scale_new" introspectable="0">
       <doc xml:space="preserve">Create a new font size scale attribute. The base font for the
 affected text will have its size multiplied by @scale_factor.</doc>
       <return-value transfer-ownership="full">
@@ -12194,9 +10226,7 @@ affected text will have its size multiplied by @scale_factor.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_stretch_new"
-              c:identifier="pango_attr_stretch_new"
-              introspectable="0">
+    <function name="attr_stretch_new" c:identifier="pango_attr_stretch_new" introspectable="0">
       <doc xml:space="preserve">Create a new font stretch attribute</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -12210,10 +10240,7 @@ affected text will have its size multiplied by @scale_factor.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_strikethrough_color_new"
-              c:identifier="pango_attr_strikethrough_color_new"
-              version="1.8"
-              introspectable="0">
+    <function name="attr_strikethrough_color_new" c:identifier="pango_attr_strikethrough_color_new" version="1.8" introspectable="0">
       <doc xml:space="preserve">Create a new strikethrough color attribute. This attribute
 modifies the color of strikethrough lines. If not set, strikethrough
 lines will use the foreground color.</doc>
@@ -12237,9 +10264,7 @@ lines will use the foreground color.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_strikethrough_new"
-              c:identifier="pango_attr_strikethrough_new"
-              introspectable="0">
+    <function name="attr_strikethrough_new" c:identifier="pango_attr_strikethrough_new" introspectable="0">
       <doc xml:space="preserve">Create a new strike-through attribute.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -12253,9 +10278,7 @@ lines will use the foreground color.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_style_new"
-              c:identifier="pango_attr_style_new"
-              introspectable="0">
+    <function name="attr_style_new" c:identifier="pango_attr_style_new" introspectable="0">
       <doc xml:space="preserve">Create a new font slant style attribute.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -12269,10 +10292,7 @@ lines will use the foreground color.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_type_get_name"
-              c:identifier="pango_attr_type_get_name"
-              moved-to="AttrType.get_name"
-              version="1.22">
+    <function name="attr_type_get_name" c:identifier="pango_attr_type_get_name" moved-to="AttrType.get_name" version="1.22">
       <doc xml:space="preserve">Fetches the attribute type name passed in when registering the type using
 pango_attr_type_register().
 
@@ -12290,9 +10310,7 @@ that means) that should not be modified or freed.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_type_register"
-              c:identifier="pango_attr_type_register"
-              moved-to="AttrType.register">
+    <function name="attr_type_register" c:identifier="pango_attr_type_register" moved-to="AttrType.register">
       <doc xml:space="preserve">Allocate a new attribute type ID.  The attribute type name can be accessed
 later by using pango_attr_type_get_name().</doc>
       <return-value transfer-ownership="none">
@@ -12306,10 +10324,7 @@ later by using pango_attr_type_get_name().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_underline_color_new"
-              c:identifier="pango_attr_underline_color_new"
-              version="1.8"
-              introspectable="0">
+    <function name="attr_underline_color_new" c:identifier="pango_attr_underline_color_new" version="1.8" introspectable="0">
       <doc xml:space="preserve">Create a new underline color attribute. This attribute
 modifies the color of underlines. If not set, underlines
 will use the foreground color.</doc>
@@ -12333,9 +10348,7 @@ will use the foreground color.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_underline_new"
-              c:identifier="pango_attr_underline_new"
-              introspectable="0">
+    <function name="attr_underline_new" c:identifier="pango_attr_underline_new" introspectable="0">
       <doc xml:space="preserve">Create a new underline-style attribute.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -12349,9 +10362,7 @@ will use the foreground color.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_variant_new"
-              c:identifier="pango_attr_variant_new"
-              introspectable="0">
+    <function name="attr_variant_new" c:identifier="pango_attr_variant_new" introspectable="0">
       <doc xml:space="preserve">Create a new font variant attribute (normal or small caps)</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -12365,9 +10376,7 @@ will use the foreground color.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="attr_weight_new"
-              c:identifier="pango_attr_weight_new"
-              introspectable="0">
+    <function name="attr_weight_new" c:identifier="pango_attr_weight_new" introspectable="0">
       <doc xml:space="preserve">Create a new font weight attribute.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the newly allocated #PangoAttribute,
@@ -12381,10 +10390,7 @@ will use the foreground color.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="bidi_type_for_unichar"
-              c:identifier="pango_bidi_type_for_unichar"
-              moved-to="BidiType.for_unichar"
-              version="1.22">
+    <function name="bidi_type_for_unichar" c:identifier="pango_bidi_type_for_unichar" moved-to="BidiType.for_unichar" version="1.22">
       <doc xml:space="preserve">Determines the normative bidirectional character type of a
 character, as specified in the Unicode Character Database.
 
@@ -12435,10 +10441,7 @@ purposes you may want to use pango_get_log_attrs().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="config_key_get"
-              c:identifier="pango_config_key_get"
-              deprecated="1"
-              deprecated-version="1.38">
+    <function name="config_key_get" c:identifier="pango_config_key_get" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Do not use.  Does not do anything.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">%NULL</doc>
@@ -12451,10 +10454,7 @@ purposes you may want to use pango_get_log_attrs().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="config_key_get_system"
-              c:identifier="pango_config_key_get_system"
-              deprecated="1"
-              deprecated-version="1.38">
+    <function name="config_key_get_system" c:identifier="pango_config_key_get_system" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Do not use.  Does not do anything.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">%NULL</doc>
@@ -12487,10 +10487,7 @@ simply use pango_get_log_attrs().</doc>
           <doc xml:space="preserve">length of text in bytes (may be -1 if @text is nul-terminated)</doc>
           <type name="gint" c:type="int"/>
         </parameter>
-        <parameter name="analysis"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="analysis" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">a #PangoAnalysis for the @text</doc>
           <type name="Analysis" c:type="PangoAnalysis*"/>
         </parameter>
@@ -12504,9 +10501,7 @@ simply use pango_get_log_attrs().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="extents_to_pixels"
-              c:identifier="pango_extents_to_pixels"
-              version="1.16">
+    <function name="extents_to_pixels" c:identifier="pango_extents_to_pixels" version="1.16">
       <doc xml:space="preserve">Converts extents from Pango units to device units, dividing by the
 %PANGO_SCALE factor and performing rounding.
 
@@ -12526,25 +10521,17 @@ as @nearest.</doc>
         <type name="none" c:type="void"/>
       </return-value>
       <parameters>
-        <parameter name="inclusive"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="inclusive" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">rectangle to round to pixels inclusively, or %NULL.</doc>
           <type name="Rectangle" c:type="PangoRectangle*"/>
         </parameter>
-        <parameter name="nearest"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="nearest" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">rectangle to round to nearest pixels, or %NULL.</doc>
           <type name="Rectangle" c:type="PangoRectangle*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="find_base_dir"
-              c:identifier="pango_find_base_dir"
-              version="1.4">
+    <function name="find_base_dir" c:identifier="pango_find_base_dir" version="1.4">
       <doc xml:space="preserve">Searches a string the first character that has a strong
 direction, according to the Unicode bidirectional algorithm.</doc>
       <return-value transfer-ownership="none">
@@ -12563,11 +10550,7 @@ If no such character is found, then %PANGO_DIRECTION_NEUTRAL is returned.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="find_map"
-              c:identifier="pango_find_map"
-              introspectable="0"
-              deprecated="1"
-              deprecated-version="1.38">
+    <function name="find_map" c:identifier="pango_find_map" introspectable="0" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Do not use.  Does not do anything.</doc>
       <return-value>
         <doc xml:space="preserve">%NULL.</doc>
@@ -12588,8 +10571,7 @@ If no such character is found, then %PANGO_DIRECTION_NEUTRAL is returned.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="find_paragraph_boundary"
-              c:identifier="pango_find_paragraph_boundary">
+    <function name="find_paragraph_boundary" c:identifier="pango_find_paragraph_boundary">
       <doc xml:space="preserve">Locates a paragraph boundary in @text. A boundary is caused by
 delimiter characters, such as a newline, carriage return, carriage
 return-newline pair, or Unicode paragraph separator character.  The
@@ -12612,27 +10594,19 @@ off the end).</doc>
           <doc xml:space="preserve">length of @text in bytes, or -1 if nul-terminated</doc>
           <type name="gint" c:type="gint"/>
         </parameter>
-        <parameter name="paragraph_delimiter_index"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="paragraph_delimiter_index" direction="out" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">return location for index of
   delimiter</doc>
           <type name="gint" c:type="gint*"/>
         </parameter>
-        <parameter name="next_paragraph_start"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="next_paragraph_start" direction="out" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">return location for start of next
   paragraph</doc>
           <type name="gint" c:type="gint*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="font_description_from_string"
-              c:identifier="pango_font_description_from_string"
-              moved-to="FontDescription.from_string">
+    <function name="font_description_from_string" c:identifier="pango_font_description_from_string" moved-to="FontDescription.from_string">
       <doc xml:space="preserve">Creates a new font description from a string representation in the
 form "[FAMILY-LIST] [STYLE-OPTIONS] [SIZE]", where FAMILY-LIST is a
 comma separated list of families optionally terminated by a comma,
@@ -12656,10 +10630,7 @@ description will be set to 0.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="get_lib_subdirectory"
-              c:identifier="pango_get_lib_subdirectory"
-              deprecated="1"
-              deprecated-version="1.38">
+    <function name="get_lib_subdirectory" c:identifier="pango_get_lib_subdirectory" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Returns the name of the "pango" subdirectory of LIBDIR
 (which is set at compile time).</doc>
       <return-value transfer-ownership="none">
@@ -12732,10 +10703,7 @@ filled in, %FALSE otherwise</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="get_sysconf_subdirectory"
-              c:identifier="pango_get_sysconf_subdirectory"
-              deprecated="1"
-              deprecated-version="1.38">
+    <function name="get_sysconf_subdirectory" c:identifier="pango_get_sysconf_subdirectory" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Returns the name of the "pango" subdirectory of SYSCONFDIR
 (which is set at compile time).</doc>
       <return-value transfer-ownership="none">
@@ -12744,10 +10712,7 @@ not be freed.</doc>
         <type name="utf8" c:type="const char*"/>
       </return-value>
     </function>
-    <function name="gravity_get_for_matrix"
-              c:identifier="pango_gravity_get_for_matrix"
-              moved-to="Gravity.get_for_matrix"
-              version="1.16">
+    <function name="gravity_get_for_matrix" c:identifier="pango_gravity_get_for_matrix" moved-to="Gravity.get_for_matrix" version="1.16">
       <doc xml:space="preserve">Finds the gravity that best matches the rotation component
 in a #PangoMatrix.</doc>
       <return-value transfer-ownership="none">
@@ -12756,19 +10721,13 @@ in a #PangoMatrix.</doc>
         <type name="Gravity" c:type="PangoGravity"/>
       </return-value>
       <parameters>
-        <parameter name="matrix"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="matrix" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">a #PangoMatrix</doc>
           <type name="Matrix" c:type="const PangoMatrix*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="gravity_get_for_script"
-              c:identifier="pango_gravity_get_for_script"
-              moved-to="Gravity.get_for_script"
-              version="1.16">
+    <function name="gravity_get_for_script" c:identifier="pango_gravity_get_for_script" moved-to="Gravity.get_for_script" version="1.16">
       <doc xml:space="preserve">Based on the script, base gravity, and hint, returns actual gravity
 to use in laying out a single #PangoItem.
 
@@ -12795,10 +10754,7 @@ with @script.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="gravity_get_for_script_and_width"
-              c:identifier="pango_gravity_get_for_script_and_width"
-              moved-to="Gravity.get_for_script_and_width"
-              version="1.26">
+    <function name="gravity_get_for_script_and_width" c:identifier="pango_gravity_get_for_script_and_width" moved-to="Gravity.get_for_script_and_width" version="1.26">
       <doc xml:space="preserve">Based on the script, East Asian width, base gravity, and hint,
 returns actual gravity to use in laying out a single character
 or #PangoItem.
@@ -12836,10 +10792,7 @@ with @script and @wide.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="gravity_to_rotation"
-              c:identifier="pango_gravity_to_rotation"
-              moved-to="Gravity.to_rotation"
-              version="1.16">
+    <function name="gravity_to_rotation" c:identifier="pango_gravity_to_rotation" moved-to="Gravity.to_rotation" version="1.16">
       <doc xml:space="preserve">Converts a #PangoGravity value to its natural rotation in radians.
 @gravity should not be %PANGO_GRAVITY_AUTO.
 
@@ -12857,9 +10810,7 @@ you should multiply it by (180. / G_PI).</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="is_zero_width"
-              c:identifier="pango_is_zero_width"
-              version="1.10">
+    <function name="is_zero_width" c:identifier="pango_is_zero_width" version="1.10">
       <doc xml:space="preserve">Checks @ch to see if it is a character that should not be
 normally rendered on the screen.  This includes all Unicode characters
 with "ZERO WIDTH" in their name, as well as &lt;firstterm&gt;bidi&lt;/firstterm&gt; formatting characters, and
@@ -12920,18 +10871,13 @@ the range covering the position just after @start_index + @length.
           <doc xml:space="preserve">the set of attributes that apply to @text.</doc>
           <type name="AttrList" c:type="PangoAttrList*"/>
         </parameter>
-        <parameter name="cached_iter"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="cached_iter" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Cached attribute iterator, or %NULL</doc>
           <type name="AttrIterator" c:type="PangoAttrIterator*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="itemize_with_base_dir"
-              c:identifier="pango_itemize_with_base_dir"
-              version="1.4">
+    <function name="itemize_with_base_dir" c:identifier="pango_itemize_with_base_dir" version="1.4">
       <doc xml:space="preserve">Like pango_itemize(), but the base direction to use when
 computing bidirectional levels (see pango_context_set_base_dir ()),
 is specified explicitly rather than gotten from the #PangoContext.</doc>
@@ -12971,18 +10917,13 @@ is specified explicitly rather than gotten from the #PangoContext.</doc>
           <doc xml:space="preserve">the set of attributes that apply to @text.</doc>
           <type name="AttrList" c:type="PangoAttrList*"/>
         </parameter>
-        <parameter name="cached_iter"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="cached_iter" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">Cached attribute iterator, or %NULL</doc>
           <type name="AttrIterator" c:type="PangoAttrIterator*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="language_from_string"
-              c:identifier="pango_language_from_string"
-              moved-to="Language.from_string">
+    <function name="language_from_string" c:identifier="pango_language_from_string" moved-to="Language.from_string">
       <doc xml:space="preserve">Take a RFC-3066 format language tag as a string and convert it to a
 #PangoLanguage pointer that can be efficiently copied (copy the
 pointer) and compared with other language tags (compare the
@@ -13002,19 +10943,13 @@ the current locale of the process.</doc>
         <type name="Language" c:type="PangoLanguage*"/>
       </return-value>
       <parameters>
-        <parameter name="language"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="language" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">a string representing a language tag, or %NULL</doc>
           <type name="utf8" c:type="const char*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="language_get_default"
-              c:identifier="pango_language_get_default"
-              moved-to="Language.get_default"
-              version="1.16">
+    <function name="language_get_default" c:identifier="pango_language_get_default" moved-to="Language.get_default" version="1.16">
       <doc xml:space="preserve">Returns the #PangoLanguage for the current locale of the process.
 Note that this can change over the life of an application.
 
@@ -13047,9 +10982,7 @@ See &lt;literal&gt;man setlocale&lt;/literal&gt; for more details.</doc>
         <type name="Language" c:type="PangoLanguage*"/>
       </return-value>
     </function>
-    <function name="log2vis_get_embedding_levels"
-              c:identifier="pango_log2vis_get_embedding_levels"
-              version="1.4">
+    <function name="log2vis_get_embedding_levels" c:identifier="pango_log2vis_get_embedding_levels" version="1.4">
       <doc xml:space="preserve">This will return the bidirectional embedding levels of the input paragraph
 as defined by the Unicode Bidirectional Algorithm available at:
 
@@ -13078,10 +11011,7 @@ characters in the text will determine the final resolved direction.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="lookup_aliases"
-              c:identifier="pango_lookup_aliases"
-              deprecated="1"
-              deprecated-version="1.32">
+    <function name="lookup_aliases" c:identifier="pango_lookup_aliases" deprecated="1" deprecated-version="1.32">
       <doc xml:space="preserve">Look up all user defined aliases for the alias @fontname.
 The resulting font family names will be stored in @families,
 and the number of families in @n_families.</doc>
@@ -13094,29 +11024,20 @@ and the number of families in @n_families.</doc>
           <doc xml:space="preserve">an ascii string</doc>
           <type name="utf8" c:type="const char*"/>
         </parameter>
-        <parameter name="families"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="families" direction="out" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">will be set to an array of font family names.
    this array is owned by pango and should not be freed.</doc>
           <array length="2" zero-terminated="0" c:type="char***">
             <type name="utf8" c:type="char**"/>
           </array>
         </parameter>
-        <parameter name="n_families"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="n_families" direction="out" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">will be set to the length of the @families array.</doc>
           <type name="gint" c:type="int*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="markup_parser_finish"
-              c:identifier="pango_markup_parser_finish"
-              version="1.31.0"
-              throws="1">
+    <function name="markup_parser_finish" c:identifier="pango_markup_parser_finish" version="1.31.0" throws="1">
       <doc xml:space="preserve">After feeding a pango markup parser some data with g_markup_parse_context_parse(),
 use this function to get the list of pango attributes and text out of the
 markup. This function will not free @context, use g_markup_parse_context_free()
@@ -13130,38 +11051,21 @@ to do so.</doc>
           <doc xml:space="preserve">A valid parse context that was returned from pango_markup_parser_new()</doc>
           <type name="GLib.MarkupParseContext" c:type="GMarkupParseContext*"/>
         </parameter>
-        <parameter name="attr_list"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full"
-                   optional="1"
-                   allow-none="1">
+        <parameter name="attr_list" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
           <doc xml:space="preserve">address of return location for a #PangoAttrList, or %NULL</doc>
           <type name="AttrList" c:type="PangoAttrList**"/>
         </parameter>
-        <parameter name="text"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full"
-                   optional="1"
-                   allow-none="1">
+        <parameter name="text" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
           <doc xml:space="preserve">address of return location for text with tags stripped, or %NULL</doc>
           <type name="utf8" c:type="char**"/>
         </parameter>
-        <parameter name="accel_char"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full"
-                   optional="1"
-                   allow-none="1">
+        <parameter name="accel_char" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
           <doc xml:space="preserve">address of return location for accelerator char, or %NULL</doc>
           <type name="gunichar" c:type="gunichar*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="markup_parser_new"
-              c:identifier="pango_markup_parser_new"
-              version="1.31.0">
+    <function name="markup_parser_new" c:identifier="pango_markup_parser_new" version="1.31.0">
       <doc xml:space="preserve">Parses marked-up text (see
 &lt;link linkend="PangoMarkupFormat"&gt;markup format&lt;/link&gt;) to create
 a plain-text string and an attribute list.
@@ -13194,10 +11098,7 @@ destroyed with g_markup_parse_context_free().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="module_register"
-              c:identifier="pango_module_register"
-              deprecated="1"
-              deprecated-version="1.38">
+    <function name="module_register" c:identifier="pango_module_register" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Do not use.  Does not do anything.</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
@@ -13209,11 +11110,7 @@ destroyed with g_markup_parse_context_free().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="parse_enum"
-              c:identifier="pango_parse_enum"
-              version="1.16"
-              deprecated="1"
-              deprecated-version="1.38">
+    <function name="parse_enum" c:identifier="pango_parse_enum" version="1.16" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Parses an enum type and stores the result in @value.
 
 If @str does not match the nick name of any of the possible values for the
@@ -13232,19 +11129,11 @@ returned string should be freed using g_free().</doc>
           <doc xml:space="preserve">enum type to parse, eg. %PANGO_TYPE_ELLIPSIZE_MODE.</doc>
           <type name="GType" c:type="GType"/>
         </parameter>
-        <parameter name="str"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="str" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">string to parse.  May be %NULL.</doc>
           <type name="utf8" c:type="const char*"/>
         </parameter>
-        <parameter name="value"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full"
-                   optional="1"
-                   allow-none="1">
+        <parameter name="value" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
           <doc xml:space="preserve">integer to store the result in, or %NULL.</doc>
           <type name="gint" c:type="int*"/>
         </parameter>
@@ -13252,12 +11141,7 @@ returned string should be freed using g_free().</doc>
           <doc xml:space="preserve">if %TRUE, issue a g_warning() on bad input.</doc>
           <type name="gboolean" c:type="gboolean"/>
         </parameter>
-        <parameter name="possible_values"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full"
-                   optional="1"
-                   allow-none="1">
+        <parameter name="possible_values" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
           <doc xml:space="preserve">place to store list of possible values on failure, or %NULL.</doc>
           <type name="utf8" c:type="char**"/>
         </parameter>
@@ -13297,30 +11181,15 @@ for @error.</doc>
           <doc xml:space="preserve">character that precedes an accelerator, or 0 for none</doc>
           <type name="gunichar" c:type="gunichar"/>
         </parameter>
-        <parameter name="attr_list"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full"
-                   optional="1"
-                   allow-none="1">
+        <parameter name="attr_list" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
           <doc xml:space="preserve">address of return location for a #PangoAttrList, or %NULL</doc>
           <type name="AttrList" c:type="PangoAttrList**"/>
         </parameter>
-        <parameter name="text"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full"
-                   optional="1"
-                   allow-none="1">
+        <parameter name="text" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
           <doc xml:space="preserve">address of return location for text with tags stripped, or %NULL</doc>
           <type name="utf8" c:type="char**"/>
         </parameter>
-        <parameter name="accel_char"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full"
-                   optional="1"
-                   allow-none="1">
+        <parameter name="accel_char" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
           <doc xml:space="preserve">address of return location for accelerator char, or %NULL</doc>
           <type name="gunichar" c:type="gunichar*"/>
         </parameter>
@@ -13341,10 +11210,7 @@ ignored and the '_' characters may be omitted.</doc>
           <doc xml:space="preserve">a string to parse.</doc>
           <type name="utf8" c:type="const char*"/>
         </parameter>
-        <parameter name="stretch"
-                   direction="out"
-                   caller-allocates="1"
-                   transfer-ownership="none">
+        <parameter name="stretch" direction="out" caller-allocates="1" transfer-ownership="none">
           <doc xml:space="preserve">a #PangoStretch to store the
   result in.</doc>
           <type name="Stretch" c:type="PangoStretch*"/>
@@ -13368,10 +11234,7 @@ ignored.</doc>
           <doc xml:space="preserve">a string to parse.</doc>
           <type name="utf8" c:type="const char*"/>
         </parameter>
-        <parameter name="style"
-                   direction="out"
-                   caller-allocates="1"
-                   transfer-ownership="none">
+        <parameter name="style" direction="out" caller-allocates="1" transfer-ownership="none">
           <doc xml:space="preserve">a #PangoStyle to store the result
   in.</doc>
           <type name="Style" c:type="PangoStyle*"/>
@@ -13395,10 +11258,7 @@ ignored.</doc>
           <doc xml:space="preserve">a string to parse.</doc>
           <type name="utf8" c:type="const char*"/>
         </parameter>
-        <parameter name="variant"
-                   direction="out"
-                   caller-allocates="1"
-                   transfer-ownership="none">
+        <parameter name="variant" direction="out" caller-allocates="1" transfer-ownership="none">
           <doc xml:space="preserve">a #PangoVariant to store the
   result in.</doc>
           <type name="Variant" c:type="PangoVariant*"/>
@@ -13422,10 +11282,7 @@ and integers. Case variations are ignored.</doc>
           <doc xml:space="preserve">a string to parse.</doc>
           <type name="utf8" c:type="const char*"/>
         </parameter>
-        <parameter name="weight"
-                   direction="out"
-                   caller-allocates="1"
-                   transfer-ownership="none">
+        <parameter name="weight" direction="out" caller-allocates="1" transfer-ownership="none">
           <doc xml:space="preserve">a #PangoWeight to store the result
   in.</doc>
           <type name="Weight" c:type="PangoWeight*"/>
@@ -13436,9 +11293,7 @@ and integers. Case variations are ignored.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="quantize_line_geometry"
-              c:identifier="pango_quantize_line_geometry"
-              version="1.12">
+    <function name="quantize_line_geometry" c:identifier="pango_quantize_line_geometry" version="1.12">
       <doc xml:space="preserve">Quantizes the thickness and position of a line, typically an
 underline or strikethrough, to whole device pixels, that is integer
 multiples of %PANGO_SCALE. The purpose of this function is to avoid
@@ -13451,26 +11306,17 @@ of rounding.</doc>
         <type name="none" c:type="void"/>
       </return-value>
       <parameters>
-        <parameter name="thickness"
-                   direction="inout"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="thickness" direction="inout" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">pointer to the thickness of a line, in Pango units</doc>
           <type name="gint" c:type="int*"/>
         </parameter>
-        <parameter name="position"
-                   direction="inout"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="position" direction="inout" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">corresponding position</doc>
           <type name="gint" c:type="int*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="read_line"
-              c:identifier="pango_read_line"
-              deprecated="1"
-              deprecated-version="1.38">
+    <function name="read_line" c:identifier="pango_read_line" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Reads an entire line from a file into a buffer. Lines may
 be delimited with '\n', '\r', '\n\r', or '\r\n'. The delimiter
 is not written into the buffer. Text after a '#' character is treated as
@@ -13485,17 +11331,11 @@ unmodified.</doc>
         <type name="gint" c:type="gint"/>
       </return-value>
       <parameters>
-        <parameter name="stream"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="stream" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">a stdio stream</doc>
           <type name="gpointer" c:type="FILE*"/>
         </parameter>
-        <parameter name="str"
-                   direction="out"
-                   caller-allocates="1"
-                   transfer-ownership="none">
+        <parameter name="str" direction="out" caller-allocates="1" transfer-ownership="none">
           <doc xml:space="preserve">#GString buffer into which to write the result</doc>
           <type name="GLib.String" c:type="GString*"/>
         </parameter>
@@ -13525,10 +11365,7 @@ The original list is unmodified.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="scan_int"
-              c:identifier="pango_scan_int"
-              deprecated="1"
-              deprecated-version="1.38">
+    <function name="scan_int" c:identifier="pango_scan_int" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Scans an integer.
 Leading white space is skipped.</doc>
       <return-value transfer-ownership="none">
@@ -13536,26 +11373,17 @@ Leading white space is skipped.</doc>
         <type name="gboolean" c:type="gboolean"/>
       </return-value>
       <parameters>
-        <parameter name="pos"
-                   direction="inout"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="pos" direction="inout" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">in/out string position</doc>
           <type name="utf8" c:type="const char**"/>
         </parameter>
-        <parameter name="out"
-                   direction="out"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="out" direction="out" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">an int into which to write the result</doc>
           <type name="gint" c:type="int*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="scan_string"
-              c:identifier="pango_scan_string"
-              deprecated="1"
-              deprecated-version="1.38">
+    <function name="scan_string" c:identifier="pango_scan_string" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Scans a string into a #GString buffer. The string may either
 be a sequence of non-white-space characters, or a quoted
 string with '"'. Instead a quoted string, '\"' represents
@@ -13565,26 +11393,17 @@ a literal quote. Leading white space outside of quotes is skipped.</doc>
         <type name="gboolean" c:type="gboolean"/>
       </return-value>
       <parameters>
-        <parameter name="pos"
-                   direction="inout"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="pos" direction="inout" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">in/out string position</doc>
           <type name="utf8" c:type="const char**"/>
         </parameter>
-        <parameter name="out"
-                   direction="out"
-                   caller-allocates="1"
-                   transfer-ownership="none">
+        <parameter name="out" direction="out" caller-allocates="1" transfer-ownership="none">
           <doc xml:space="preserve">a #GString into which to write the result</doc>
           <type name="GLib.String" c:type="GString*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="scan_word"
-              c:identifier="pango_scan_word"
-              deprecated="1"
-              deprecated-version="1.38">
+    <function name="scan_word" c:identifier="pango_scan_word" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Scans a word into a #GString buffer. A word consists
 of [A-Za-z_] followed by zero or more [A-Za-z_0-9]
 Leading white space is skipped.</doc>
@@ -13593,26 +11412,17 @@ Leading white space is skipped.</doc>
         <type name="gboolean" c:type="gboolean"/>
       </return-value>
       <parameters>
-        <parameter name="pos"
-                   direction="inout"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="pos" direction="inout" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">in/out string position</doc>
           <type name="utf8" c:type="const char**"/>
         </parameter>
-        <parameter name="out"
-                   direction="out"
-                   caller-allocates="1"
-                   transfer-ownership="none">
+        <parameter name="out" direction="out" caller-allocates="1" transfer-ownership="none">
           <doc xml:space="preserve">a #GString into which to write the result</doc>
           <type name="GLib.String" c:type="GString*"/>
         </parameter>
       </parameters>
     </function>
-    <function name="script_for_unichar"
-              c:identifier="pango_script_for_unichar"
-              moved-to="Script.for_unichar"
-              version="1.4">
+    <function name="script_for_unichar" c:identifier="pango_script_for_unichar" moved-to="Script.for_unichar" version="1.4">
       <doc xml:space="preserve">Looks up the #PangoScript for a particular character (as defined by
 Unicode Standard Annex \#24). No check is made for @ch being a
 valid Unicode character; if you pass in invalid character, the
@@ -13631,10 +11441,7 @@ g_unichar_get_script().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="script_get_sample_language"
-              c:identifier="pango_script_get_sample_language"
-              moved-to="Script.get_sample_language"
-              version="1.4">
+    <function name="script_get_sample_language" c:identifier="pango_script_get_sample_language" moved-to="Script.get_sample_language" version="1.4">
       <doc xml:space="preserve">Given a script, finds a language tag that is reasonably
 representative of that script. This will usually be the
 most widely spoken or used language written in that script:
@@ -13731,10 +11538,7 @@ text of which @item_text is part of, provide the broader text as
           <doc xml:space="preserve">the length (in bytes) of @item_text. -1 means nul-terminated text.</doc>
           <type name="gint" c:type="gint"/>
         </parameter>
-        <parameter name="paragraph_text"
-                   transfer-ownership="none"
-                   nullable="1"
-                   allow-none="1">
+        <parameter name="paragraph_text" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">text of the paragraph (see details).  May be %NULL.</doc>
           <type name="utf8" c:type="const gchar*"/>
         </parameter>
@@ -13752,10 +11556,7 @@ text of which @item_text is part of, provide the broader text as
         </parameter>
       </parameters>
     </function>
-    <function name="skip_space"
-              c:identifier="pango_skip_space"
-              deprecated="1"
-              deprecated-version="1.38">
+    <function name="skip_space" c:identifier="pango_skip_space" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Skips 0 or more characters of white space.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">%FALSE if skipping the white space leaves
@@ -13763,19 +11564,13 @@ the position at a '\0' character.</doc>
         <type name="gboolean" c:type="gboolean"/>
       </return-value>
       <parameters>
-        <parameter name="pos"
-                   direction="inout"
-                   caller-allocates="0"
-                   transfer-ownership="full">
+        <parameter name="pos" direction="inout" caller-allocates="0" transfer-ownership="full">
           <doc xml:space="preserve">in/out string position</doc>
           <type name="utf8" c:type="const char**"/>
         </parameter>
       </parameters>
     </function>
-    <function name="split_file_list"
-              c:identifier="pango_split_file_list"
-              deprecated="1"
-              deprecated-version="1.38">
+    <function name="split_file_list" c:identifier="pango_split_file_list" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Splits a %G_SEARCHPATH_SEPARATOR-separated list of files, stripping
 white space and substituting ~/ with $HOME/.</doc>
       <return-value transfer-ownership="full">
@@ -13792,10 +11587,7 @@ strings to be freed with g_strfreev()</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="trim_string"
-              c:identifier="pango_trim_string"
-              deprecated="1"
-              deprecated-version="1.38">
+    <function name="trim_string" c:identifier="pango_trim_string" deprecated="1" deprecated-version="1.38">
       <doc xml:space="preserve">Trims leading and trailing whitespace from a string.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">A newly-allocated string that must be freed with g_free()</doc>
@@ -13828,9 +11620,7 @@ pango_bidi_type_for_unichar() can be used instead.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="units_from_double"
-              c:identifier="pango_units_from_double"
-              version="1.16">
+    <function name="units_from_double" c:identifier="pango_units_from_double" version="1.16">
       <doc xml:space="preserve">Converts a floating-point number to Pango units: multiplies
 it by %PANGO_SCALE and rounds to nearest integer.</doc>
       <return-value transfer-ownership="none">
@@ -13844,9 +11634,7 @@ it by %PANGO_SCALE and rounds to nearest integer.</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="units_to_double"
-              c:identifier="pango_units_to_double"
-              version="1.16">
+    <function name="units_to_double" c:identifier="pango_units_to_double" version="1.16">
       <doc xml:space="preserve">Converts a number in Pango units to floating-point: divides
 it by %PANGO_SCALE.</doc>
       <return-value transfer-ownership="none">
@@ -13873,9 +11661,7 @@ PANGO_VERSION_ENCODE().</doc>
         <type name="gint" c:type="int"/>
       </return-value>
     </function>
-    <function name="version_check"
-              c:identifier="pango_version_check"
-              version="1.16">
+    <function name="version_check" c:identifier="pango_version_check" version="1.16">
       <doc xml:space="preserve">Checks that the Pango library in use is compatible with the
 given version. Generally you would pass in the constants
 %PANGO_VERSION_MAJOR, %PANGO_VERSION_MINOR, %PANGO_VERSION_MICRO
@@ -13913,9 +11699,7 @@ For compile-time version checking use PANGO_VERSION_CHECK().</doc>
         </parameter>
       </parameters>
     </function>
-    <function name="version_string"
-              c:identifier="pango_version_string"
-              version="1.16">
+    <function name="version_string" c:identifier="pango_version_string" version="1.16">
       <doc xml:space="preserve">This is similar to the macro %PANGO_VERSION_STRING except that
 it returns the version of Pango available at run-time, as opposed to
 the version available at compile-time.</doc>

--- a/fix.sh
+++ b/fix.sh
@@ -44,3 +44,7 @@ xmlstarlet ed -P -L \
 	-i '//_:namespace' -t elem -n c:include \
 	-a '$prev' -t attr -n name -v gtk/gtk-a11y.h \
 	Gtk-3.0.gir
+
+xmlstarlet ed -P -L \
+	GObject-2.0.gir
+	

--- a/fix.sh
+++ b/fix.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -x -e
 
+xmlstarlet ed -P -L \
+	Pango-1.0.gir
+
 # Remove all fields from FcFontMap. Its' parent_instance field is broken and we don't need the type anyway.
 # Replace cairo_font_type_t with enums::FontType as well.
 xmlstarlet ed -P -L \

--- a/fix.sh
+++ b/fix.sh
@@ -23,6 +23,8 @@ xmlstarlet ed -P -L \
 # but in this case it happens to be named differently, i.e., as g_option_error_quark.
 xmlstarlet ed -P -L \
 	-u '//*[@glib:error-domain="g-option-context-error-quark"]/@glib:error-domain' -v g-option-error-quark \
+	-i '//_:namespace' -t elem -n c:include \
+	-a '$prev' -t attr -n name -v glib-object.h \
 	GLib-2.0.gir
 
 # GdkEventTouchpadPinch and GdkEventTouchpadSwipe contains phase field,
@@ -32,7 +34,13 @@ xmlstarlet ed -P -L \
 	Gdk-3.0.gir
 
 xmlstarlet ed -P -L \
+	-i '//_:namespace' -t elem -n c:include \
+	-a '$prev' -t attr -n name -v gdk-pixbuf/gdk-pixdata.h \
 	GdkPixbuf-2.0.gir
 
 xmlstarlet ed -P -L \
+	-i '//_:namespace' -t elem -n c:include \
+	-a '$prev' -t attr -n name -v gtk/gtk.h \
+	-i '//_:namespace' -t elem -n c:include \
+	-a '$prev' -t attr -n name -v gtk/gtk-a11y.h \
 	Gtk-3.0.gir

--- a/fix.sh
+++ b/fix.sh
@@ -30,3 +30,9 @@ xmlstarlet ed -P -L \
 xmlstarlet ed -P -L \
 	-i '//_:field[@name="phase"]/_:type[@name="TouchpadGesturePhase"]' -t attr -n 'c:type' -v 'gint8' \
 	Gdk-3.0.gir
+
+xmlstarlet ed -P -L \
+	GdkPixbuf-2.0.gir
+
+xmlstarlet ed -P -L \
+	Gtk-3.0.gir

--- a/fix.sh
+++ b/fix.sh
@@ -3,35 +3,30 @@ set -x -e
 
 # Remove all fields from FcFontMap. Its' parent_instance field is broken and we don't need the type anyway.
 # Replace cairo_font_type_t with enums::FontType as well.
-xmlstarlet ed -P \
+xmlstarlet ed -P -L \
 	-d '//_:class[@name="FcFontMap"]/_:field' \
 	-u '//*[@c:type="cairo_font_type_t"]/@c:type' -v enums::FontType \
-	PangoCairo-1.0.gir > tmp
-mv tmp PangoCairo-1.0.gir
+	PangoCairo-1.0.gir
 
 # Remove Int32 alias because it misses c:type, it not like anyone actually cares about it.
-xmlstarlet ed -P \
-	-d '//_:alias[@name="Int32"]' freetype2-2.0.gir > tmp
-mv tmp freetype2-2.0.gir
+xmlstarlet ed -P -L \
+	-d '//_:alias[@name="Int32"]' freetype2-2.0.gir
 
 # Change FontType glib:type to FontType.
 # Replace cairo_font_type_t with enums::FontType as well.
-xmlstarlet ed -P \
+xmlstarlet ed -P -L \
 	-u '//_:enumeration[@name="FontType"]/@glib:type-name' -v FontType \
 	-u '//*[@c:type="cairo_font_type_t"]/@c:type' -v enums::FontType \
-	cairo-1.0.gir > tmp
-mv tmp cairo-1.0.gir
+	cairo-1.0.gir
 
 # gir uses error domain to find quark function corresponding to given error enum,
 # but in this case it happens to be named differently, i.e., as g_option_error_quark.
-xmlstarlet ed -P \
+xmlstarlet ed -P -L \
 	-u '//*[@glib:error-domain="g-option-context-error-quark"]/@glib:error-domain' -v g-option-error-quark \
-	GLib-2.0.gir > tmp
-mv tmp GLib-2.0.gir
+	GLib-2.0.gir
 
 # GdkEventTouchpadPinch and GdkEventTouchpadSwipe contains phase field,
 # it type enum TouchpadGesturePhase but if takes only one byte.
-xmlstarlet ed -P \
+xmlstarlet ed -P -L \
 	-i '//_:field[@name="phase"]/_:type[@name="TouchpadGesturePhase"]' -t attr -n 'c:type' -v 'gint8' \
-	Gdk-3.0.gir > tmp
-mv tmp Gdk-3.0.gir
+	Gdk-3.0.gir

--- a/fix.sh
+++ b/fix.sh
@@ -2,6 +2,8 @@
 set -x -e
 
 xmlstarlet ed -P -L \
+	-i '//_:namespace' -t elem -n c:include \
+	-a '$prev' -t attr -n name -v pango/pango-modules.h \
 	Pango-1.0.gir
 
 # Remove all fields from FcFontMap. Its' parent_instance field is broken and we don't need the type anyway.

--- a/fix.sh
+++ b/fix.sh
@@ -46,5 +46,7 @@ xmlstarlet ed -P -L \
 	Gtk-3.0.gir
 
 xmlstarlet ed -P -L \
+	-i '//_:namespace' -t elem -n c:include \
+	-a '$prev' -t attr -n name -v gobject/gvaluecollector.h \
 	GObject-2.0.gir
 	


### PR DESCRIPTION
No functional changes intended for files generated by gir generator.
At least until it starts to generate test cross-validating ABI with C.

Also, use -L option to xmlstarlet to make changes in-place.

Sidenote: ./fix.sh is not idempotent right now (neither was it before this
change) so to apply changes you need to checkout gir files from last update.

Sidenote 2: I plan to report those upstream as well, with exception of issue in
glib, because the problem is the result of ugly hack in headers that is very
unlikely to get fixed.