### PR TITLE
Undo name fix for Cairo.FontType

### DIFF
--- a/PangoCairo-1.0.gir
+++ b/PangoCairo-1.0.gir
@@ -107,7 +107,7 @@ or in fact in most of those cases, just use
         <parameters>
           <parameter name="fonttype" transfer-ownership="none">
             <doc xml:space="preserve">desired #cairo_font_type_t</doc>
-            <type name="cairo.FontType" c:type="enums::FontType"/>
+            <type name="cairo.FontType" c:type="cairo_font_type_t"/>
           </parameter>
         </parameters>
       </function>
@@ -129,7 +129,7 @@ or in fact in most of those cases, just use
         <doc xml:space="preserve">Gets the type of Cairo font backend that @fontmap uses.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the #cairo_font_type_t cairo font backend type</doc>
-          <type name="cairo.FontType" c:type="enums::FontType"/>
+          <type name="cairo.FontType" c:type="cairo_font_type_t"/>
         </return-value>
         <parameters>
           <instance-parameter name="fontmap" transfer-ownership="none">
@@ -491,7 +491,7 @@ or in fact in most of those cases, just use
       <parameters>
         <parameter name="fonttype" transfer-ownership="none">
           <doc xml:space="preserve">desired #cairo_font_type_t</doc>
-          <type name="cairo.FontType" c:type="enums::FontType"/>
+          <type name="cairo.FontType" c:type="cairo_font_type_t"/>
         </parameter>
       </parameters>
     </function>

--- a/cairo-1.0.gir
+++ b/cairo-1.0.gir
@@ -140,7 +140,7 @@
       <member name="on" value="2" c:identifier="CAIRO_HINT_METRICS_ON"/>
     </enumeration>
     <record name="FontOptions" c:type="cairo_font_options_t" foreign="1" glib:type-name="CairoFontOptions" glib:get-type="cairo_gobject_font_options_get_type"/>
-    <enumeration name="FontType" c:type="enums::FontType" glib:type-name="FontType" glib:get-type="cairo_gobject_font_type_get_type">
+    <enumeration name="FontType" c:type="cairo_font_type_t" glib:type-name="cairo_font_type_t" glib:get-type="cairo_gobject_font_type_get_type">
       <member name="toy" value="0" c:identifier="CAIRO_FONT_TYPE_TOY"/>
       <member name="ft" value="1" c:identifier="CAIRO_FONT_TYPE_FT"/>
       <member name="win32" value="2" c:identifier="CAIRO_FONT_TYPE_WIN32"/>

--- a/dl.sh
+++ b/dl.sh
@@ -5,7 +5,7 @@ VER="bionic"
 
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libatk1.0-dev/download
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libgirepository1.0-dev/download
-./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libpango1.0-dev/download
+./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libpango1.0-dev/download security.ubuntu.com/ubuntu
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libgdk-pixbuf2.0-dev/download
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libgtk-3-dev/download
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libgtksourceview-3.0-dev/download

--- a/fix.sh
+++ b/fix.sh
@@ -2,23 +2,14 @@
 set -x -e
 
 # Remove all fields from FcFontMap. Its' parent_instance field is broken and we don't need the type anyway.
-# Replace cairo_font_type_t with enums::FontType as well.
 xmlstarlet ed -P -L \
 	-d '//_:class[@name="FcFontMap"]/_:field' \
-	-u '//*[@c:type="cairo_font_type_t"]/@c:type' -v enums::FontType \
 	PangoCairo-1.0.gir
 
 # Remove Int32 alias because it misses c:type, it not like anyone actually cares about it.
 xmlstarlet ed -P -L \
 	-d '//_:alias[@name="Int32"]' \
 	freetype2-2.0.gir
-
-# Change FontType glib:type to FontType.
-# Replace cairo_font_type_t with enums::FontType as well.
-xmlstarlet ed -P -L \
-	-u '//_:enumeration[@name="FontType"]/@glib:type-name' -v FontType \
-	-u '//*[@c:type="cairo_font_type_t"]/@c:type' -v enums::FontType \
-	cairo-1.0.gir
 
 # gir uses error domain to find quark function corresponding to given error enum,
 # but in this case it happens to be named differently, i.e., as g_option_error_quark.


### PR DESCRIPTION
Part of https://github.com/gtk-rs/sys/issues/116

Now it use cairo_font_type_t from https://github.com/gtk-rs/cairo/pull/219

cc @GuillaumeGomez , @sdroege , @vhdirk