### PR TITLE
Fix incorrect GIR due to gobject-introspection GitLab issue #189

### DIFF
--- a/GLib-2.0.gir
+++ b/GLib-2.0.gir
@@ -10237,7 +10237,7 @@ If @group_name is %NULL, the start_group is used.</doc>
           </parameter>
           <parameter name="list" transfer-ownership="none">
             <doc xml:space="preserve">an array of boolean values</doc>
-            <array length="3" zero-terminated="0" c:type="gboolean">
+            <array length="3" zero-terminated="0" c:type="gboolean*">
               <type name="gboolean" c:type="gboolean"/>
             </array>
           </parameter>
@@ -10325,7 +10325,7 @@ If @key cannot be found then it is created.</doc>
           </parameter>
           <parameter name="list" transfer-ownership="none">
             <doc xml:space="preserve">an array of double values</doc>
-            <array length="3" zero-terminated="0" c:type="gdouble">
+            <array length="3" zero-terminated="0" c:type="gdouble*">
               <type name="gdouble" c:type="gdouble"/>
             </array>
           </parameter>
@@ -10406,7 +10406,7 @@ If @key cannot be found then it is created.</doc>
           </parameter>
           <parameter name="list" transfer-ownership="none">
             <doc xml:space="preserve">an array of integer values</doc>
-            <array length="3" zero-terminated="0" c:type="gint">
+            <array length="3" zero-terminated="0" c:type="gint*">
               <type name="gint" c:type="gint"/>
             </array>
           </parameter>
@@ -10489,7 +10489,7 @@ it is created.</doc>
           </parameter>
           <parameter name="list" transfer-ownership="none">
             <doc xml:space="preserve">a %NULL-terminated array of locale string values</doc>
-            <array length="4" zero-terminated="1" c:type="gchar*">
+            <array length="4" zero-terminated="1" c:type="const gchar* const*">
               <type name="utf8" c:type="gchar"/>
             </array>
           </parameter>
@@ -10549,7 +10549,7 @@ If @group_name cannot be found then it is created.</doc>
           </parameter>
           <parameter name="list" transfer-ownership="none">
             <doc xml:space="preserve">an array of string values</doc>
-            <array length="3" zero-terminated="1" c:type="gchar*">
+            <array length="3" zero-terminated="1" c:type="const gchar* const*">
               <type name="utf8"/>
             </array>
           </parameter>

--- a/GObject-2.0.gir
+++ b/GObject-2.0.gir
@@ -3431,13 +3431,13 @@ which are not explicitly specified are set to their default values.</doc>
           </parameter>
           <parameter name="names" transfer-ownership="none">
             <doc xml:space="preserve">the names of each property to be set</doc>
-            <array length="1" zero-terminated="0" c:type="char*">
+            <array length="1" zero-terminated="0" c:type="const char**">
               <type name="utf8" c:type="char"/>
             </array>
           </parameter>
           <parameter name="values" transfer-ownership="none">
             <doc xml:space="preserve">the values of each property to be set</doc>
-            <array length="1" zero-terminated="0" c:type="GValue">
+            <array length="1" zero-terminated="0" c:type="const GValue*">
               <type name="Value" c:type="GValue"/>
             </array>
           </parameter>
@@ -4266,13 +4266,13 @@ properties are passed in.</doc>
           </parameter>
           <parameter name="names" transfer-ownership="none">
             <doc xml:space="preserve">the names of each property to get</doc>
-            <array length="0" zero-terminated="0" c:type="gchar*">
+            <array length="0" zero-terminated="0" c:type="const gchar**">
               <type name="utf8" c:type="gchar"/>
             </array>
           </parameter>
           <parameter name="values" transfer-ownership="none">
             <doc xml:space="preserve">the values of each property to get</doc>
-            <array length="0" zero-terminated="0" c:type="GValue">
+            <array length="0" zero-terminated="0" c:type="GValue*">
               <type name="Value" c:type="GValue"/>
             </array>
           </parameter>
@@ -4752,13 +4752,13 @@ properties are passed in.</doc>
           </parameter>
           <parameter name="names" transfer-ownership="none">
             <doc xml:space="preserve">the names of each property to be set</doc>
-            <array length="0" zero-terminated="0" c:type="gchar*">
+            <array length="0" zero-terminated="0" c:type="const gchar**">
               <type name="utf8" c:type="gchar"/>
             </array>
           </parameter>
           <parameter name="values" transfer-ownership="none">
             <doc xml:space="preserve">the values of each property to be set</doc>
-            <array length="0" zero-terminated="0" c:type="GValue">
+            <array length="0" zero-terminated="0" c:type="const GValue*">
               <type name="Value" c:type="GValue"/>
             </array>
           </parameter>

--- a/fix.sh
+++ b/fix.sh
@@ -25,3 +25,31 @@ xmlstarlet ed -P -L \
 xmlstarlet ed -P -L \
 	-u '//*[@glib:error-domain="g-option-context-error-quark"]/@glib:error-domain' -v g-option-error-quark \
 	GLib-2.0.gir
+
+
+# incorrect GIR due to gobject-introspection GitLab issue #189
+xmlstarlet ed -P -L \
+	-u '//_:class[@name="IconTheme"]/_:method//_:parameter[@name="icon_names"]/_:array/@c:type' -v "const gchar**" \
+	-u '//_:class[@name="IconTheme"]/_:method[@name="get_search_path"]//_:parameter[@name="path"]/_:array/@c:type' -v "gchar***" \
+	-u '//_:class[@name="IconTheme"]/_:method[@name="set_search_path"]//_:parameter[@name="path"]/_:array/@c:type' -v "const gchar**" \
+	Gtk-3.0.gir
+
+# incorrect GIR due to gobject-introspection GitLab issue #189
+xmlstarlet ed -P -L \
+	-u '//_:record[@name="KeyFile"]/_:method[@name="set_boolean_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "gboolean*" \
+	-u '//_:record[@name="KeyFile"]/_:method[@name="set_double_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "gdouble*" \
+	-u '//_:record[@name="KeyFile"]/_:method[@name="set_integer_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "gint*" \
+	-u '//_:record[@name="KeyFile"]/_:method[@name="set_locale_string_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "const gchar* const*" \
+	-u '//_:record[@name="KeyFile"]/_:method[@name="set_string_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "const gchar* const*" \
+	GLib-2.0.gir
+
+# incorrect GIR due to gobject-introspection GitLab issue #189
+xmlstarlet ed -P -L \
+	-u '//_:class[@name="Object"]/_:method[@name="getv"]//_:parameter[@name="names"]/_:array/@c:type' -v "const gchar**" \
+	-u '//_:class[@name="Object"]/_:method[@name="getv"]//_:parameter[@name="values"]/_:array/@c:type' -v "GValue*" \
+	-u '//_:class[@name="Object"]/_:method[@name="setv"]//_:parameter[@name="names"]/_:array/@c:type' -v "const gchar**" \
+	-u '//_:class[@name="Object"]/_:method[@name="setv"]//_:parameter[@name="values"]/_:array/@c:type' -v "const GValue*" \
+	-u '//_:class[@name="Object"]/_:constructor[@name="new_with_properties"]//_:parameter[@name="names"]/_:array/@c:type' -v "const char**" \
+	-u '//_:class[@name="Object"]/_:constructor[@name="new_with_properties"]//_:parameter[@name="values"]/_:array/@c:type' -v "const GValue*" \
+	GObject-2.0.gir
+


### PR DESCRIPTION
This fixes gtk-rs/sys#92.  This is an alternate way of fixing it.  My first attempt is the PR at gtk-rs/sys#93 where I added these functions as manual implementations.

This fixes the same issue, but by using fix.sh instead.

You can read about why the GIR is incorrect in gobject-introspection GitLab issue #189.  Basically any header files that uses the `[]` operator will have incorrect GIR generated from it.

I took care to make sure to match the `const`-ness of the functions in C.