### PR TITLE
Update script to download Ubuntu Disco packages

### DIFF
--- a/Atk-1.0.gir
+++ b/Atk-1.0.gir
@@ -527,7 +527,7 @@ A string name/value pair representing a generic attribute.</doc>
         </parameters>
       </function>
     </record>
-    <constant name="BINARY_AGE" value="22811" c:type="ATK_BINARY_AGE" version="2.7.4">
+    <constant name="BINARY_AGE" value="23010" c:type="ATK_BINARY_AGE" version="2.7.4">
       <doc xml:space="preserve">Like atk_get_binary_age(), but from the headers used at
 application compile time, rather than from the library linked
 against at application run time.</doc>
@@ -797,6 +797,54 @@ from @component</doc>
           </parameter>
         </parameters>
       </virtual-method>
+      <virtual-method name="scroll_to" invoker="scroll_to" version="2.30">
+        <doc xml:space="preserve">Makes @component visible on the screen by scrolling all necessary parents.
+
+Contrary to atk_component_set_position, this does not actually move
+@component in its parent, this only makes the parents scroll so that the
+object shows up on the screen, given its current position within the parents.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether scrolling was successful.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="component" transfer-ownership="none">
+            <doc xml:space="preserve">an #AtkComponent</doc>
+            <type name="Component" c:type="AtkComponent*"/>
+          </instance-parameter>
+          <parameter name="type" transfer-ownership="none">
+            <doc xml:space="preserve">specify where the object should be made visible.</doc>
+            <type name="ScrollType" c:type="AtkScrollType"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="scroll_to_point" invoker="scroll_to_point" version="2.30">
+        <doc xml:space="preserve">Makes an object visible on the screen at a given position by scrolling all
+necessary parents.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether scrolling was successful.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="component" transfer-ownership="none">
+            <doc xml:space="preserve">an #AtkComponent</doc>
+            <type name="Component" c:type="AtkComponent*"/>
+          </instance-parameter>
+          <parameter name="coords" transfer-ownership="none">
+            <doc xml:space="preserve">specify whether coordinates are relative to the screen or to the
+parent object.</doc>
+            <type name="CoordType" c:type="AtkCoordType"/>
+          </parameter>
+          <parameter name="x" transfer-ownership="none">
+            <doc xml:space="preserve">x-position where to scroll to</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="y" transfer-ownership="none">
+            <doc xml:space="preserve">y-position where to scroll to</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
       <virtual-method name="set_extents" invoker="set_extents">
         <doc xml:space="preserve">Sets the extents of @component.</doc>
         <return-value transfer-ownership="none">
@@ -832,7 +880,10 @@ or to the components top level window</doc>
         </parameters>
       </virtual-method>
       <virtual-method name="set_position" invoker="set_position">
-        <doc xml:space="preserve">Sets the postition of @component.</doc>
+        <doc xml:space="preserve">Sets the position of @component.
+
+Contrary to atk_component_scroll_to, this does not trigger any scrolling,
+this just moves @component in its parent.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE or %FALSE whether or not the position was set or not</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -852,7 +903,7 @@ or to the components top level window</doc>
           </parameter>
           <parameter name="coord_type" transfer-ownership="none">
             <doc xml:space="preserve">specifies whether the coordinates are relative to the screen
-or to the components top level window</doc>
+or to the component's top level window</doc>
             <type name="CoordType" c:type="AtkCoordType"/>
           </parameter>
         </parameters>
@@ -1118,6 +1169,54 @@ from @component</doc>
           </parameter>
         </parameters>
       </method>
+      <method name="scroll_to" c:identifier="atk_component_scroll_to" version="2.30">
+        <doc xml:space="preserve">Makes @component visible on the screen by scrolling all necessary parents.
+
+Contrary to atk_component_set_position, this does not actually move
+@component in its parent, this only makes the parents scroll so that the
+object shows up on the screen, given its current position within the parents.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether scrolling was successful.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="component" transfer-ownership="none">
+            <doc xml:space="preserve">an #AtkComponent</doc>
+            <type name="Component" c:type="AtkComponent*"/>
+          </instance-parameter>
+          <parameter name="type" transfer-ownership="none">
+            <doc xml:space="preserve">specify where the object should be made visible.</doc>
+            <type name="ScrollType" c:type="AtkScrollType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="scroll_to_point" c:identifier="atk_component_scroll_to_point" version="2.30">
+        <doc xml:space="preserve">Makes an object visible on the screen at a given position by scrolling all
+necessary parents.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether scrolling was successful.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="component" transfer-ownership="none">
+            <doc xml:space="preserve">an #AtkComponent</doc>
+            <type name="Component" c:type="AtkComponent*"/>
+          </instance-parameter>
+          <parameter name="coords" transfer-ownership="none">
+            <doc xml:space="preserve">specify whether coordinates are relative to the screen or to the
+parent object.</doc>
+            <type name="CoordType" c:type="AtkCoordType"/>
+          </parameter>
+          <parameter name="x" transfer-ownership="none">
+            <doc xml:space="preserve">x-position where to scroll to</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="y" transfer-ownership="none">
+            <doc xml:space="preserve">y-position where to scroll to</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
       <method name="set_extents" c:identifier="atk_component_set_extents">
         <doc xml:space="preserve">Sets the extents of @component.</doc>
         <return-value transfer-ownership="none">
@@ -1153,7 +1252,10 @@ or to the components top level window</doc>
         </parameters>
       </method>
       <method name="set_position" c:identifier="atk_component_set_position">
-        <doc xml:space="preserve">Sets the postition of @component.</doc>
+        <doc xml:space="preserve">Sets the position of @component.
+
+Contrary to atk_component_scroll_to, this does not trigger any scrolling,
+this just moves @component in its parent.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE or %FALSE whether or not the position was set or not</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -1173,7 +1275,7 @@ or to the components top level window</doc>
           </parameter>
           <parameter name="coord_type" transfer-ownership="none">
             <doc xml:space="preserve">specifies whether the coordinates are relative to the screen
-or to the components top level window</doc>
+or to the component's top level window</doc>
             <type name="CoordType" c:type="AtkCoordType"/>
           </parameter>
         </parameters>
@@ -1461,7 +1563,7 @@ or to the components top level window</doc>
             </parameter>
             <parameter name="coord_type" transfer-ownership="none">
               <doc xml:space="preserve">specifies whether the coordinates are relative to the screen
-or to the components top level window</doc>
+or to the component's top level window</doc>
               <type name="CoordType" c:type="AtkCoordType"/>
             </parameter>
           </parameters>
@@ -1548,6 +1650,51 @@ container.</doc>
           </parameters>
         </callback>
       </field>
+      <field name="scroll_to">
+        <callback name="scroll_to">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">whether scrolling was successful.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </return-value>
+          <parameters>
+            <parameter name="component" transfer-ownership="none">
+              <doc xml:space="preserve">an #AtkComponent</doc>
+              <type name="Component" c:type="AtkComponent*"/>
+            </parameter>
+            <parameter name="type" transfer-ownership="none">
+              <doc xml:space="preserve">specify where the object should be made visible.</doc>
+              <type name="ScrollType" c:type="AtkScrollType"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="scroll_to_point">
+        <callback name="scroll_to_point">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">whether scrolling was successful.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </return-value>
+          <parameters>
+            <parameter name="component" transfer-ownership="none">
+              <doc xml:space="preserve">an #AtkComponent</doc>
+              <type name="Component" c:type="AtkComponent*"/>
+            </parameter>
+            <parameter name="coords" transfer-ownership="none">
+              <doc xml:space="preserve">specify whether coordinates are relative to the screen or to the
+parent object.</doc>
+              <type name="CoordType" c:type="AtkCoordType"/>
+            </parameter>
+            <parameter name="x" transfer-ownership="none">
+              <doc xml:space="preserve">x-position where to scroll to</doc>
+              <type name="gint" c:type="gint"/>
+            </parameter>
+            <parameter name="y" transfer-ownership="none">
+              <doc xml:space="preserve">y-position where to scroll to</doc>
+              <type name="gint" c:type="gint"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
     </record>
     <enumeration name="CoordType" glib:type-name="AtkCoordType" glib:get-type="atk_coord_type_get_type" c:type="AtkCoordType">
       <doc xml:space="preserve">Specifies how xy coordinates are to be interpreted. Used by functions such
@@ -1558,6 +1705,10 @@ as atk_component_get_position() and atk_text_get_character_extents()</doc>
       <member name="window" value="1" c:identifier="ATK_XY_WINDOW" glib:nick="window">
         <doc xml:space="preserve">specifies xy coordinates relative to the widget's
 top-level window</doc>
+      </member>
+      <member name="parent" value="2" c:identifier="ATK_XY_PARENT" glib:nick="parent">
+        <doc xml:space="preserve">specifies xy coordinates relative to the widget's
+immediate parent. Since: 2.30</doc>
       </member>
     </enumeration>
     <interface name="Document" c:symbol-prefix="document" c:type="AtkDocument" glib:type-name="AtkDocument" glib:get-type="atk_document_get_type" glib:type-struct="DocumentIface">
@@ -1599,35 +1750,57 @@ instance of the DOM.</doc-deprecated>
           </instance-parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="get_document_attribute_value">
-        <return-value transfer-ownership="none">
+      <virtual-method name="get_document_attribute_value" invoker="get_attribute_value" version="1.12">
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">a string value associated with the named
+   attribute for this document, or NULL if a value for
+   #attribute_name has not been specified for this document.</doc>
           <type name="utf8" c:type="const gchar*"/>
         </return-value>
         <parameters>
           <instance-parameter name="document" transfer-ownership="none">
+            <doc xml:space="preserve">a #GObject instance that implements AtkDocumentIface</doc>
             <type name="Document" c:type="AtkDocument*"/>
           </instance-parameter>
           <parameter name="attribute_name" transfer-ownership="none">
+            <doc xml:space="preserve">a character string representing the name of the attribute
+           whose value is being queried.</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="get_document_attributes" introspectable="0">
-        <return-value>
+      <virtual-method name="get_document_attributes" invoker="get_attributes" version="1.12">
+        <doc xml:space="preserve">Gets an AtkAttributeSet which describes document-wide
+         attributes as name-value pairs.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">An AtkAttributeSet containing the explicitly
+         set name-value-pair attributes associated with this document
+         as a whole.</doc>
           <type name="AttributeSet" c:type="AtkAttributeSet*"/>
         </return-value>
         <parameters>
           <instance-parameter name="document" transfer-ownership="none">
+            <doc xml:space="preserve">a #GObject instance that implements AtkDocumentIface</doc>
             <type name="Document" c:type="AtkDocument*"/>
           </instance-parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="get_document_locale">
+      <virtual-method name="get_document_locale" invoker="get_locale" deprecated="1" deprecated-version="2.7.90">
+        <doc xml:space="preserve">Gets a UTF-8 string indicating the POSIX-style LC_MESSAGES locale
+         of the content of this document instance.  Individual
+         text substrings or images within this document may have
+         a different locale, see atk_text_get_attributes and
+         atk_image_get_image_locale.</doc>
+        <doc-deprecated xml:space="preserve">Please use atk_object_get_object_locale() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a UTF-8 string indicating the POSIX-style LC_MESSAGES
+         locale of the document content as a whole, or NULL if
+         the document content does not specify a locale.</doc>
           <type name="utf8" c:type="const gchar*"/>
         </return-value>
         <parameters>
           <instance-parameter name="document" transfer-ownership="none">
+            <doc xml:space="preserve">a #GObject instance that implements AtkDocumentIface</doc>
             <type name="Document" c:type="AtkDocument*"/>
           </instance-parameter>
         </parameters>
@@ -1660,18 +1833,25 @@ know by the implementor or irrelevant.</doc>
           </instance-parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="set_document_attribute">
+      <virtual-method name="set_document_attribute" invoker="set_attribute_value" version="1.12">
         <return-value transfer-ownership="none">
+          <doc xml:space="preserve">TRUE if #value is successfully associated with #attribute_name
+         for this document, FALSE otherwise (e.g. if the document does not
+         allow the attribute to be modified).</doc>
           <type name="gboolean" c:type="gboolean"/>
         </return-value>
         <parameters>
           <instance-parameter name="document" transfer-ownership="none">
+            <doc xml:space="preserve">a #GObject instance that implements AtkDocumentIface</doc>
             <type name="Document" c:type="AtkDocument*"/>
           </instance-parameter>
           <parameter name="attribute_name" transfer-ownership="none">
+            <doc xml:space="preserve">a character string representing the name of the attribute
+           whose value is being set.</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
           <parameter name="attribute_value" transfer-ownership="none">
+            <doc xml:space="preserve">a string value to be associated with #attribute_name.</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
         </parameters>
@@ -1899,22 +2079,30 @@ interrogating ATK for the latest document content.</doc>
       <field name="get_document_locale">
         <callback name="get_document_locale">
           <return-value transfer-ownership="none">
+            <doc xml:space="preserve">a UTF-8 string indicating the POSIX-style LC_MESSAGES
+         locale of the document content as a whole, or NULL if
+         the document content does not specify a locale.</doc>
             <type name="utf8" c:type="const gchar*"/>
           </return-value>
           <parameters>
             <parameter name="document" transfer-ownership="none">
+              <doc xml:space="preserve">a #GObject instance that implements AtkDocumentIface</doc>
               <type name="Document" c:type="AtkDocument*"/>
             </parameter>
           </parameters>
         </callback>
       </field>
-      <field name="get_document_attributes" introspectable="0">
-        <callback name="get_document_attributes" introspectable="0">
-          <return-value>
+      <field name="get_document_attributes">
+        <callback name="get_document_attributes">
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve">An AtkAttributeSet containing the explicitly
+         set name-value-pair attributes associated with this document
+         as a whole.</doc>
             <type name="AttributeSet" c:type="AtkAttributeSet*"/>
           </return-value>
           <parameters>
             <parameter name="document" transfer-ownership="none">
+              <doc xml:space="preserve">a #GObject instance that implements AtkDocumentIface</doc>
               <type name="Document" c:type="AtkDocument*"/>
             </parameter>
           </parameters>
@@ -1922,14 +2110,20 @@ interrogating ATK for the latest document content.</doc>
       </field>
       <field name="get_document_attribute_value">
         <callback name="get_document_attribute_value">
-          <return-value transfer-ownership="none">
+          <return-value transfer-ownership="none" nullable="1">
+            <doc xml:space="preserve">a string value associated with the named
+   attribute for this document, or NULL if a value for
+   #attribute_name has not been specified for this document.</doc>
             <type name="utf8" c:type="const gchar*"/>
           </return-value>
           <parameters>
             <parameter name="document" transfer-ownership="none">
+              <doc xml:space="preserve">a #GObject instance that implements AtkDocumentIface</doc>
               <type name="Document" c:type="AtkDocument*"/>
             </parameter>
             <parameter name="attribute_name" transfer-ownership="none">
+              <doc xml:space="preserve">a character string representing the name of the attribute
+           whose value is being queried.</doc>
               <type name="utf8" c:type="const gchar*"/>
             </parameter>
           </parameters>
@@ -1938,16 +2132,23 @@ interrogating ATK for the latest document content.</doc>
       <field name="set_document_attribute">
         <callback name="set_document_attribute">
           <return-value transfer-ownership="none">
+            <doc xml:space="preserve">TRUE if #value is successfully associated with #attribute_name
+         for this document, FALSE otherwise (e.g. if the document does not
+         allow the attribute to be modified).</doc>
             <type name="gboolean" c:type="gboolean"/>
           </return-value>
           <parameters>
             <parameter name="document" transfer-ownership="none">
+              <doc xml:space="preserve">a #GObject instance that implements AtkDocumentIface</doc>
               <type name="Document" c:type="AtkDocument*"/>
             </parameter>
             <parameter name="attribute_name" transfer-ownership="none">
+              <doc xml:space="preserve">a character string representing the name of the attribute
+           whose value is being set.</doc>
               <type name="utf8" c:type="const gchar*"/>
             </parameter>
             <parameter name="attribute_value" transfer-ownership="none">
+              <doc xml:space="preserve">a string value to be associated with #attribute_name.</doc>
               <type name="utf8" c:type="const gchar*"/>
             </parameter>
           </parameters>
@@ -3733,13 +3934,13 @@ application compile time, rather than from the library linked
 against at application run time.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="MICRO_VERSION" value="1" c:type="ATK_MICRO_VERSION" version="2.7.4">
+    <constant name="MICRO_VERSION" value="0" c:type="ATK_MICRO_VERSION" version="2.7.4">
       <doc xml:space="preserve">Like atk_get_micro_version(), but from the headers used at
 application compile time, rather than from the library linked
 against at application run time.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="MINOR_VERSION" value="28" c:type="ATK_MINOR_VERSION" version="2.7.4">
+    <constant name="MINOR_VERSION" value="30" c:type="ATK_MINOR_VERSION" version="2.7.4">
       <doc xml:space="preserve">Like atk_get_minor_version(), but from the headers used at
 application compile time, rather than from the library linked
 against at application run time.</doc>
@@ -4787,7 +4988,7 @@ a empty value you can use "".</doc>
         <type name="Object"/>
       </property>
       <property name="accessible-role" writable="1" transfer-ownership="none">
-        <type name="gint" c:type="gint"/>
+        <type name="Role"/>
       </property>
       <property name="accessible-table-caption" deprecated="1" writable="1" transfer-ownership="none">
         <doc xml:space="preserve">Table caption.</doc>
@@ -4861,9 +5062,9 @@ signal when the cell in the table which has focus changes.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <parameter name="arg1" transfer-ownership="none" nullable="1" allow-none="1">
+          <parameter name="arg1" transfer-ownership="none">
             <doc xml:space="preserve">the newly focused object.</doc>
-            <type name="gpointer" c:type="gpointer"/>
+            <type name="Object" c:type="gpointer"/>
           </parameter>
         </parameters>
       </glib:signal>
@@ -4881,12 +5082,12 @@ removed form an object. It supports two details: "add" and
 when the child is added/removed or irrelevant.</doc>
             <type name="guint" c:type="guint"/>
           </parameter>
-          <parameter name="arg2" transfer-ownership="none" nullable="1" allow-none="1">
+          <parameter name="arg2" transfer-ownership="none">
             <doc xml:space="preserve">A gpointer to the child AtkObject which was added or
 removed. If the child was removed, it is possible that it is not
 available for the implementor. In that case this pointer can be
 NULL.</doc>
-            <type name="gpointer" c:type="gpointer"/>
+            <type name="Object" c:type="gpointer"/>
           </parameter>
         </parameters>
       </glib:signal>
@@ -4923,10 +5124,10 @@ notify doesn't support emission hooks.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <parameter name="arg1" transfer-ownership="none" nullable="1" allow-none="1">
-            <doc xml:space="preserve">an #AtkPropertyValues containing the new value of the
-  property which changed.</doc>
-            <type name="gpointer" c:type="gpointer"/>
+          <parameter name="arg1" transfer-ownership="none">
+            <doc xml:space="preserve">an #AtkPropertyValues containing the new
+value of the property which changed.</doc>
+            <type name="PropertyValues" c:type="gpointer"/>
           </parameter>
         </parameters>
       </glib:signal>
@@ -6725,6 +6926,38 @@ properly. ATK_ROLE_INVALID in case of error.</doc>
           </parameter>
         </parameters>
       </function>
+    </enumeration>
+    <enumeration name="ScrollType" version="2.30" glib:type-name="AtkScrollType" glib:get-type="atk_scroll_type_get_type" c:type="AtkScrollType">
+      <doc xml:space="preserve">Specifies where an object should be placed on the screen when using scroll_to.</doc>
+      <member name="top_left" value="0" c:identifier="ATK_SCROLL_TOP_LEFT" glib:nick="top-left">
+        <doc xml:space="preserve">Scroll the object vertically and horizontally to the top
+left corner of the window.</doc>
+      </member>
+      <member name="bottom_right" value="1" c:identifier="ATK_SCROLL_BOTTOM_RIGHT" glib:nick="bottom-right">
+        <doc xml:space="preserve">Scroll the object vertically and horizontally to the
+bottom right corner of the window.</doc>
+      </member>
+      <member name="top_edge" value="2" c:identifier="ATK_SCROLL_TOP_EDGE" glib:nick="top-edge">
+        <doc xml:space="preserve">Scroll the object vertically to the top edge of the
+ window.</doc>
+      </member>
+      <member name="bottom_edge" value="3" c:identifier="ATK_SCROLL_BOTTOM_EDGE" glib:nick="bottom-edge">
+        <doc xml:space="preserve">Scroll the object vertically to the bottom edge of
+the window.</doc>
+      </member>
+      <member name="left_edge" value="4" c:identifier="ATK_SCROLL_LEFT_EDGE" glib:nick="left-edge">
+        <doc xml:space="preserve">Scroll the object vertically and horizontally to the
+left edge of the window.</doc>
+      </member>
+      <member name="right_edge" value="5" c:identifier="ATK_SCROLL_RIGHT_EDGE" glib:nick="right-edge">
+        <doc xml:space="preserve">Scroll the object vertically and horizontally to the
+right edge of the window.</doc>
+      </member>
+      <member name="anywhere" value="6" c:identifier="ATK_SCROLL_ANYWHERE" glib:nick="anywhere">
+        <doc xml:space="preserve">Scroll the object vertically and horizontally so that
+as much as possible of the object becomes visible. The exact placement is
+determined by the application.</doc>
+      </member>
     </enumeration>
     <interface name="Selection" c:symbol-prefix="selection" c:type="AtkSelection" glib:type-name="AtkSelection" glib:get-type="atk_selection_get_type" glib:type-struct="SelectionIface">
       <doc xml:space="preserve">#AtkSelection should be implemented by UI components with children
@@ -10411,7 +10644,7 @@ and is NULL terminated.</doc>
             <type name="Text" c:type="AtkText*"/>
           </instance-parameter>
           <parameter name="start_offset" transfer-ownership="none">
-            <doc xml:space="preserve">the start position of the selected region</doc>
+            <doc xml:space="preserve">the starting character offset of the selected region</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="end_offset" transfer-ownership="none">
@@ -10420,32 +10653,42 @@ and is NULL terminated.</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="get_bounded_ranges">
+      <virtual-method name="get_bounded_ranges" invoker="get_bounded_ranges" version="1.3">
+        <doc xml:space="preserve">Get the ranges of text in the specified bounding box.</doc>
         <return-value transfer-ownership="full">
-          <type name="TextRange" c:type="AtkTextRange**"/>
+          <doc xml:space="preserve">Array of AtkTextRange. The last
+         element of the array returned by this function will be NULL.</doc>
+          <array c:type="AtkTextRange**">
+            <type name="TextRange" c:type="AtkTextRange*"/>
+          </array>
         </return-value>
         <parameters>
           <instance-parameter name="text" transfer-ownership="none">
+            <doc xml:space="preserve">an #AtkText</doc>
             <type name="Text" c:type="AtkText*"/>
           </instance-parameter>
           <parameter name="rect" transfer-ownership="none">
+            <doc xml:space="preserve">An AtkTextRectangle giving the dimensions of the bounding box.</doc>
             <type name="TextRectangle" c:type="AtkTextRectangle*"/>
           </parameter>
           <parameter name="coord_type" transfer-ownership="none">
+            <doc xml:space="preserve">Specify whether coordinates are relative to the screen or widget window.</doc>
             <type name="CoordType" c:type="AtkCoordType"/>
           </parameter>
           <parameter name="x_clip_type" transfer-ownership="none">
+            <doc xml:space="preserve">Specify the horizontal clip type.</doc>
             <type name="TextClipType" c:type="AtkTextClipType"/>
           </parameter>
           <parameter name="y_clip_type" transfer-ownership="none">
+            <doc xml:space="preserve">Specify the vertical clip type.</doc>
             <type name="TextClipType" c:type="AtkTextClipType"/>
           </parameter>
         </parameters>
       </virtual-method>
       <virtual-method name="get_caret_offset" invoker="get_caret_offset">
-        <doc xml:space="preserve">Gets the offset position of the caret (cursor).</doc>
+        <doc xml:space="preserve">Gets the offset of the position of the caret (cursor).</doc>
         <return-value transfer-ownership="none">
-          <doc xml:space="preserve">the offset position of the caret (cursor).</doc>
+          <doc xml:space="preserve">the character offset of position of the caret (cursor).</doc>
           <type name="gint" c:type="gint"/>
         </return-value>
         <parameters>
@@ -10467,7 +10710,7 @@ and is NULL terminated.</doc>
             <type name="Text" c:type="AtkText*"/>
           </instance-parameter>
           <parameter name="offset" transfer-ownership="none">
-            <doc xml:space="preserve">position</doc>
+            <doc xml:space="preserve">a character offset within @text</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
         </parameters>
@@ -10501,11 +10744,11 @@ and is NULL terminated.</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="x" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
-            <doc xml:space="preserve">Pointer for the x cordinate of the bounding box</doc>
+            <doc xml:space="preserve">Pointer for the x coordinate of the bounding box</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
           <parameter name="y" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
-            <doc xml:space="preserve">Pointer for the y cordinate of the bounding box</doc>
+            <doc xml:space="preserve">Pointer for the y coordinate of the bounding box</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
           <parameter name="width" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
@@ -10633,7 +10876,7 @@ to atk_attribute_set_free().</doc>
             <type name="Text" c:type="AtkText*"/>
           </instance-parameter>
           <parameter name="offset" transfer-ownership="none">
-            <doc xml:space="preserve">the offset at which to get the attributes, -1 means the offset of
+            <doc xml:space="preserve">the character offset at which to get the attributes, -1 means the offset of
 the character to be inserted at the caret location.</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
@@ -10668,12 +10911,12 @@ moving or deleting a selected region can change the numbering.</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-            <doc xml:space="preserve">passes back the start position of the selected region</doc>
+            <doc xml:space="preserve">passes back the starting character offset of the selected region</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
           <parameter name="end_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-            <doc xml:space="preserve">passes back the end position of (e.g. offset immediately past)
-the selected region</doc>
+            <doc xml:space="preserve">passes back the ending character offset (offset immediately past)
+of the selected region</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
         </parameters>
@@ -10730,7 +10973,7 @@ of the following paragraph after the offset.</doc>
             <type name="TextGranularity" c:type="AtkTextGranularity"/>
           </parameter>
           <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-            <doc xml:space="preserve">the start offset of the returned string, or -1
+            <doc xml:space="preserve">the starting character offset of the returned string, or -1
                if an error has occurred (e.g. invalid offset, not implemented)</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
@@ -10754,11 +10997,11 @@ of the following paragraph after the offset.</doc>
             <type name="Text" c:type="AtkText*"/>
           </instance-parameter>
           <parameter name="start_offset" transfer-ownership="none">
-            <doc xml:space="preserve">start position</doc>
+            <doc xml:space="preserve">a starting character offset within @text</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="end_offset" transfer-ownership="none">
-            <doc xml:space="preserve">end position, or -1 for the end of the string.</doc>
+            <doc xml:space="preserve">an ending character offset within @text, or -1 for the end of the string.</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
         </parameters>
@@ -10785,7 +11028,7 @@ of the following paragraph after the offset.</doc>
             <type name="TextBoundary" c:type="AtkTextBoundary"/>
           </parameter>
           <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-            <doc xml:space="preserve">the start offset of the returned string</doc>
+            <doc xml:space="preserve">the starting character offset of the returned string</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
           <parameter name="end_offset" direction="out" caller-allocates="0" transfer-ownership="full">
@@ -10841,7 +11084,7 @@ start after the offset.</doc>
             <type name="TextBoundary" c:type="AtkTextBoundary"/>
           </parameter>
           <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-            <doc xml:space="preserve">the start offset of the returned string</doc>
+            <doc xml:space="preserve">the starting character offset of the returned string</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
           <parameter name="end_offset" direction="out" caller-allocates="0" transfer-ownership="full">
@@ -10873,7 +11116,7 @@ start after the offset.</doc>
             <type name="TextBoundary" c:type="AtkTextBoundary"/>
           </parameter>
           <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-            <doc xml:space="preserve">the start offset of the returned string</doc>
+            <doc xml:space="preserve">the starting character offset of the returned string</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
           <parameter name="end_offset" direction="out" caller-allocates="0" transfer-ownership="full">
@@ -10916,7 +11159,7 @@ moving or deleting a selected region can change the numbering.</doc>
             <type name="Text" c:type="AtkText*"/>
           </instance-parameter>
           <parameter name="offset" transfer-ownership="none">
-            <doc xml:space="preserve">position</doc>
+            <doc xml:space="preserve">the character offset of the new caret position</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
         </parameters>
@@ -10941,7 +11184,7 @@ moving or deleting a selected region can change the numbering.</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="start_offset" transfer-ownership="none">
-            <doc xml:space="preserve">the new start position of the selection</doc>
+            <doc xml:space="preserve">the new starting character offset of the selection</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="end_offset" transfer-ownership="none">
@@ -11012,7 +11255,7 @@ the selection</doc>
             <type name="Text" c:type="AtkText*"/>
           </instance-parameter>
           <parameter name="start_offset" transfer-ownership="none">
-            <doc xml:space="preserve">the start position of the selected region</doc>
+            <doc xml:space="preserve">the starting character offset of the selected region</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="end_offset" transfer-ownership="none">
@@ -11054,9 +11297,9 @@ the selection</doc>
         </parameters>
       </method>
       <method name="get_caret_offset" c:identifier="atk_text_get_caret_offset">
-        <doc xml:space="preserve">Gets the offset position of the caret (cursor).</doc>
+        <doc xml:space="preserve">Gets the offset of the position of the caret (cursor).</doc>
         <return-value transfer-ownership="none">
-          <doc xml:space="preserve">the offset position of the caret (cursor).</doc>
+          <doc xml:space="preserve">the character offset of position of the caret (cursor).</doc>
           <type name="gint" c:type="gint"/>
         </return-value>
         <parameters>
@@ -11078,7 +11321,7 @@ the selection</doc>
             <type name="Text" c:type="AtkText*"/>
           </instance-parameter>
           <parameter name="offset" transfer-ownership="none">
-            <doc xml:space="preserve">position</doc>
+            <doc xml:space="preserve">a character offset within @text</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
         </parameters>
@@ -11112,11 +11355,11 @@ the selection</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="x" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
-            <doc xml:space="preserve">Pointer for the x cordinate of the bounding box</doc>
+            <doc xml:space="preserve">Pointer for the x coordinate of the bounding box</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
           <parameter name="y" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
-            <doc xml:space="preserve">Pointer for the y cordinate of the bounding box</doc>
+            <doc xml:space="preserve">Pointer for the y coordinate of the bounding box</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
           <parameter name="width" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
@@ -11244,7 +11487,7 @@ to atk_attribute_set_free().</doc>
             <type name="Text" c:type="AtkText*"/>
           </instance-parameter>
           <parameter name="offset" transfer-ownership="none">
-            <doc xml:space="preserve">the offset at which to get the attributes, -1 means the offset of
+            <doc xml:space="preserve">the character offset at which to get the attributes, -1 means the offset of
 the character to be inserted at the caret location.</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
@@ -11279,12 +11522,12 @@ moving or deleting a selected region can change the numbering.</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-            <doc xml:space="preserve">passes back the start position of the selected region</doc>
+            <doc xml:space="preserve">passes back the starting character offset of the selected region</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
           <parameter name="end_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-            <doc xml:space="preserve">passes back the end position of (e.g. offset immediately past)
-the selected region</doc>
+            <doc xml:space="preserve">passes back the ending character offset (offset immediately past)
+of the selected region</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
         </parameters>
@@ -11341,7 +11584,7 @@ of the following paragraph after the offset.</doc>
             <type name="TextGranularity" c:type="AtkTextGranularity"/>
           </parameter>
           <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-            <doc xml:space="preserve">the start offset of the returned string, or -1
+            <doc xml:space="preserve">the starting character offset of the returned string, or -1
                if an error has occurred (e.g. invalid offset, not implemented)</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
@@ -11365,11 +11608,11 @@ of the following paragraph after the offset.</doc>
             <type name="Text" c:type="AtkText*"/>
           </instance-parameter>
           <parameter name="start_offset" transfer-ownership="none">
-            <doc xml:space="preserve">start position</doc>
+            <doc xml:space="preserve">a starting character offset within @text</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="end_offset" transfer-ownership="none">
-            <doc xml:space="preserve">end position, or -1 for the end of the string.</doc>
+            <doc xml:space="preserve">an ending character offset within @text, or -1 for the end of the string.</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
         </parameters>
@@ -11396,7 +11639,7 @@ of the following paragraph after the offset.</doc>
             <type name="TextBoundary" c:type="AtkTextBoundary"/>
           </parameter>
           <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-            <doc xml:space="preserve">the start offset of the returned string</doc>
+            <doc xml:space="preserve">the starting character offset of the returned string</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
           <parameter name="end_offset" direction="out" caller-allocates="0" transfer-ownership="full">
@@ -11452,7 +11695,7 @@ start after the offset.</doc>
             <type name="TextBoundary" c:type="AtkTextBoundary"/>
           </parameter>
           <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-            <doc xml:space="preserve">the start offset of the returned string</doc>
+            <doc xml:space="preserve">the starting character offset of the returned string</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
           <parameter name="end_offset" direction="out" caller-allocates="0" transfer-ownership="full">
@@ -11484,7 +11727,7 @@ start after the offset.</doc>
             <type name="TextBoundary" c:type="AtkTextBoundary"/>
           </parameter>
           <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-            <doc xml:space="preserve">the start offset of the returned string</doc>
+            <doc xml:space="preserve">the starting character offset of the returned string</doc>
             <type name="gint" c:type="gint*"/>
           </parameter>
           <parameter name="end_offset" direction="out" caller-allocates="0" transfer-ownership="full">
@@ -11527,7 +11770,7 @@ moving or deleting a selected region can change the numbering.</doc>
             <type name="Text" c:type="AtkText*"/>
           </instance-parameter>
           <parameter name="offset" transfer-ownership="none">
-            <doc xml:space="preserve">position</doc>
+            <doc xml:space="preserve">the character offset of the new caret position</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
         </parameters>
@@ -11552,7 +11795,7 @@ moving or deleting a selected region can change the numbering.</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="start_offset" transfer-ownership="none">
-            <doc xml:space="preserve">the new start position of the selection</doc>
+            <doc xml:space="preserve">the new starting character offset of the selection</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="end_offset" transfer-ownership="none">
@@ -11903,11 +12146,11 @@ the following one, if present.</doc>
               <type name="Text" c:type="AtkText*"/>
             </parameter>
             <parameter name="start_offset" transfer-ownership="none">
-              <doc xml:space="preserve">start position</doc>
+              <doc xml:space="preserve">a starting character offset within @text</doc>
               <type name="gint" c:type="gint"/>
             </parameter>
             <parameter name="end_offset" transfer-ownership="none">
-              <doc xml:space="preserve">end position, or -1 for the end of the string.</doc>
+              <doc xml:space="preserve">an ending character offset within @text, or -1 for the end of the string.</doc>
               <type name="gint" c:type="gint"/>
             </parameter>
           </parameters>
@@ -11934,7 +12177,7 @@ the following one, if present.</doc>
               <type name="TextBoundary" c:type="AtkTextBoundary"/>
             </parameter>
             <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-              <doc xml:space="preserve">the start offset of the returned string</doc>
+              <doc xml:space="preserve">the starting character offset of the returned string</doc>
               <type name="gint" c:type="gint*"/>
             </parameter>
             <parameter name="end_offset" direction="out" caller-allocates="0" transfer-ownership="full">
@@ -11966,7 +12209,7 @@ the following one, if present.</doc>
               <type name="TextBoundary" c:type="AtkTextBoundary"/>
             </parameter>
             <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-              <doc xml:space="preserve">the start offset of the returned string</doc>
+              <doc xml:space="preserve">the starting character offset of the returned string</doc>
               <type name="gint" c:type="gint*"/>
             </parameter>
             <parameter name="end_offset" direction="out" caller-allocates="0" transfer-ownership="full">
@@ -11989,7 +12232,7 @@ the following one, if present.</doc>
               <type name="Text" c:type="AtkText*"/>
             </parameter>
             <parameter name="offset" transfer-ownership="none">
-              <doc xml:space="preserve">position</doc>
+              <doc xml:space="preserve">a character offset within @text</doc>
               <type name="gint" c:type="gint"/>
             </parameter>
           </parameters>
@@ -12016,7 +12259,7 @@ the following one, if present.</doc>
               <type name="TextBoundary" c:type="AtkTextBoundary"/>
             </parameter>
             <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-              <doc xml:space="preserve">the start offset of the returned string</doc>
+              <doc xml:space="preserve">the starting character offset of the returned string</doc>
               <type name="gint" c:type="gint*"/>
             </parameter>
             <parameter name="end_offset" direction="out" caller-allocates="0" transfer-ownership="full">
@@ -12030,7 +12273,7 @@ the following one, if present.</doc>
       <field name="get_caret_offset">
         <callback name="get_caret_offset">
           <return-value transfer-ownership="none">
-            <doc xml:space="preserve">the offset position of the caret (cursor).</doc>
+            <doc xml:space="preserve">the character offset of position of the caret (cursor).</doc>
             <type name="gint" c:type="gint"/>
           </return-value>
           <parameters>
@@ -12055,7 +12298,7 @@ to atk_attribute_set_free().</doc>
               <type name="Text" c:type="AtkText*"/>
             </parameter>
             <parameter name="offset" transfer-ownership="none">
-              <doc xml:space="preserve">the offset at which to get the attributes, -1 means the offset of
+              <doc xml:space="preserve">the character offset at which to get the attributes, -1 means the offset of
 the character to be inserted at the caret location.</doc>
               <type name="gint" c:type="gint"/>
             </parameter>
@@ -12101,11 +12344,11 @@ a call to atk_attribute_set_free().</doc>
               <type name="gint" c:type="gint"/>
             </parameter>
             <parameter name="x" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
-              <doc xml:space="preserve">Pointer for the x cordinate of the bounding box</doc>
+              <doc xml:space="preserve">Pointer for the x coordinate of the bounding box</doc>
               <type name="gint" c:type="gint*"/>
             </parameter>
             <parameter name="y" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
-              <doc xml:space="preserve">Pointer for the y cordinate of the bounding box</doc>
+              <doc xml:space="preserve">Pointer for the y coordinate of the bounding box</doc>
               <type name="gint" c:type="gint*"/>
             </parameter>
             <parameter name="width" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
@@ -12201,12 +12444,12 @@ moving or deleting a selected region can change the numbering.</doc>
               <type name="gint" c:type="gint"/>
             </parameter>
             <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-              <doc xml:space="preserve">passes back the start position of the selected region</doc>
+              <doc xml:space="preserve">passes back the starting character offset of the selected region</doc>
               <type name="gint" c:type="gint*"/>
             </parameter>
             <parameter name="end_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-              <doc xml:space="preserve">passes back the end position of (e.g. offset immediately past)
-the selected region</doc>
+              <doc xml:space="preserve">passes back the ending character offset (offset immediately past)
+of the selected region</doc>
               <type name="gint" c:type="gint*"/>
             </parameter>
           </parameters>
@@ -12224,7 +12467,7 @@ the selected region</doc>
               <type name="Text" c:type="AtkText*"/>
             </parameter>
             <parameter name="start_offset" transfer-ownership="none">
-              <doc xml:space="preserve">the start position of the selected region</doc>
+              <doc xml:space="preserve">the starting character offset of the selected region</doc>
               <type name="gint" c:type="gint"/>
             </parameter>
             <parameter name="end_offset" transfer-ownership="none">
@@ -12276,7 +12519,7 @@ moving or deleting a selected region can change the numbering.</doc>
               <type name="gint" c:type="gint"/>
             </parameter>
             <parameter name="start_offset" transfer-ownership="none">
-              <doc xml:space="preserve">the new start position of the selection</doc>
+              <doc xml:space="preserve">the new starting character offset of the selection</doc>
               <type name="gint" c:type="gint"/>
             </parameter>
             <parameter name="end_offset" transfer-ownership="none">
@@ -12299,7 +12542,7 @@ the selection</doc>
               <type name="Text" c:type="AtkText*"/>
             </parameter>
             <parameter name="offset" transfer-ownership="none">
-              <doc xml:space="preserve">position</doc>
+              <doc xml:space="preserve">the character offset of the new caret position</doc>
               <type name="gint" c:type="gint"/>
             </parameter>
           </parameters>
@@ -12396,22 +12639,31 @@ the selection</doc>
       <field name="get_bounded_ranges">
         <callback name="get_bounded_ranges">
           <return-value transfer-ownership="full">
-            <type name="TextRange" c:type="AtkTextRange**"/>
+            <doc xml:space="preserve">Array of AtkTextRange. The last
+         element of the array returned by this function will be NULL.</doc>
+            <array c:type="AtkTextRange**">
+              <type name="TextRange" c:type="AtkTextRange*"/>
+            </array>
           </return-value>
           <parameters>
             <parameter name="text" transfer-ownership="none">
+              <doc xml:space="preserve">an #AtkText</doc>
               <type name="Text" c:type="AtkText*"/>
             </parameter>
             <parameter name="rect" transfer-ownership="none">
+              <doc xml:space="preserve">An AtkTextRectangle giving the dimensions of the bounding box.</doc>
               <type name="TextRectangle" c:type="AtkTextRectangle*"/>
             </parameter>
             <parameter name="coord_type" transfer-ownership="none">
+              <doc xml:space="preserve">Specify whether coordinates are relative to the screen or widget window.</doc>
               <type name="CoordType" c:type="AtkCoordType"/>
             </parameter>
             <parameter name="x_clip_type" transfer-ownership="none">
+              <doc xml:space="preserve">Specify the horizontal clip type.</doc>
               <type name="TextClipType" c:type="AtkTextClipType"/>
             </parameter>
             <parameter name="y_clip_type" transfer-ownership="none">
+              <doc xml:space="preserve">Specify the vertical clip type.</doc>
               <type name="TextClipType" c:type="AtkTextClipType"/>
             </parameter>
           </parameters>
@@ -12440,7 +12692,7 @@ the selection</doc>
               <type name="TextGranularity" c:type="AtkTextGranularity"/>
             </parameter>
             <parameter name="start_offset" direction="out" caller-allocates="0" transfer-ownership="full">
-              <doc xml:space="preserve">the start offset of the returned string, or -1
+              <doc xml:space="preserve">the starting character offset of the returned string, or -1
                if an error has occurred (e.g. invalid offset, not implemented)</doc>
               <type name="gint" c:type="gint*"/>
             </parameter>

--- a/GIRepository-2.0.gir
+++ b/GIRepository-2.0.gir
@@ -1672,7 +1672,7 @@ g_base_info_unref() when done.</doc>
         </parameter>
         <parameter name="in_args" transfer-ownership="none">
           <doc xml:space="preserve">TODO</doc>
-          <array length="3" zero-terminated="0" c:type="GIArgument*">
+          <array length="3" zero-terminated="0" c:type="const GIArgument*">
             <type name="Argument" c:type="GIArgument"/>
           </array>
         </parameter>
@@ -1682,7 +1682,7 @@ g_base_info_unref() when done.</doc>
         </parameter>
         <parameter name="out_args" transfer-ownership="none">
           <doc xml:space="preserve">TODO</doc>
-          <array length="5" zero-terminated="0" c:type="GIArgument*">
+          <array length="5" zero-terminated="0" c:type="const GIArgument*">
             <type name="Argument" c:type="GIArgument"/>
           </array>
         </parameter>
@@ -2161,7 +2161,7 @@ have been g_module_symbol()&lt;!-- --&gt;ed before calling this function.</doc>
           <doc xml:space="preserve">an array of #GIArgument&lt;!-- --&gt;s, one for each in
    parameter of @info. If there are no in parameter, @in_args
    can be %NULL</doc>
-          <array length="2" zero-terminated="0" c:type="GIArgument*">
+          <array length="2" zero-terminated="0" c:type="const GIArgument*">
             <type name="Argument" c:type="GIArgument"/>
           </array>
         </parameter>
@@ -2173,7 +2173,7 @@ have been g_module_symbol()&lt;!-- --&gt;ed before calling this function.</doc>
           <doc xml:space="preserve">an array of #GIArgument&lt;!-- --&gt;s, one for each out
    parameter of @info. If there are no out parameters, @out_args
    may be %NULL</doc>
-          <array length="4" zero-terminated="0" c:type="GIArgument*">
+          <array length="4" zero-terminated="0" c:type="const GIArgument*">
             <type name="Argument" c:type="GIArgument"/>
           </array>
         </parameter>
@@ -3756,7 +3756,7 @@ argument lists.</doc>
           <doc xml:space="preserve">an array of #GIArgument&lt;!-- --&gt;s, one for each in
    parameter of @info. If there are no in parameter, @in_args
    can be %NULL</doc>
-          <array length="3" zero-terminated="0" c:type="GIArgument*">
+          <array length="3" zero-terminated="0" c:type="const GIArgument*">
             <type name="Argument" c:type="GIArgument"/>
           </array>
         </parameter>
@@ -3768,7 +3768,7 @@ argument lists.</doc>
           <doc xml:space="preserve">an array of #GIArgument&lt;!-- --&gt;s, one for each out
    parameter of @info. If there are no out parameters, @out_args
    may be %NULL</doc>
-          <array length="5" zero-terminated="0" c:type="GIArgument*">
+          <array length="5" zero-terminated="0" c:type="const GIArgument*">
             <type name="Argument" c:type="GIArgument"/>
           </array>
         </parameter>

--- a/GLib-2.0.gir
+++ b/GLib-2.0.gir
@@ -36,6 +36,9 @@ the g_spawn functions.</doc>
 particular string. A GQuark value of zero is associated to %NULL.</doc>
       <type name="guint32" c:type="guint32"/>
     </alias>
+    <alias name="RefString" c:type="GRefString">
+      <type name="gchar" c:type="char"/>
+    </alias>
     <alias name="Strv" c:type="GStrv">
       <doc xml:space="preserve">A typedef alias for gchar**. This is mostly useful when used together with
 g_auto().</doc>
@@ -171,7 +174,15 @@ functions.</doc>
         </parameters>
       </function>
       <function name="insert_vals" c:identifier="g_array_insert_vals" introspectable="0">
-        <doc xml:space="preserve">Inserts @len elements into a #GArray at the given index.</doc>
+        <doc xml:space="preserve">Inserts @len elements into a #GArray at the given index.
+
+If @index_ is greater than the array&#x2019;s current length, the array is expanded.
+The elements between the old end of the array and the newly inserted elements
+will be initialised to zero if the array was configured to clear elements;
+otherwise their values will be undefined.
+
+@data may be %NULL if (and only if) @len is zero. If @len is zero, this
+function is a no-op.</doc>
         <return-value>
           <doc xml:space="preserve">the #GArray</doc>
           <array name="GLib.Array" c:type="GArray*">
@@ -189,7 +200,7 @@ functions.</doc>
             <doc xml:space="preserve">the index to place the elements at</doc>
             <type name="guint" c:type="guint"/>
           </parameter>
-          <parameter name="data" transfer-ownership="none">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a pointer to the elements to insert</doc>
             <type name="gpointer" c:type="gconstpointer"/>
           </parameter>
@@ -227,6 +238,9 @@ functions.</doc>
       <function name="prepend_vals" c:identifier="g_array_prepend_vals" introspectable="0">
         <doc xml:space="preserve">Adds @len elements onto the start of the array.
 
+@data may be %NULL if (and only if) @len is zero. If @len is zero, this
+function is a no-op.
+
 This operation is slower than g_array_append_vals() since the
 existing elements in the array have to be moved to make space for
 the new elements.</doc>
@@ -243,12 +257,12 @@ the new elements.</doc>
               <type name="gpointer" c:type="gpointer"/>
             </array>
           </parameter>
-          <parameter name="data" transfer-ownership="none">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a pointer to the elements to prepend to the start of the array</doc>
             <type name="gpointer" c:type="gconstpointer"/>
           </parameter>
           <parameter name="len" transfer-ownership="none">
-            <doc xml:space="preserve">the number of elements to prepend</doc>
+            <doc xml:space="preserve">the number of elements to prepend, which may be zero</doc>
             <type name="guint" c:type="guint"/>
           </parameter>
         </parameters>
@@ -1205,8 +1219,8 @@ In the event the URI cannot be found, -1 is returned and
         </parameters>
       </method>
       <method name="get_app_info" c:identifier="g_bookmark_file_get_app_info" version="2.12" throws="1">
-        <doc xml:space="preserve">Gets the registration informations of @app_name for the bookmark for
-@uri.  See g_bookmark_file_set_app_info() for more informations about
+        <doc xml:space="preserve">Gets the registration information of @app_name for the bookmark for
+@uri.  See g_bookmark_file_set_app_info() for more information about
 the returned data.
 
 The string returned in @app_exec must be freed.
@@ -1583,7 +1597,7 @@ structure.  If the object cannot be created then @error is set to a
           <parameter name="data" transfer-ownership="none">
             <doc xml:space="preserve">desktop bookmarks
    loaded in memory</doc>
-            <array length="1" zero-terminated="0" c:type="gchar*">
+            <array length="1" zero-terminated="0" c:type="const gchar*">
               <type name="guint8"/>
             </array>
           </parameter>
@@ -1597,7 +1611,7 @@ structure.  If the object cannot be created then @error is set to a
         <doc xml:space="preserve">This function looks for a desktop bookmark file named @file in the
 paths returned from g_get_user_data_dir() and g_get_system_data_dirs(),
 loads the file into @bookmark and returns the file's full path in
-@full_path.  If the file could not be loaded then an %error is
+@full_path.  If the file could not be loaded then @error is
 set to either a #GFileError or #GBookmarkFileError.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE if a key file could be loaded, %FALSE otherwise</doc>
@@ -1864,7 +1878,7 @@ If @uri cannot be found then an item for it is created.</doc>
           <parameter name="groups" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">an array of
    group names, or %NULL to remove all groups</doc>
-            <array length="2" zero-terminated="0" c:type="gchar**">
+            <array length="2" zero-terminated="0" c:type="const gchar**">
               <type name="utf8"/>
             </array>
           </parameter>
@@ -2587,10 +2601,17 @@ been called to indicate that the bytes is no longer in use.
       <method name="compare" c:identifier="g_bytes_compare" version="2.32">
         <doc xml:space="preserve">Compares the two #GBytes values.
 
-This function can be used to sort GBytes instances in lexographical order.</doc>
+This function can be used to sort GBytes instances in lexicographical order.
+
+If @bytes1 and @bytes2 have different length but the shorter one is a
+prefix of the longer one then the shorter one is considered to be less than
+the longer one. Otherwise the first byte where both differ is used for
+comparison. If @bytes1 has a smaller value at that position it is
+considered less, otherwise greater than @bytes2.</doc>
         <return-value transfer-ownership="none">
-          <doc xml:space="preserve">a negative value if bytes2 is lesser, a positive value if bytes2 is
-         greater, and zero if bytes2 is equal to bytes1</doc>
+          <doc xml:space="preserve">a negative value if @bytes1 is less than @bytes2, a positive value
+         if @bytes1 is greater than @bytes2, and zero if @bytes1 is equal to
+         @bytes2</doc>
           <type name="gint" c:type="gint"/>
         </return-value>
         <parameters>
@@ -2879,9 +2900,11 @@ no longer be updated with g_checksum_update().</doc>
           </instance-parameter>
           <parameter name="buffer" transfer-ownership="none">
             <doc xml:space="preserve">output buffer</doc>
-            <type name="guint8" c:type="guint8*"/>
+            <array length="1" zero-terminated="0" c:type="guint8*">
+              <type name="guint8" c:type="guint8"/>
+            </array>
           </parameter>
-          <parameter name="digest_len" transfer-ownership="none">
+          <parameter name="digest_len" direction="inout" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">an inout parameter. The caller initializes it to the size of @buffer.
   After the call it contains the length of the digest.</doc>
             <type name="gsize" c:type="gsize*"/>
@@ -2934,7 +2957,7 @@ not have been called on @checksum.</doc>
           </instance-parameter>
           <parameter name="data" transfer-ownership="none">
             <doc xml:space="preserve">buffer used to compute the checksum</doc>
-            <array length="1" zero-terminated="0" c:type="guchar*">
+            <array length="1" zero-terminated="0" c:type="const guchar*">
               <type name="guint8"/>
             </array>
           </parameter>
@@ -3962,7 +3985,10 @@ the user's current timezone.
 
 To set the value of a date to the current day, you could write:
 |[&lt;!-- language="C" --&gt;
- g_date_set_time_t (date, time (NULL));
+ time_t now = time (NULL);
+ if (now == (time_t) -1)
+   // handle the error
+ g_date_set_time_t (date, now);
 ]|</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -5138,6 +5164,19 @@ including the fractional part.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the number of seconds</doc>
           <type name="gdouble" c:type="gdouble"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="datetime" transfer-ownership="none">
+            <doc xml:space="preserve">a #GDateTime</doc>
+            <type name="DateTime" c:type="GDateTime*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_timezone" c:identifier="g_date_time_get_timezone" version="2.58">
+        <doc xml:space="preserve">Get the time zone for this @datetime.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the time zone</doc>
+          <type name="TimeZone" c:type="GTimeZone*"/>
         </return-value>
         <parameters>
           <instance-parameter name="datetime" transfer-ownership="none">
@@ -6984,6 +7023,45 @@ without calling the key and value destroy functions.</doc>
           </parameter>
         </parameters>
       </function>
+      <function name="steal_extended" c:identifier="g_hash_table_steal_extended" version="2.58">
+        <doc xml:space="preserve">Looks up a key in the #GHashTable, stealing the original key and the
+associated value and returning %TRUE if the key was found. If the key was
+not found, %FALSE is returned.
+
+If found, the stolen key and value are removed from the hash table without
+calling the key and value destroy functions, and ownership is transferred to
+the caller of this method; as with g_hash_table_steal().
+
+You can pass %NULL for @lookup_key, provided the hash and equal functions
+of @hash_table are %NULL-safe.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the key was found in the #GHashTable</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="hash_table" transfer-ownership="none">
+            <doc xml:space="preserve">a #GHashTable</doc>
+            <type name="GLib.HashTable" c:type="GHashTable*">
+              <type name="gpointer" c:type="gpointer"/>
+              <type name="gpointer" c:type="gpointer"/>
+            </type>
+          </parameter>
+          <parameter name="lookup_key" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">the key to look up</doc>
+            <type name="gpointer" c:type="gconstpointer"/>
+          </parameter>
+          <parameter name="stolen_key" direction="out" caller-allocates="0" transfer-ownership="full" nullable="1" optional="1" allow-none="1">
+            <doc xml:space="preserve">return location for the
+   original key</doc>
+            <type name="gpointer" c:type="gpointer*"/>
+          </parameter>
+          <parameter name="stolen_value" direction="out" caller-allocates="0" transfer-ownership="full" nullable="1" optional="1" allow-none="1">
+            <doc xml:space="preserve">return location
+   for the value associated with the key</doc>
+            <type name="gpointer" c:type="gpointer*"/>
+          </parameter>
+        </parameters>
+      </function>
       <function name="unref" c:identifier="g_hash_table_unref" version="2.10">
         <doc xml:space="preserve">Atomically decrements the reference count of @hash_table by one.
 If the reference count drops to 0, all keys and values will be
@@ -7199,9 +7277,11 @@ no longer be updated with g_checksum_update().</doc>
           </instance-parameter>
           <parameter name="buffer" transfer-ownership="none">
             <doc xml:space="preserve">output buffer</doc>
-            <type name="guint8" c:type="guint8*"/>
+            <array length="1" zero-terminated="0" c:type="guint8*">
+              <type name="guint8" c:type="guint8"/>
+            </array>
           </parameter>
-          <parameter name="digest_len" transfer-ownership="none">
+          <parameter name="digest_len" direction="inout" caller-allocates="0" transfer-ownership="full">
             <doc xml:space="preserve">an inout parameter. The caller initializes it to the
   size of @buffer. After the call it contains the length of the digest</doc>
             <type name="gsize" c:type="gsize*"/>
@@ -7275,7 +7355,7 @@ g_hmac_get_digest() must not have been called on @hmac.</doc>
           </instance-parameter>
           <parameter name="data" transfer-ownership="none">
             <doc xml:space="preserve">buffer used to compute the checksum</doc>
-            <array length="1" zero-terminated="0" c:type="guchar*">
+            <array length="1" zero-terminated="0" c:type="const guchar*">
               <type name="guint8" c:type="guchar"/>
             </array>
           </parameter>
@@ -7314,7 +7394,7 @@ Support for %G_CHECKSUM_SHA384 was added in GLib 2.52.</doc>
           </parameter>
           <parameter name="key" transfer-ownership="none">
             <doc xml:space="preserve">the key for the HMAC</doc>
-            <array length="2" zero-terminated="0" c:type="guchar*">
+            <array length="2" zero-terminated="0" c:type="const guchar*">
               <type name="guint8" c:type="guchar"/>
             </array>
           </parameter>
@@ -8838,7 +8918,7 @@ cases described in the documentation for g_io_channel_set_encoding ().</doc>
           </instance-parameter>
           <parameter name="buf" transfer-ownership="none">
             <doc xml:space="preserve">a buffer to write data from</doc>
-            <array zero-terminated="0" c:type="gchar*">
+            <array zero-terminated="0" c:type="const gchar*">
               <type name="guint8"/>
             </array>
           </parameter>
@@ -10050,7 +10130,7 @@ file, a %G_FILE_ERROR is returned. If there is a problem parsing the file, a
           </parameter>
           <parameter name="search_dirs" transfer-ownership="none">
             <doc xml:space="preserve">%NULL-terminated array of directories to search</doc>
-            <array c:type="gchar**">
+            <array c:type="const gchar**">
               <type name="filename"/>
             </array>
           </parameter>
@@ -10490,7 +10570,7 @@ it is created.</doc>
           <parameter name="list" transfer-ownership="none">
             <doc xml:space="preserve">a %NULL-terminated array of locale string values</doc>
             <array length="4" zero-terminated="1" c:type="const gchar* const*">
-              <type name="utf8" c:type="gchar"/>
+              <type name="utf8" c:type="gchar*"/>
             </array>
           </parameter>
           <parameter name="length" transfer-ownership="none">
@@ -10885,8 +10965,10 @@ a copy of each list element, in addition to copying the list
 container itself.
 
 @func, as a #GCopyFunc, takes two arguments, the data to be copied
-and a @user_data pointer. It's safe to pass %NULL as user_data,
-if the copy function takes only one argument.
+and a @user_data pointer. On common processor architectures, it's safe to
+pass %NULL as @user_data if the copy function takes only one argument. You
+may get compiler warnings from this though if compiling with GCC&#x2019;s
+`-Wcast-function-type` warning.
 
 For instance, if @list holds a list of GObjects, you can do:
 |[&lt;!-- language="C" --&gt;
@@ -11691,7 +11773,7 @@ chained and fall back to simpler handlers in case of failure.</doc>
         </parameter>
         <parameter name="fields" transfer-ownership="none">
           <doc xml:space="preserve">fields forming the message</doc>
-          <array length="2" zero-terminated="0" c:type="GLogField*">
+          <array length="2" zero-terminated="0" c:type="const GLogField*">
             <type name="LogField" c:type="GLogField"/>
           </array>
         </parameter>
@@ -11783,7 +11865,7 @@ linked against at application run time.</doc>
       <doc xml:space="preserve">The minimum value which can be held in a #gint8.</doc>
       <type name="gint8" c:type="gint8"/>
     </constant>
-    <constant name="MINOR_VERSION" value="56" c:type="GLIB_MINOR_VERSION">
+    <constant name="MINOR_VERSION" value="58" c:type="GLIB_MINOR_VERSION">
       <doc xml:space="preserve">The minor version number of the GLib library.
 
 Like #gtk_minor_version, but from the headers used at
@@ -12316,12 +12398,13 @@ the result is zero, free the context and free all associated memory.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="wait" c:identifier="g_main_context_wait">
+      <method name="wait" c:identifier="g_main_context_wait" deprecated="1" deprecated-version="2.58">
         <doc xml:space="preserve">Tries to become the owner of the specified context,
 as with g_main_context_acquire(). But if another thread
 is the owner, atomically drop @mutex and wait on @cond until
 that owner releases ownership or until @cond is signaled, then
 try again (once) to become the owner.</doc>
+        <doc-deprecated xml:space="preserve">Use g_main_context_is_owner() and separate locking instead.</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE if the operation succeeded, and
   this thread is now the owner of @context.</doc>
@@ -15348,7 +15431,7 @@ which have been added to a #GOptionContext.</doc>
       <method name="ref" c:identifier="g_option_group_ref" version="2.44">
         <doc xml:space="preserve">Increments the reference count of @group by one.</doc>
         <return-value transfer-ownership="full">
-          <doc xml:space="preserve">a #GoptionGroup</doc>
+          <doc xml:space="preserve">a #GOptionGroup</doc>
           <type name="OptionGroup" c:type="GOptionGroup*"/>
         </return-value>
         <parameters>
@@ -16048,7 +16131,8 @@ pointer was not found.</doc>
         <doc xml:space="preserve">Removes the pointer at the given index from the pointer array.
 The following elements are moved down one place. If @array has
 a non-%NULL #GDestroyNotify function it is called for the removed
-element.</doc>
+element. If so, the return value from this function will potentially point
+to freed memory (depending on the #GDestroyNotify implementation).</doc>
         <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">the pointer which was removed</doc>
           <type name="gpointer" c:type="gpointer"/>
@@ -16071,7 +16155,9 @@ element.</doc>
 The last element in the array is used to fill in the space, so
 this function does not preserve the order of the array. But it
 is faster than g_ptr_array_remove_index(). If @array has a non-%NULL
-#GDestroyNotify function it is called for the removed element.</doc>
+#GDestroyNotify function it is called for the removed element. If so, the
+return value from this function will potentially point to freed memory
+(depending on the #GDestroyNotify implementation).</doc>
         <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">the pointer which was removed</doc>
           <type name="gpointer" c:type="gpointer"/>
@@ -16230,6 +16316,52 @@ This is guaranteed to be a stable sort since version 2.32.</doc>
           <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">data to pass to @compare_func</doc>
             <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="steal_index" c:identifier="g_ptr_array_steal_index" version="2.58" introspectable="0">
+        <doc xml:space="preserve">Removes the pointer at the given index from the pointer array.
+The following elements are moved down one place. The #GDestroyNotify for
+@array is *not* called on the removed element; ownership is transferred to
+the caller of this function.</doc>
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">the pointer which was removed</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </return-value>
+        <parameters>
+          <parameter name="array" transfer-ownership="none">
+            <doc xml:space="preserve">a #GPtrArray</doc>
+            <array name="GLib.PtrArray" c:type="GPtrArray*">
+              <type name="gpointer" c:type="gpointer"/>
+            </array>
+          </parameter>
+          <parameter name="index_" transfer-ownership="none">
+            <doc xml:space="preserve">the index of the pointer to steal</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="steal_index_fast" c:identifier="g_ptr_array_steal_index_fast" version="2.58" introspectable="0">
+        <doc xml:space="preserve">Removes the pointer at the given index from the pointer array.
+The last element in the array is used to fill in the space, so
+this function does not preserve the order of the array. But it
+is faster than g_ptr_array_steal_index(). The #GDestroyNotify for @array is
+*not* called on the removed element; ownership is transferred to the caller
+of this function.</doc>
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">the pointer which was removed</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </return-value>
+        <parameters>
+          <parameter name="array" transfer-ownership="none">
+            <doc xml:space="preserve">a #GPtrArray</doc>
+            <array name="GLib.PtrArray" c:type="GPtrArray*">
+              <type name="gpointer" c:type="gpointer"/>
+            </array>
+          </parameter>
+          <parameter name="index_" transfer-ownership="none">
+            <doc xml:space="preserve">the index of the pointer to steal</doc>
+            <type name="guint" c:type="guint"/>
           </parameter>
         </parameters>
       </function>
@@ -17727,10 +17859,12 @@ the string passed to g_regex_new().</doc>
         </parameters>
       </method>
       <method name="match" c:identifier="g_regex_match" version="2.14">
-        <doc xml:space="preserve">Scans for a match in string for the pattern in @regex.
+        <doc xml:space="preserve">Scans for a match in @string for the pattern in @regex.
 The @match_options are combined with the match options specified
 when the @regex structure was created, letting you have more
 flexibility in reusing #GRegex structures.
+
+Unless %G_REGEX_RAW is specified in the options, @string must be valid UTF-8.
 
 A #GMatchInfo structure, used to get information on the match,
 is stored in @match_info if not %NULL. Note that if @match_info
@@ -17830,7 +17964,7 @@ freeing or modifying @string then the behaviour is undefined.</doc>
       </method>
       <method name="match_all_full" c:identifier="g_regex_match_all_full" version="2.14" throws="1">
         <doc xml:space="preserve">Using the standard algorithm for regular expression matching only
-the longest match in the string is retrieved, it is not possible
+the longest match in the @string is retrieved, it is not possible
 to obtain all the available matches. For instance matching
 "&lt;a&gt; &lt;b&gt; &lt;c&gt;" against the pattern "&lt;.*&gt;"
 you get "&lt;a&gt; &lt;b&gt; &lt;c&gt;".
@@ -17856,6 +17990,8 @@ Setting @start_position differs from just passing over a shortened
 string and setting #G_REGEX_MATCH_NOTBOL in the case of a pattern
 that begins with any kind of lookbehind assertion, such as "\b".
 
+Unless %G_REGEX_RAW is specified in the options, @string must be valid UTF-8.
+
 A #GMatchInfo structure, used to get information on the match, is
 stored in @match_info if not %NULL. Note that if @match_info is
 not %NULL then it is created even if the function returns %FALSE,
@@ -17876,12 +18012,12 @@ freeing or modifying @string then the behaviour is undefined.</doc>
           </instance-parameter>
           <parameter name="string" transfer-ownership="none">
             <doc xml:space="preserve">the string to scan for matches</doc>
-            <array length="1" zero-terminated="0" c:type="gchar*">
+            <array length="1" zero-terminated="0" c:type="const gchar*">
               <type name="utf8" c:type="gchar"/>
             </array>
           </parameter>
           <parameter name="string_len" transfer-ownership="none">
-            <doc xml:space="preserve">the length of @string, or -1 if @string is nul-terminated</doc>
+            <doc xml:space="preserve">the length of @string, in bytes, or -1 if @string is nul-terminated</doc>
             <type name="gssize" c:type="gssize"/>
           </parameter>
           <parameter name="start_position" transfer-ownership="none">
@@ -17900,7 +18036,7 @@ freeing or modifying @string then the behaviour is undefined.</doc>
         </parameters>
       </method>
       <method name="match_full" c:identifier="g_regex_match_full" version="2.14" throws="1">
-        <doc xml:space="preserve">Scans for a match in string for the pattern in @regex.
+        <doc xml:space="preserve">Scans for a match in @string for the pattern in @regex.
 The @match_options are combined with the match options specified
 when the @regex structure was created, letting you have more
 flexibility in reusing #GRegex structures.
@@ -17908,6 +18044,8 @@ flexibility in reusing #GRegex structures.
 Setting @start_position differs from just passing over a shortened
 string and setting #G_REGEX_MATCH_NOTBOL in the case of a pattern
 that begins with any kind of lookbehind assertion, such as "\b".
+
+Unless %G_REGEX_RAW is specified in the options, @string must be valid UTF-8.
 
 A #GMatchInfo structure, used to get information on the match, is
 stored in @match_info if not %NULL. Note that if @match_info is
@@ -17960,12 +18098,12 @@ print_uppercase_words (const gchar *string)
           </instance-parameter>
           <parameter name="string" transfer-ownership="none">
             <doc xml:space="preserve">the string to scan for matches</doc>
-            <array length="1" zero-terminated="0" c:type="gchar*">
+            <array length="1" zero-terminated="0" c:type="const gchar*">
               <type name="utf8" c:type="gchar"/>
             </array>
           </parameter>
           <parameter name="string_len" transfer-ownership="none">
-            <doc xml:space="preserve">the length of @string, or -1 if @string is nul-terminated</doc>
+            <doc xml:space="preserve">the length of @string, in bytes, or -1 if @string is nul-terminated</doc>
             <type name="gssize" c:type="gssize"/>
           </parameter>
           <parameter name="start_position" transfer-ownership="none">
@@ -18034,12 +18172,12 @@ begins with any kind of lookbehind assertion, such as "\b".</doc>
           </instance-parameter>
           <parameter name="string" transfer-ownership="none">
             <doc xml:space="preserve">the string to perform matches against</doc>
-            <array length="1" zero-terminated="0" c:type="gchar*">
+            <array length="1" zero-terminated="0" c:type="const gchar*">
               <type name="utf8" c:type="gchar"/>
             </array>
           </parameter>
           <parameter name="string_len" transfer-ownership="none">
-            <doc xml:space="preserve">the length of @string, or -1 if @string is nul-terminated</doc>
+            <doc xml:space="preserve">the length of @string, in bytes, or -1 if @string is nul-terminated</doc>
             <type name="gssize" c:type="gssize"/>
           </parameter>
           <parameter name="start_position" transfer-ownership="none">
@@ -18113,12 +18251,12 @@ g_hash_table_destroy (h);
           </instance-parameter>
           <parameter name="string" transfer-ownership="none">
             <doc xml:space="preserve">string to perform matches against</doc>
-            <array length="1" zero-terminated="0" c:type="gchar*">
+            <array length="1" zero-terminated="0" c:type="const gchar*">
               <type name="utf8" c:type="gchar"/>
             </array>
           </parameter>
           <parameter name="string_len" transfer-ownership="none">
-            <doc xml:space="preserve">the length of @string, or -1 if @string is nul-terminated</doc>
+            <doc xml:space="preserve">the length of @string, in bytes, or -1 if @string is nul-terminated</doc>
             <type name="gssize" c:type="gssize"/>
           </parameter>
           <parameter name="start_position" transfer-ownership="none">
@@ -18159,12 +18297,12 @@ assertion, such as "\b".</doc>
           </instance-parameter>
           <parameter name="string" transfer-ownership="none">
             <doc xml:space="preserve">the string to perform matches against</doc>
-            <array length="1" zero-terminated="0" c:type="gchar*">
+            <array length="1" zero-terminated="0" c:type="const gchar*">
               <type name="utf8" c:type="gchar"/>
             </array>
           </parameter>
           <parameter name="string_len" transfer-ownership="none">
-            <doc xml:space="preserve">the length of @string, or -1 if @string is nul-terminated</doc>
+            <doc xml:space="preserve">the length of @string, in bytes, or -1 if @string is nul-terminated</doc>
             <type name="gssize" c:type="gssize"/>
           </parameter>
           <parameter name="start_position" transfer-ownership="none">
@@ -18257,12 +18395,12 @@ it using g_strfreev()</doc>
           </instance-parameter>
           <parameter name="string" transfer-ownership="none">
             <doc xml:space="preserve">the string to split with the pattern</doc>
-            <array length="1" zero-terminated="0" c:type="gchar*">
+            <array length="1" zero-terminated="0" c:type="const gchar*">
               <type name="utf8" c:type="gchar"/>
             </array>
           </parameter>
           <parameter name="string_len" transfer-ownership="none">
-            <doc xml:space="preserve">the length of @string, or -1 if @string is nul-terminated</doc>
+            <doc xml:space="preserve">the length of @string, in bytes, or -1 if @string is nul-terminated</doc>
             <type name="gssize" c:type="gssize"/>
           </parameter>
           <parameter name="start_position" transfer-ownership="none">
@@ -18360,12 +18498,12 @@ in @length.</doc>
         <parameters>
           <parameter name="string" transfer-ownership="none">
             <doc xml:space="preserve">the string to escape</doc>
-            <array length="1" zero-terminated="0" c:type="gchar*">
+            <array length="1" zero-terminated="0" c:type="const gchar*">
               <type name="utf8" c:type="gchar"/>
             </array>
           </parameter>
           <parameter name="length" transfer-ownership="none">
-            <doc xml:space="preserve">the length of @string, or -1 if @string is nul-terminated</doc>
+            <doc xml:space="preserve">the length of @string, in bytes, or -1 if @string is nul-terminated</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
         </parameters>
@@ -19045,9 +19183,11 @@ to copy the data as well.</doc>
 In contrast with g_slist_copy(), this function uses @func to make a copy of
 each list element, in addition to copying the list container itself.
 
-@func, as a #GCopyFunc, takes two arguments, the data to be copied and a user
-pointer. It's safe to pass #NULL as user_data, if the copy function takes only
-one argument.
+@func, as a #GCopyFunc, takes two arguments, the data to be copied
+and a @user_data pointer. On common processor architectures, it's safe to
+pass %NULL as @user_data if the copy function takes only one argument. You
+may get compiler warnings from this though if compiling with GCC&#x2019;s
+`-Wcast-function-type` warning.
 
 For instance, if @list holds a list of GObjects, you can do:
 |[&lt;!-- language="C" --&gt;
@@ -19059,7 +19199,7 @@ And, to entirely free the new list, you could do:
 g_slist_free_full (another_list, g_object_unref);
 ]|</doc>
         <return-value>
-          <doc xml:space="preserve">a full copy of @list, use #g_slist_free_full to free it</doc>
+          <doc xml:space="preserve">a full copy of @list, use g_slist_free_full() to free it</doc>
           <type name="GLib.SList" c:type="GSList*">
             <type name="gpointer" c:type="gpointer"/>
           </type>
@@ -20505,14 +20645,14 @@ when comparing the length to zero.</doc>
         </parameters>
       </method>
       <method name="insert_sorted" c:identifier="g_sequence_insert_sorted" version="2.14" introspectable="0">
-        <doc xml:space="preserve">Inserts @data into @sequence using @func to determine the new
+        <doc xml:space="preserve">Inserts @data into @seq using @cmp_func to determine the new
 position. The sequence must already be sorted according to @cmp_func;
 otherwise the new position of @data is undefined.
 
-@cmp_func is called with two items of the @seq and @user_data.
+@cmp_func is called with two items of the @seq, and @cmp_data.
 It should return 0 if the items are equal, a negative value
 if the first item comes before the second, and a positive value
-if the second  item comes before the first.
+if the second item comes before the first.
 
 Note that when adding a large amount of data to a #GSequence,
 it is more efficient to do unsorted insertions and then call
@@ -20550,11 +20690,6 @@ It should return 0 if the iterators are equal, a negative
 value if the first iterator comes before the second, and a
 positive value if the second iterator comes before the first.
 
-It is called with two iterators pointing into @seq. It should
-return 0 if the iterators are equal, a negative value if the
-first iterator comes before the second, and a positive value
-if the second iterator comes before the first.
-
 Note that when adding a large amount of data to a #GSequence,
 it is more efficient to do unsorted insertions and then call
 g_sequence_sort() or g_sequence_sort_iter().</doc>
@@ -20576,7 +20711,7 @@ g_sequence_sort() or g_sequence_sort_iter().</doc>
             <type name="SequenceIterCompareFunc" c:type="GSequenceIterCompareFunc"/>
           </parameter>
           <parameter name="cmp_data" transfer-ownership="none" nullable="1" allow-none="1">
-            <doc xml:space="preserve">user data passed to @cmp_func</doc>
+            <doc xml:space="preserve">user data passed to @iter_cmp</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
         </parameters>
@@ -20605,7 +20740,7 @@ item is equal, it is not guaranteed that it is the first which is
 returned. In that case, you can use g_sequence_iter_next() and
 g_sequence_iter_prev() to get others.
 
-@cmp_func is called with two items of the @seq and @user_data.
+@cmp_func is called with two items of the @seq, and @cmp_data.
 It should return 0 if the items are equal, a negative value if
 the first item comes before the second, and a positive value if
 the second item comes before the first.
@@ -20650,7 +20785,7 @@ This function will fail if the data contained in the sequence is
 unsorted.</doc>
         <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">an #GSequenceIter pointing to the position of
-    the first item found equal to @data according to @cmp_func
+    the first item found equal to @data according to @iter_cmp
     and @cmp_data, or %NULL if no such item exists</doc>
           <type name="SequenceIter" c:type="GSequenceIter*"/>
         </return-value>
@@ -20694,7 +20829,7 @@ unsorted.</doc>
         <doc xml:space="preserve">Returns an iterator pointing to the position where @data would
 be inserted according to @cmp_func and @cmp_data.
 
-@cmp_func is called with two items of the @seq and @user_data.
+@cmp_func is called with two items of the @seq, and @cmp_data.
 It should return 0 if the items are equal, a negative value if
 the first item comes before the second, and a positive value if
 the second item comes before the first.
@@ -20794,7 +20929,7 @@ if the second comes before the first.</doc>
       </method>
       <method name="sort_iter" c:identifier="g_sequence_sort_iter" version="2.14" introspectable="0">
         <doc xml:space="preserve">Like g_sequence_sort(), but uses a #GSequenceIterCompareFunc instead
-of a GCompareDataFunc as the compare function
+of a #GCompareDataFunc as the compare function
 
 @cmp_func is called with two iterators pointing into @seq. It should
 return 0 if the iterators are equal, a negative value if the first
@@ -20895,13 +21030,13 @@ sequences.</doc>
         </parameters>
       </function>
       <function name="move_range" c:identifier="g_sequence_move_range" version="2.14">
-        <doc xml:space="preserve">Inserts the (@begin, @end) range at the destination pointed to by ptr.
+        <doc xml:space="preserve">Inserts the (@begin, @end) range at the destination pointed to by @dest.
 The @begin and @end iters must point into the same sequence. It is
 allowed for @dest to point to a different sequence than the one pointed
 into by @begin and @end.
 
-If @dest is NULL, the range indicated by @begin and @end is
-removed from the sequence. If @dest iter points to a place within
+If @dest is %NULL, the range indicated by @begin and @end is
+removed from the sequence. If @dest points to a place within
 the (@begin, @end) range, the range does not move.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -21013,12 +21148,13 @@ function is called on the existing data that @iter pointed to.</doc>
         </parameters>
       </function>
       <function name="sort_changed" c:identifier="g_sequence_sort_changed" version="2.14" introspectable="0">
-        <doc xml:space="preserve">Moves the data pointed to a new position as indicated by @cmp_func. This
+        <doc xml:space="preserve">Moves the data pointed to by @iter to a new position as indicated by
+@cmp_func. This
 function should be called for items in a sequence already sorted according
 to @cmp_func whenever some aspect of an item changes so that @cmp_func
 may return different values for that item.
 
-@cmp_func is called with two items of the @seq and @user_data.
+@cmp_func is called with two items of the @seq, and @cmp_data.
 It should return 0 if the items are equal, a negative value if
 the first item comes before the second, and a positive value if
 the second item comes before the first.</doc>
@@ -21045,7 +21181,8 @@ the second item comes before the first.</doc>
 a #GSequenceIterCompareFunc instead of a #GCompareDataFunc as
 the compare function.
 
-@iter_cmp is called with two iterators pointing into @seq. It should
+@iter_cmp is called with two iterators pointing into the #GSequence that
+@iter points into. It should
 return 0 if the iterators are equal, a negative value if the first
 iterator comes before the second, and a positive value if the second
 iterator comes before the first.</doc>
@@ -21516,7 +21653,12 @@ g_get_current_time().</doc>
         <doc xml:space="preserve">Returns the numeric ID for a particular source. The ID of a source
 is a positive integer which is unique within a particular main loop
 context. The reverse
-mapping from ID to source is done by g_main_context_find_source_by_id().</doc>
+mapping from ID to source is done by g_main_context_find_source_by_id().
+
+You can only call this function while the source is associated to a
+#GMainContext instance; calling this function before g_source_attach()
+or after g_source_destroy() yields undefined behavior. The ID returned
+is unique within the #GMainContext instance passed to g_source_attach().</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the ID (greater than 0) for the source</doc>
           <type name="guint" c:type="guint"/>
@@ -21809,7 +21951,8 @@ called from the source's dispatch function.
 
 The exact type of @func depends on the type of source; ie. you
 should not count on @func being called with @data as its first
-parameter.
+parameter. Cast @func with G_SOURCE_FUNC() to avoid warnings about
+incompatible function types.
 
 See [memory management of sources][mainloop-memory-management] for details
 on how to handle memory management of @data.
@@ -22161,7 +22304,11 @@ which cannot be used here for dependency reasons.</doc>
     </callback>
     <callback name="SourceFunc" c:type="GSourceFunc">
       <doc xml:space="preserve">Specifies the type of function passed to g_timeout_add(),
-g_timeout_add_full(), g_idle_add(), and g_idle_add_full().</doc>
+g_timeout_add_full(), g_idle_add(), and g_idle_add_full().
+
+When calling g_source_set_callback(), you may need to cast a function of a
+different type to this type. Use G_SOURCE_FUNC() to avoid warnings about
+incompatible function types.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">%FALSE if the source should be removed. #G_SOURCE_CONTINUE and
 #G_SOURCE_REMOVE are more memorable names for the return value.</doc>
@@ -24127,7 +24274,9 @@ UNIX system call.
 
 GLib is attempting to unify around the use of 64bit integers to
 represent microsecond-precision time. As such, this type will be
-removed from a future version of GLib.</doc>
+removed from a future version of GLib. A consequence of using `glong` for
+`tv_sec` is that on 32-bit systems `GTimeVal` is subject to the year 2038
+problem.</doc>
       <field name="tv_sec" writable="1">
         <doc xml:space="preserve">seconds</doc>
         <type name="glong" c:type="glong"/>
@@ -24176,10 +24325,12 @@ Use g_date_time_format() or g_strdup_printf() if a different
 variation of ISO 8601 format is required.
 
 If @time_ represents a date which is too large to fit into a `struct tm`,
-%NULL will be returned. This is platform dependent, but it is safe to assume
-years up to 3000 are supported. The return value of g_time_val_to_iso8601()
-has been nullable since GLib 2.54; before then, GLib would crash under the
-same conditions.</doc>
+%NULL will be returned. This is platform dependent. Note also that since
+`GTimeVal` stores the number of seconds as a `glong`, on 32-bit systems it
+is subject to the year 2038 problem.
+
+The return value of g_time_val_to_iso8601() has been nullable since GLib
+2.54; before then, GLib would crash under the same conditions.</doc>
         <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">a newly allocated string containing an ISO 8601 date,
    or %NULL if @time_ was too large</doc>
@@ -24199,7 +24350,9 @@ to a #GTimeVal and puts it into @time_.
 @iso_date must include year, month, day, hours, minutes, and
 seconds. It can optionally include fractions of a second and a time
 zone indicator. (In the absence of any time zone indication, the
-timestamp is assumed to be in local time.)</doc>
+timestamp is assumed to be in local time.)
+
+Any leading or trailing space in @iso_date is ignored.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE if the conversion was successful.</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -24309,6 +24462,23 @@ when you are done with it.</doc>
           <type name="TimeZone" c:type="GTimeZone*"/>
         </return-value>
       </constructor>
+      <constructor name="new_offset" c:identifier="g_time_zone_new_offset" version="2.58">
+        <doc xml:space="preserve">Creates a #GTimeZone corresponding to the given constant offset from UTC,
+in seconds.
+
+This is equivalent to calling g_time_zone_new() with a string in the form
+`[+|-]hh[:mm[:ss]]`.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a timezone at the given offset from UTC</doc>
+          <type name="TimeZone" c:type="GTimeZone*"/>
+        </return-value>
+        <parameters>
+          <parameter name="seconds" transfer-ownership="none">
+            <doc xml:space="preserve">offset to UTC, in seconds</doc>
+            <type name="gint32" c:type="gint32"/>
+          </parameter>
+        </parameters>
+      </constructor>
       <constructor name="new_utc" c:identifier="g_time_zone_new_utc" version="2.26">
         <doc xml:space="preserve">Creates a #GTimeZone corresponding to UTC.
 
@@ -24416,6 +24586,26 @@ is in effect.</doc>
             <doc xml:space="preserve">an interval within the timezone</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
+        </parameters>
+      </method>
+      <method name="get_identifier" c:identifier="g_time_zone_get_identifier" version="2.58">
+        <doc xml:space="preserve">Get the identifier of this #GTimeZone, as passed to g_time_zone_new().
+If the identifier passed at construction time was not recognised, `UTC` will
+be returned. If it was %NULL, the identifier of the local timezone at
+construction time will be returned.
+
+The identifier will be returned in the same format as provided at
+construction time: if provided as a time offset, that will be returned by
+this function.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">identifier for this timezone</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="tz" transfer-ownership="none">
+            <doc xml:space="preserve">a #GTimeZone</doc>
+            <type name="TimeZone" c:type="GTimeZone*"/>
+          </instance-parameter>
         </parameters>
       </method>
       <method name="get_offset" c:identifier="g_time_zone_get_offset" version="2.26">
@@ -25873,6 +26063,27 @@ See [Unicode Standard Annex #24: Script names](http://www.unicode.org/reports/tr
       <member name="zanabazar_square" value="141" c:identifier="G_UNICODE_SCRIPT_ZANABAZAR_SQUARE">
         <doc xml:space="preserve">Zanabazar Square. Since: 2.54</doc>
       </member>
+      <member name="dogra" value="142" c:identifier="G_UNICODE_SCRIPT_DOGRA">
+        <doc xml:space="preserve">Dogra. Since: 2.58</doc>
+      </member>
+      <member name="gunjala_gondi" value="143" c:identifier="G_UNICODE_SCRIPT_GUNJALA_GONDI">
+        <doc xml:space="preserve">Gunjala Gondi. Since: 2.58</doc>
+      </member>
+      <member name="hanifi_rohingya" value="144" c:identifier="G_UNICODE_SCRIPT_HANIFI_ROHINGYA">
+        <doc xml:space="preserve">Hanifi Rohingya. Since: 2.58</doc>
+      </member>
+      <member name="makasar" value="145" c:identifier="G_UNICODE_SCRIPT_MAKASAR">
+        <doc xml:space="preserve">Makasar. Since: 2.58</doc>
+      </member>
+      <member name="medefaidrin" value="146" c:identifier="G_UNICODE_SCRIPT_MEDEFAIDRIN">
+        <doc xml:space="preserve">Medefaidrin. Since: 2.58</doc>
+      </member>
+      <member name="old_sogdian" value="147" c:identifier="G_UNICODE_SCRIPT_OLD_SOGDIAN">
+        <doc xml:space="preserve">Old Sogdian. Since: 2.58</doc>
+      </member>
+      <member name="sogdian" value="148" c:identifier="G_UNICODE_SCRIPT_SOGDIAN">
+        <doc xml:space="preserve">Sogdian. Since: 2.58</doc>
+      </member>
     </enumeration>
     <enumeration name="UnicodeType" c:type="GUnicodeType">
       <doc xml:space="preserve">These are the possible character classifications from the
@@ -26360,7 +26571,7 @@ new instance takes ownership of them as if via g_variant_ref_sink().</doc>
           <parameter name="children" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">an array of
            #GVariant pointers, the children</doc>
-            <array length="2" zero-terminated="0" c:type="GVariant**">
+            <array length="2" zero-terminated="0" c:type="GVariant* const*">
               <type name="Variant" c:type="GVariant*"/>
             </array>
           </parameter>
@@ -26392,7 +26603,7 @@ new instance takes ownership of them as if via g_variant_ref_sink().</doc>
         <parameters>
           <parameter name="value" transfer-ownership="none">
             <doc xml:space="preserve">a #guint8 value</doc>
-            <type name="guint8" c:type="guchar"/>
+            <type name="guint8" c:type="guint8"/>
           </parameter>
         </parameters>
       </constructor>
@@ -26411,7 +26622,7 @@ the array.</doc>
           <parameter name="string" transfer-ownership="none">
             <doc xml:space="preserve">a normal
          nul-terminated string in no particular encoding</doc>
-            <array c:type="gchar*">
+            <array c:type="const gchar*">
               <type name="guint8"/>
             </array>
           </parameter>
@@ -26429,7 +26640,7 @@ If @length is -1 then @strv is %NULL-terminated.</doc>
         <parameters>
           <parameter name="strv" transfer-ownership="none">
             <doc xml:space="preserve">an array of strings</doc>
-            <array length="1" zero-terminated="0" c:type="gchar**">
+            <array length="1" zero-terminated="0" c:type="const gchar* const*">
               <type name="utf8" c:type="gchar*"/>
             </array>
           </parameter>
@@ -26705,7 +26916,7 @@ If @length is -1 then @strv is %NULL-terminated.</doc>
         <parameters>
           <parameter name="strv" transfer-ownership="none">
             <doc xml:space="preserve">an array of strings</doc>
-            <array length="1" zero-terminated="0" c:type="gchar**">
+            <array length="1" zero-terminated="0" c:type="const gchar* const*">
               <type name="utf8"/>
             </array>
           </parameter>
@@ -26866,7 +27077,7 @@ If @length is -1 then @strv is %NULL-terminated.</doc>
         <parameters>
           <parameter name="strv" transfer-ownership="none">
             <doc xml:space="preserve">an array of strings</doc>
-            <array length="1" zero-terminated="0" c:type="gchar**">
+            <array length="1" zero-terminated="0" c:type="const gchar* const*">
               <type name="utf8"/>
             </array>
           </parameter>
@@ -26916,7 +27127,7 @@ new instance takes ownership of them as if via g_variant_ref_sink().</doc>
         <parameters>
           <parameter name="children" transfer-ownership="none">
             <doc xml:space="preserve">the items to make the tuple out of</doc>
-            <array length="1" zero-terminated="0" c:type="GVariant**">
+            <array length="1" zero-terminated="0" c:type="GVariant* const*">
               <type name="Variant" c:type="GVariant*"/>
             </array>
           </parameter>
@@ -27353,8 +27564,8 @@ other than %G_VARIANT_TYPE_BOOLEAN.</doc>
 It is an error to call this function with a @value of any type
 other than %G_VARIANT_TYPE_BYTE.</doc>
         <return-value transfer-ownership="none">
-          <doc xml:space="preserve">a #guchar</doc>
-          <type name="guint8" c:type="guchar"/>
+          <doc xml:space="preserve">a #guint8</doc>
+          <type name="guint8" c:type="guint8"/>
         </return-value>
         <parameters>
           <instance-parameter name="value" transfer-ownership="none">
@@ -27385,7 +27596,7 @@ The return value remains valid as long as @value exists.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">
          the constant string</doc>
-          <array c:type="gchar*">
+          <array c:type="const gchar*">
             <type name="guint8"/>
           </array>
         </return-value>
@@ -27409,7 +27620,7 @@ For an empty array, @length will be set to 0 and a pointer to a
 %NULL pointer will be returned.</doc>
         <return-value transfer-ownership="container">
           <doc xml:space="preserve">an array of constant strings</doc>
-          <array length="0" zero-terminated="0" c:type="gchar**">
+          <array length="0" zero-terminated="0" c:type="const gchar**">
             <type name="utf8"/>
           </array>
         </return-value>
@@ -27467,6 +27678,11 @@ in the container.  See g_variant_n_children().
 
 The returned value is never floating.  You should free it with
 g_variant_unref() when you're done with it.
+
+There may be implementation specific restrictions on deeply nested values,
+which would result in the unit tuple being returned as the child value,
+instead of further nested children. #GVariant is guaranteed to handle
+nesting up to at least 64 levels.
 
 This function is O(1).</doc>
         <return-value transfer-ownership="full">
@@ -27569,7 +27785,7 @@ as an array of the given C type, with @element_size set to the size
 the appropriate type:
 - %G_VARIANT_TYPE_INT16 (etc.): #gint16 (etc.)
 - %G_VARIANT_TYPE_BOOLEAN: #guchar (not #gboolean!)
-- %G_VARIANT_TYPE_BYTE: #guchar
+- %G_VARIANT_TYPE_BYTE: #guint8
 - %G_VARIANT_TYPE_HANDLE: #guint32
 - %G_VARIANT_TYPE_DOUBLE: #gdouble
 
@@ -27732,7 +27948,7 @@ For an empty array, @length will be set to 0 and a pointer to a
 %NULL pointer will be returned.</doc>
         <return-value transfer-ownership="container">
           <doc xml:space="preserve">an array of constant strings</doc>
-          <array length="0" zero-terminated="1" c:type="gchar**">
+          <array length="0" zero-terminated="1" c:type="const gchar**">
             <type name="utf8"/>
           </array>
         </return-value>
@@ -27814,7 +28030,7 @@ For an empty array, @length will be set to 0 and a pointer to a
 %NULL pointer will be returned.</doc>
         <return-value transfer-ownership="container">
           <doc xml:space="preserve">an array of constant strings</doc>
-          <array length="0" zero-terminated="1" c:type="gchar**">
+          <array length="0" zero-terminated="1" c:type="const gchar**">
             <type name="utf8"/>
           </array>
         </return-value>
@@ -28035,7 +28251,10 @@ check.
 
 If @value is found to be in normal form then it will be marked as
 being trusted.  If the value was already marked as being trusted then
-this function will immediately return %TRUE.</doc>
+this function will immediately return %TRUE.
+
+There may be implementation specific restrictions on deeply nested values.
+GVariant is guaranteed to handle nesting up to at least 64 levels.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE if @value is in normal form</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -28370,10 +28589,10 @@ drops to 0, the memory used by the variant is freed.</doc>
 should ensure that a string is a valid D-Bus object path before
 passing it to g_variant_new_object_path().
 
-A valid object path starts with '/' followed by zero or more
-sequences of characters separated by '/' characters.  Each sequence
-must contain only the characters "[A-Z][a-z][0-9]_".  No sequence
-(including the one following the final '/' character) may be empty.</doc>
+A valid object path starts with `/` followed by zero or more
+sequences of characters separated by `/` characters.  Each sequence
+must contain only the characters `[A-Z][a-z][0-9]_`.  No sequence
+(including the one following the final `/` character) may be empty.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE if @string is a D-Bus object path</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -29740,7 +29959,10 @@ The valid basic type strings are "b", "y", "n", "q", "i", "u", "x", "t",
 
 The above definition is recursive to arbitrary depth. "aaaaai" and
 "(ui(nq((y)))s)" are both valid type strings, as is
-"a(aa(ui)(qna{ya(yd)}))".
+"a(aa(ui)(qna{ya(yd)}))". In order to not hit memory limits, #GVariant
+imposes a limit on recursion depth of 65 nested containers. This is the
+limit in the D-Bus specification (64) plus one to allow a #GDBusMessage to
+be nested in a top-level tuple.
 
 The meaning of each of the characters is as follows:
 - `b`: the type string of %G_VARIANT_TYPE_BOOLEAN; a boolean value.
@@ -29896,7 +30118,7 @@ Since 2.24</doc>
         <parameters>
           <parameter name="items" transfer-ownership="none">
             <doc xml:space="preserve">an array of #GVariantTypes, one for each item</doc>
-            <array length="1" zero-terminated="0" c:type="GVariantType**">
+            <array length="1" zero-terminated="0" c:type="const GVariantType* const*">
               <type name="VariantType" c:type="GVariantType*"/>
             </array>
           </parameter>
@@ -31488,6 +31710,179 @@ This call acts as a full compiler and hardware memory barrier.</doc>
         </parameter>
       </parameters>
     </function>
+    <function name="atomic_rc_box_acquire" c:identifier="g_atomic_rc_box_acquire" version="2.58">
+      <doc xml:space="preserve">Atomically acquires a reference on the data pointed by @mem_block.</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">a pointer to the data,
+  with its reference count increased</doc>
+        <type name="gpointer" c:type="gpointer"/>
+      </return-value>
+      <parameters>
+        <parameter name="mem_block" transfer-ownership="none">
+          <doc xml:space="preserve">a pointer to reference counted data</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="atomic_rc_box_alloc" c:identifier="g_atomic_rc_box_alloc" version="2.58">
+      <doc xml:space="preserve">Allocates @block_size bytes of memory, and adds atomic
+reference counting semantics to it.
+
+The data will be freed when its reference count drops to
+zero.</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">a pointer to the allocated memory</doc>
+        <type name="gpointer" c:type="gpointer"/>
+      </return-value>
+      <parameters>
+        <parameter name="block_size" transfer-ownership="none">
+          <doc xml:space="preserve">the size of the allocation, must be greater than 0</doc>
+          <type name="gsize" c:type="gsize"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="atomic_rc_box_alloc0" c:identifier="g_atomic_rc_box_alloc0" version="2.58">
+      <doc xml:space="preserve">Allocates @block_size bytes of memory, and adds atomic
+referenc counting semantics to it.
+
+The contents of the returned data is set to zero.
+
+The data will be freed when its reference count drops to
+zero.</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">a pointer to the allocated memory</doc>
+        <type name="gpointer" c:type="gpointer"/>
+      </return-value>
+      <parameters>
+        <parameter name="block_size" transfer-ownership="none">
+          <doc xml:space="preserve">the size of the allocation, must be greater than 0</doc>
+          <type name="gsize" c:type="gsize"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="atomic_rc_box_dup" c:identifier="g_atomic_rc_box_dup" version="2.58">
+      <doc xml:space="preserve">Allocates a new block of data with atomit reference counting
+semantics, and copies @block_size bytes of @mem_block
+into it.</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">a pointer to the allocated
+  memory</doc>
+        <type name="gpointer" c:type="gpointer"/>
+      </return-value>
+      <parameters>
+        <parameter name="block_size" transfer-ownership="none">
+          <doc xml:space="preserve">the number of bytes to copy, must be greater than 0</doc>
+          <type name="gsize" c:type="gsize"/>
+        </parameter>
+        <parameter name="mem_block" transfer-ownership="none">
+          <doc xml:space="preserve">the memory to copy</doc>
+          <type name="gpointer" c:type="gconstpointer"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="atomic_rc_box_get_size" c:identifier="g_atomic_rc_box_get_size" version="2.58">
+      <doc xml:space="preserve">Retrieves the size of the reference counted data pointed by @mem_block.</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">the size of the data, in bytes</doc>
+        <type name="gsize" c:type="gsize"/>
+      </return-value>
+      <parameters>
+        <parameter name="mem_block" transfer-ownership="none">
+          <doc xml:space="preserve">a pointer to reference counted data</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="atomic_rc_box_release" c:identifier="g_atomic_rc_box_release" version="2.58">
+      <doc xml:space="preserve">Atomically releases a reference on the data pointed by @mem_block.
+
+If the reference was the last one, it will free the
+resources allocated for @mem_block.</doc>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="mem_block" transfer-ownership="full">
+          <doc xml:space="preserve">a pointer to reference counted data</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="atomic_rc_box_release_full" c:identifier="g_atomic_rc_box_release_full" version="2.58">
+      <doc xml:space="preserve">Atomically releases a reference on the data pointed by @mem_block.
+
+If the reference was the last one, it will call @clear_func
+to clear the contents of @mem_block, and then will free the
+resources allocated for @mem_block.</doc>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="mem_block" transfer-ownership="full">
+          <doc xml:space="preserve">a pointer to reference counted data</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="clear_func" transfer-ownership="none" scope="async">
+          <doc xml:space="preserve">a function to call when clearing the data</doc>
+          <type name="DestroyNotify" c:type="GDestroyNotify"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="atomic_ref_count_compare" c:identifier="g_atomic_ref_count_compare" version="2.58">
+      <doc xml:space="preserve">Atomically compares the current value of @arc with @val.</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">%TRUE if the reference count is the same
+  as the given value</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="arc" transfer-ownership="none">
+          <doc xml:space="preserve">the address of an atomic reference count variable</doc>
+          <type name="gint" c:type="gatomicrefcount*"/>
+        </parameter>
+        <parameter name="val" transfer-ownership="none">
+          <doc xml:space="preserve">the value to compare</doc>
+          <type name="gint" c:type="gint"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="atomic_ref_count_dec" c:identifier="g_atomic_ref_count_dec" version="2.58">
+      <doc xml:space="preserve">Atomically decreases the reference count.</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">%TRUE if the reference count reached 0, and %FALSE otherwise</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="arc" transfer-ownership="none">
+          <doc xml:space="preserve">the address of an atomic reference count variable</doc>
+          <type name="gint" c:type="gatomicrefcount*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="atomic_ref_count_inc" c:identifier="g_atomic_ref_count_inc" version="2.58">
+      <doc xml:space="preserve">Atomically increases the reference count.</doc>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="arc" transfer-ownership="none">
+          <doc xml:space="preserve">the address of an atomic reference count variable</doc>
+          <type name="gint" c:type="gatomicrefcount*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="atomic_ref_count_init" c:identifier="g_atomic_ref_count_init" version="2.58">
+      <doc xml:space="preserve">Atomically initializes a reference count variable.</doc>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="arc" transfer-ownership="none">
+          <doc xml:space="preserve">the address of an atomic reference count variable</doc>
+          <type name="gint" c:type="gatomicrefcount*"/>
+        </parameter>
+      </parameters>
+    </function>
     <function name="base64_decode" c:identifier="g_base64_decode" version="2.12">
       <doc xml:space="preserve">Decode a sequence of Base-64 encoded text into binary data.  Note
 that the returned binary data is not necessarily zero-terminated,
@@ -31550,7 +31945,7 @@ state).</doc>
       <parameters>
         <parameter name="in" transfer-ownership="none">
           <doc xml:space="preserve">binary input data</doc>
-          <array length="1" zero-terminated="0" c:type="gchar*">
+          <array length="1" zero-terminated="0" c:type="const gchar*">
             <type name="guint8"/>
           </array>
         </parameter>
@@ -31586,7 +31981,7 @@ representation.</doc>
       <parameters>
         <parameter name="data" transfer-ownership="none">
           <doc xml:space="preserve">the binary data to encode</doc>
-          <array length="1" zero-terminated="0" c:type="guchar*">
+          <array length="1" zero-terminated="0" c:type="const guchar*">
             <type name="guint8"/>
           </array>
         </parameter>
@@ -31656,7 +32051,7 @@ or certain other protocols.</doc>
       <parameters>
         <parameter name="in" transfer-ownership="none">
           <doc xml:space="preserve">the binary data to encode</doc>
-          <array length="1" zero-terminated="0" c:type="guchar*">
+          <array length="1" zero-terminated="0" c:type="const guchar*">
             <type name="guint8"/>
           </array>
         </parameter>
@@ -32078,6 +32473,38 @@ thread.</doc>
         </parameter>
       </parameters>
     </function>
+    <function name="canonicalize_filename" c:identifier="g_canonicalize_filename" version="2.58">
+      <doc xml:space="preserve">Gets the canonical file name from @filename. All triple slashes are turned into
+single slashes, and all `..` and `.`s resolved against @relative_to.
+
+Symlinks are not followed, and the returned path is guaranteed to be absolute.
+
+If @filename is an absolute path, @relative_to is ignored. Otherwise,
+@relative_to will be prepended to @filename to make it absolute. @relative_to
+must be an absolute path, or %NULL. If @relative_to is %NULL, it'll fallback
+to g_get_current_dir().
+
+This function never fails, and will canonicalize file paths even if they don't
+exist.
+
+No file system I/O is done.</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">a newly allocated string with the
+canonical file path</doc>
+        <type name="filename" c:type="gchar*"/>
+      </return-value>
+      <parameters>
+        <parameter name="filename" transfer-ownership="none">
+          <doc xml:space="preserve">the name of the file</doc>
+          <type name="filename" c:type="const gchar*"/>
+        </parameter>
+        <parameter name="relative_to" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve">the relative directory, or %NULL
+to use the current working directory</doc>
+          <type name="filename" c:type="const gchar*"/>
+        </parameter>
+      </parameters>
+    </function>
     <function name="chdir" c:identifier="g_chdir" version="2.8">
       <doc xml:space="preserve">A wrapper for the POSIX chdir() function. The function changes the
 current directory of the process to @path.
@@ -32329,7 +32756,11 @@ Otherwise, the variable is destroyed using @destroy and the
 pointer is set to %NULL.
 
 A macro is also included that allows this function to be used without
-pointer casts.</doc>
+pointer casts. This will mask any warnings about incompatible function types
+or calling conventions, so you must ensure that your @destroy function is
+compatible with being called as `GDestroyNotify` using the standard calling
+convention for the platform that GLib was compiled for; otherwise the program
+will experience undefined behaviour.</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
       </return-value>
@@ -32404,7 +32835,7 @@ The hexadecimal string returned will be in lower case.</doc>
         </parameter>
         <parameter name="data" transfer-ownership="none">
           <doc xml:space="preserve">binary blob to compute the digest of</doc>
-          <array length="2" zero-terminated="0" c:type="guchar*">
+          <array length="2" zero-terminated="0" c:type="const guchar*">
             <type name="guint8"/>
           </array>
         </parameter>
@@ -32482,7 +32913,7 @@ The hexadecimal string returned will be in lower case.</doc>
         </parameter>
         <parameter name="key" transfer-ownership="none">
           <doc xml:space="preserve">the key to use in the HMAC</doc>
-          <array length="2" zero-terminated="0" c:type="guchar*">
+          <array length="2" zero-terminated="0" c:type="const guchar*">
             <type name="guint8" c:type="guchar"/>
           </array>
         </parameter>
@@ -32492,7 +32923,7 @@ The hexadecimal string returned will be in lower case.</doc>
         </parameter>
         <parameter name="data" transfer-ownership="none">
           <doc xml:space="preserve">binary blob to compute the HMAC of</doc>
-          <array length="4" zero-terminated="0" c:type="guchar*">
+          <array length="4" zero-terminated="0" c:type="const guchar*">
             <type name="guint8" c:type="guchar"/>
           </array>
         </parameter>
@@ -32519,7 +32950,7 @@ The hexadecimal string returned will be in lower case.</doc>
         </parameter>
         <parameter name="key" transfer-ownership="none">
           <doc xml:space="preserve">the key to use in the HMAC</doc>
-          <array length="2" zero-terminated="0" c:type="guchar*">
+          <array length="2" zero-terminated="0" c:type="const guchar*">
             <type name="guint8" c:type="guchar"/>
           </array>
         </parameter>
@@ -32565,7 +32996,7 @@ well) on many platforms.  Consider using g_str_to_ascii() instead.</doc>
         <parameter name="str" transfer-ownership="none">
           <doc xml:space="preserve">
                 the string to convert.</doc>
-          <array length="1" zero-terminated="0" c:type="gchar*">
+          <array length="1" zero-terminated="0" c:type="const gchar*">
             <type name="guint8"/>
           </array>
         </parameter>
@@ -32638,7 +33069,7 @@ could combine with the base character.)</doc>
         <parameter name="str" transfer-ownership="none">
           <doc xml:space="preserve">
                the string to convert.</doc>
-          <array length="1" zero-terminated="0" c:type="gchar*">
+          <array length="1" zero-terminated="0" c:type="const gchar*">
             <type name="guint8"/>
           </array>
         </parameter>
@@ -32713,7 +33144,7 @@ unrepresentable characters, use g_convert_with_fallback().</doc>
         <parameter name="str" transfer-ownership="none">
           <doc xml:space="preserve">
                 the string to convert.</doc>
-          <array length="1" zero-terminated="0" c:type="gchar*">
+          <array length="1" zero-terminated="0" c:type="const gchar*">
             <type name="guint8"/>
           </array>
         </parameter>
@@ -33883,6 +34314,17 @@ file which is then renamed to the final name. Notes:
   lists, metadata etc. may be lost. If @filename is a symbolic link,
   the link itself will be replaced, not the linked file.
 
+- On UNIX, if @filename already exists and is non-empty, and if the system
+  supports it (via a journalling filesystem or equivalent), the fsync()
+  call (or equivalent) will be used to ensure atomic replacement: @filename
+  will contain either its old contents or @contents, even in the face of
+  system power loss, the disk being unsafely removed, etc.
+
+- On UNIX, if @filename does not already exist or is empty, there is a
+  possibility that system power loss etc. after calling this function will
+  leave @filename empty or full of NUL bytes, depending on the underlying
+  filesystem.
+
 - On Windows renaming a file will not remove an existing file with the
   new name, so on Windows there is a race condition between the existing
   file being removed and the temporary file being renamed.
@@ -33909,7 +34351,7 @@ to 7 characters to @filename.</doc>
         </parameter>
         <parameter name="contents" transfer-ownership="none">
           <doc xml:space="preserve">string to write to the file</doc>
-          <array length="2" zero-terminated="0" c:type="gchar*">
+          <array length="2" zero-terminated="0" c:type="const gchar*">
             <type name="guint8"/>
           </array>
         </parameter>
@@ -34441,8 +34883,12 @@ on a system might be in any random encoding or just gibberish.</doc>
         <type name="gboolean" c:type="gboolean"/>
       </return-value>
       <parameters>
-        <parameter name="charsets" transfer-ownership="none">
-          <type name="utf8" c:type="const gchar***"/>
+        <parameter name="filename_charsets" direction="out" caller-allocates="0" transfer-ownership="none">
+          <doc xml:space="preserve">
+   return location for the %NULL-terminated list of encoding names</doc>
+          <array c:type="const gchar***">
+            <type name="utf8" c:type="gchar**"/>
+          </array>
         </parameter>
       </parameters>
     </function>
@@ -34507,10 +34953,35 @@ user.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">a %NULL-terminated array of strings owned by GLib
    that must not be modified or freed.</doc>
-        <array c:type="gchar**">
+        <array c:type="const gchar* const*">
           <type name="utf8"/>
         </array>
       </return-value>
+    </function>
+    <function name="get_language_names_with_category" c:identifier="g_get_language_names_with_category" version="2.58">
+      <doc xml:space="preserve">Computes a list of applicable locale names with a locale category name,
+which can be used to construct the fallback locale-dependent filenames
+or search paths. The returned list is sorted from most desirable to
+least desirable and always contains the default locale "C".
+
+This function consults the environment variables `LANGUAGE`, `LC_ALL`,
+@category_name, and `LANG` to find the list of locales specified by the
+user.
+
+g_get_language_names() returns g_get_language_names_with_category("LC_MESSAGES").</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">a %NULL-terminated array of strings owned by GLib
+   that must not be modified or freed.</doc>
+        <array c:type="const gchar* const*">
+          <type name="utf8"/>
+        </array>
+      </return-value>
+      <parameters>
+        <parameter name="category_name" transfer-ownership="none">
+          <doc xml:space="preserve">a locale category name</doc>
+          <type name="utf8" c:type="const gchar*"/>
+        </parameter>
+      </parameters>
     </function>
     <function name="get_locale_variants" c:identifier="g_get_locale_variants" version="2.28">
       <doc xml:space="preserve">Returns a list of derived variants of @locale, which can be used to
@@ -34627,7 +35098,7 @@ to anyone using the computer.</doc>
         <doc xml:space="preserve">
     a %NULL-terminated array of strings owned by GLib that must not be
     modified or freed.</doc>
-        <array c:type="gchar**">
+        <array c:type="const gchar* const*">
           <type name="filename"/>
         </array>
       </return-value>
@@ -34668,7 +35139,7 @@ this function is called.</doc>
         <doc xml:space="preserve">
     a %NULL-terminated array of strings owned by GLib that must not be
     modified or freed.</doc>
-        <array c:type="gchar**">
+        <array c:type="const gchar* const*">
           <type name="filename"/>
         </array>
       </return-value>
@@ -35121,6 +35592,45 @@ without calling the key and value destroy functions.</doc>
             <type name="gpointer" c:type="gpointer"/>
             <type name="gpointer" c:type="gpointer"/>
           </type>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="hash_table_steal_extended" c:identifier="g_hash_table_steal_extended" moved-to="HashTable.steal_extended" version="2.58">
+      <doc xml:space="preserve">Looks up a key in the #GHashTable, stealing the original key and the
+associated value and returning %TRUE if the key was found. If the key was
+not found, %FALSE is returned.
+
+If found, the stolen key and value are removed from the hash table without
+calling the key and value destroy functions, and ownership is transferred to
+the caller of this method; as with g_hash_table_steal().
+
+You can pass %NULL for @lookup_key, provided the hash and equal functions
+of @hash_table are %NULL-safe.</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">%TRUE if the key was found in the #GHashTable</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="hash_table" transfer-ownership="none">
+          <doc xml:space="preserve">a #GHashTable</doc>
+          <type name="GLib.HashTable" c:type="GHashTable*">
+            <type name="gpointer" c:type="gpointer"/>
+            <type name="gpointer" c:type="gpointer"/>
+          </type>
+        </parameter>
+        <parameter name="lookup_key" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve">the key to look up</doc>
+          <type name="gpointer" c:type="gconstpointer"/>
+        </parameter>
+        <parameter name="stolen_key" direction="out" caller-allocates="0" transfer-ownership="full" nullable="1" optional="1" allow-none="1">
+          <doc xml:space="preserve">return location for the
+   original key</doc>
+          <type name="gpointer" c:type="gpointer*"/>
+        </parameter>
+        <parameter name="stolen_value" direction="out" caller-allocates="0" transfer-ownership="full" nullable="1" optional="1" allow-none="1">
+          <doc xml:space="preserve">return location
+   for the value associated with the key</doc>
+          <type name="gpointer" c:type="gpointer*"/>
         </parameter>
       </parameters>
     </function>
@@ -35807,7 +36317,7 @@ may contain embedded nul characters.</doc>
           <doc xml:space="preserve">a string in the
                 encoding of the current locale. On Windows
                 this means the system codepage.</doc>
-          <array length="1" zero-terminated="0" c:type="gchar*">
+          <array length="1" zero-terminated="0" c:type="const gchar*">
             <type name="guint8"/>
           </array>
         </parameter>
@@ -35839,8 +36349,9 @@ may contain embedded nul characters.</doc>
     <function name="log" c:identifier="g_log" introspectable="0">
       <doc xml:space="preserve">Logs an error or debugging message.
 
-If the log level has been set as fatal, the abort()
-function is called to terminate the program.
+If the log level has been set as fatal, G_BREAKPOINT() is called
+to terminate the program. See the documentation for G_BREAKPOINT() for
+details of the debugging options this provides.
 
 If g_log_default_handler() is used as the log handler function, a new-line
 character will automatically be appended to @..., and need not be entered
@@ -35877,7 +36388,7 @@ for the default</doc>
 allows to install an alternate default log handler.
 This is used if no log handler has been set for the particular log
 domain and log level combination. It outputs the message to stderr
-or stdout and if the log level is fatal it calls abort(). It automatically
+or stdout and if the log level is fatal it calls G_BREAKPOINT(). It automatically
 prints a new-line character after the message, so one does not need to be
 manually included in @message.
 
@@ -36001,7 +36512,12 @@ This has no effect on structured log messages (using g_log_structured() or
 g_log_structured_array()). To change the fatal behaviour for specific log
 messages, programs must install a custom log writer function using
 g_log_set_writer_func(). See
-[Using Structured Logging][using-structured-logging].</doc>
+[Using Structured Logging][using-structured-logging].
+
+This function is mostly intended to be used with
+%G_LOG_LEVEL_CRITICAL.  You should typically not set
+%G_LOG_LEVEL_WARNING, %G_LOG_LEVEL_MESSAGE, %G_LOG_LEVEL_INFO or
+%G_LOG_LEVEL_DEBUG as fatal except inside of test programs.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the old fatal mask for the log domain</doc>
         <type name="LogLevelFlags" c:type="GLogLevelFlags"/>
@@ -36144,7 +36660,7 @@ There can only be one writer function. It is an error to set more than one.</doc
       <doc xml:space="preserve">Log a message with structured data. The message will be passed through to
 the log writer set by the application using g_log_set_writer_func(). If the
 message is fatal (i.e. its log level is %G_LOG_LEVEL_ERROR), the program will
-be aborted at the end of this function. If the log writer returns
+be aborted by calling G_BREAKPOINT() at the end of this function. If the log writer returns
 %G_LOG_WRITER_UNHANDLED (failure), no other fallback writers will be tried.
 See the documentation for #GLogWriterFunc for information on chaining
 writers.
@@ -36262,7 +36778,7 @@ This assumes that @log_level is already present in @fields (typically as the
         <parameter name="fields" transfer-ownership="none">
           <doc xml:space="preserve">key&#x2013;value pairs of structured data to add
    to the log message</doc>
-          <array length="2" zero-terminated="0" c:type="GLogField*">
+          <array length="2" zero-terminated="0" c:type="const GLogField*">
             <type name="LogField" c:type="GLogField"/>
           </array>
         </parameter>
@@ -36364,7 +36880,7 @@ messages unless their log domain (or `all`) is listed in the space-separated
         <parameter name="fields" transfer-ownership="none">
           <doc xml:space="preserve">key&#x2013;value pairs of structured data forming
    the log message</doc>
-          <array length="2" zero-terminated="0" c:type="GLogField*">
+          <array length="2" zero-terminated="0" c:type="const GLogField*">
             <type name="LogField" c:type="GLogField"/>
           </array>
         </parameter>
@@ -36402,7 +36918,7 @@ UTF-8.</doc>
         <parameter name="fields" transfer-ownership="none">
           <doc xml:space="preserve">key&#x2013;value pairs of structured data forming
    the log message</doc>
-          <array length="2" zero-terminated="0" c:type="GLogField*">
+          <array length="2" zero-terminated="0" c:type="const GLogField*">
             <type name="LogField" c:type="GLogField"/>
           </array>
         </parameter>
@@ -36461,7 +36977,7 @@ defined, but will always return %G_LOG_WRITER_UNHANDLED.</doc>
         <parameter name="fields" transfer-ownership="none">
           <doc xml:space="preserve">key&#x2013;value pairs of structured data forming
    the log message</doc>
-          <array length="2" zero-terminated="0" c:type="GLogField*">
+          <array length="2" zero-terminated="0" c:type="const GLogField*">
             <type name="LogField" c:type="GLogField"/>
           </array>
         </parameter>
@@ -36501,7 +37017,7 @@ This is suitable for use as a #GLogWriterFunc.</doc>
         <parameter name="fields" transfer-ownership="none">
           <doc xml:space="preserve">key&#x2013;value pairs of structured data forming
    the log message</doc>
-          <array length="2" zero-terminated="0" c:type="GLogField*">
+          <array length="2" zero-terminated="0" c:type="const GLogField*">
             <type name="LogField" c:type="GLogField"/>
           </array>
         </parameter>
@@ -36533,8 +37049,9 @@ messages.</doc>
     <function name="logv" c:identifier="g_logv" introspectable="0">
       <doc xml:space="preserve">Logs an error or debugging message.
 
-If the log level has been set as fatal, the abort()
-function is called to terminate the program.
+If the log level has been set as fatal, G_BREAKPOINT() is called
+to terminate the program. See the documentation for G_BREAKPOINT() for
+details of the debugging options this provides.
 
 If g_log_default_handler() is used as the log handler function, a new-line
 character will automatically be appended to @..., and need not be entered
@@ -37324,7 +37841,7 @@ commas, or %NULL.</doc>
         <parameter name="keys" transfer-ownership="none">
           <doc xml:space="preserve">pointer to an array of #GDebugKey which associate
     strings with bit flags.</doc>
-          <array length="2" zero-terminated="0" c:type="GDebugKey*">
+          <array length="2" zero-terminated="0" c:type="const GDebugKey*">
             <type name="DebugKey" c:type="GDebugKey"/>
           </array>
         </parameter>
@@ -38000,6 +38517,124 @@ by the g_random_* functions, to @seed.</doc>
         </parameter>
       </parameters>
     </function>
+    <function name="rc_box_acquire" c:identifier="g_rc_box_acquire" version="2.58">
+      <doc xml:space="preserve">Acquires a reference on the data pointed by @mem_block.</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">a pointer to the data,
+  with its reference count increased</doc>
+        <type name="gpointer" c:type="gpointer"/>
+      </return-value>
+      <parameters>
+        <parameter name="mem_block" transfer-ownership="none">
+          <doc xml:space="preserve">a pointer to reference counted data</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="rc_box_alloc" c:identifier="g_rc_box_alloc" version="2.58">
+      <doc xml:space="preserve">Allocates @block_size bytes of memory, and adds reference
+counting semantics to it.
+
+The data will be freed when its reference count drops to
+zero.</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">a pointer to the allocated memory</doc>
+        <type name="gpointer" c:type="gpointer"/>
+      </return-value>
+      <parameters>
+        <parameter name="block_size" transfer-ownership="none">
+          <doc xml:space="preserve">the size of the allocation, must be greater than 0</doc>
+          <type name="gsize" c:type="gsize"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="rc_box_alloc0" c:identifier="g_rc_box_alloc0" version="2.58">
+      <doc xml:space="preserve">Allocates @block_size bytes of memory, and adds reference
+counting semantics to it.
+
+The contents of the returned data is set to zero.
+
+The data will be freed when its reference count drops to
+zero.</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">a pointer to the allocated memory</doc>
+        <type name="gpointer" c:type="gpointer"/>
+      </return-value>
+      <parameters>
+        <parameter name="block_size" transfer-ownership="none">
+          <doc xml:space="preserve">the size of the allocation, must be greater than 0</doc>
+          <type name="gsize" c:type="gsize"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="rc_box_dup" c:identifier="g_rc_box_dup" version="2.58">
+      <doc xml:space="preserve">Allocates a new block of data with reference counting
+semantics, and copies @block_size bytes of @mem_block
+into it.</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">a pointer to the allocated
+  memory</doc>
+        <type name="gpointer" c:type="gpointer"/>
+      </return-value>
+      <parameters>
+        <parameter name="block_size" transfer-ownership="none">
+          <doc xml:space="preserve">the number of bytes to copy, must be greater than 0</doc>
+          <type name="gsize" c:type="gsize"/>
+        </parameter>
+        <parameter name="mem_block" transfer-ownership="none">
+          <doc xml:space="preserve">the memory to copy</doc>
+          <type name="gpointer" c:type="gconstpointer"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="rc_box_get_size" c:identifier="g_rc_box_get_size" version="2.58">
+      <doc xml:space="preserve">Retrieves the size of the reference counted data pointed by @mem_block.</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">the size of the data, in bytes</doc>
+        <type name="gsize" c:type="gsize"/>
+      </return-value>
+      <parameters>
+        <parameter name="mem_block" transfer-ownership="none">
+          <doc xml:space="preserve">a pointer to reference counted data</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="rc_box_release" c:identifier="g_rc_box_release" version="2.58">
+      <doc xml:space="preserve">Releases a reference on the data pointed by @mem_block.
+
+If the reference was the last one, it will free the
+resources allocated for @mem_block.</doc>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="mem_block" transfer-ownership="full">
+          <doc xml:space="preserve">a pointer to reference counted data</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="rc_box_release_full" c:identifier="g_rc_box_release_full" version="2.58">
+      <doc xml:space="preserve">Releases a reference on the data pointed by @mem_block.
+
+If the reference was the last one, it will call @clear_func
+to clear the contents of @mem_block, and then will free the
+resources allocated for @mem_block.</doc>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="mem_block" transfer-ownership="full">
+          <doc xml:space="preserve">a pointer to reference counted data</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="clear_func" transfer-ownership="none" scope="async">
+          <doc xml:space="preserve">a function to call when clearing the data</doc>
+          <type name="DestroyNotify" c:type="GDestroyNotify"/>
+        </parameter>
+      </parameters>
+    </function>
     <function name="realloc" c:identifier="g_realloc">
       <doc xml:space="preserve">Reallocates the memory pointed to by @mem, so that it now has space for
 @n_bytes bytes of memory. It returns the new address of the memory, which may
@@ -38040,6 +38675,154 @@ but care is taken to detect possible overflow during multiplication.</doc>
         <parameter name="n_block_bytes" transfer-ownership="none">
           <doc xml:space="preserve">the size of each block in bytes</doc>
           <type name="gsize" c:type="gsize"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="ref_count_compare" c:identifier="g_ref_count_compare" version="2.58">
+      <doc xml:space="preserve">Compares the current value of @rc with @val.</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">%TRUE if the reference count is the same
+  as the given value</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="rc" transfer-ownership="none">
+          <doc xml:space="preserve">the address of a reference count variable</doc>
+          <type name="gint" c:type="grefcount*"/>
+        </parameter>
+        <parameter name="val" transfer-ownership="none">
+          <doc xml:space="preserve">the value to compare</doc>
+          <type name="gint" c:type="gint"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="ref_count_dec" c:identifier="g_ref_count_dec" version="2.58">
+      <doc xml:space="preserve">Decreases the reference count.</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">%TRUE if the reference count reached 0, and %FALSE otherwise</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="rc" transfer-ownership="none">
+          <doc xml:space="preserve">the address of a reference count variable</doc>
+          <type name="gint" c:type="grefcount*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="ref_count_inc" c:identifier="g_ref_count_inc" version="2.58">
+      <doc xml:space="preserve">Increases the reference count.</doc>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="rc" transfer-ownership="none">
+          <doc xml:space="preserve">the address of a reference count variable</doc>
+          <type name="gint" c:type="grefcount*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="ref_count_init" c:identifier="g_ref_count_init" version="2.58">
+      <doc xml:space="preserve">Initializes a reference count variable.</doc>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="rc" transfer-ownership="none">
+          <doc xml:space="preserve">the address of a reference count variable</doc>
+          <type name="gint" c:type="grefcount*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="ref_string_acquire" c:identifier="g_ref_string_acquire" version="2.58">
+      <doc xml:space="preserve">Acquires a reference on a string.</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">the given string, with its reference count increased</doc>
+        <type name="utf8" c:type="char*"/>
+      </return-value>
+      <parameters>
+        <parameter name="str" transfer-ownership="none">
+          <doc xml:space="preserve">a reference counted string</doc>
+          <type name="utf8" c:type="char*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="ref_string_length" c:identifier="g_ref_string_length" version="2.58">
+      <doc xml:space="preserve">Retrieves the length of @str.</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">the length of the given string, in bytes</doc>
+        <type name="gsize" c:type="gsize"/>
+      </return-value>
+      <parameters>
+        <parameter name="str" transfer-ownership="none">
+          <doc xml:space="preserve">a reference counted string</doc>
+          <type name="utf8" c:type="char*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="ref_string_new" c:identifier="g_ref_string_new" version="2.58">
+      <doc xml:space="preserve">Creates a new reference counted string and copies the contents of @str
+into it.</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">the newly created reference counted string</doc>
+        <type name="utf8" c:type="char*"/>
+      </return-value>
+      <parameters>
+        <parameter name="str" transfer-ownership="none">
+          <doc xml:space="preserve">a NUL-terminated string</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="ref_string_new_intern" c:identifier="g_ref_string_new_intern" version="2.58">
+      <doc xml:space="preserve">Creates a new reference counted string and copies the content of @str
+into it.
+
+If you call this function multiple times with the same @str, or with
+the same contents of @str, it will return a new reference, instead of
+creating a new string.</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">the newly created reference
+  counted string, or a new reference to an existing string</doc>
+        <type name="utf8" c:type="char*"/>
+      </return-value>
+      <parameters>
+        <parameter name="str" transfer-ownership="none">
+          <doc xml:space="preserve">a NUL-terminated string</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="ref_string_new_len" c:identifier="g_ref_string_new_len" version="2.58">
+      <doc xml:space="preserve">Creates a new reference counted string and copies the contents of @str
+into it, up to @len bytes.
+
+Since this function does not stop at nul bytes, it is the caller's
+responsibility to ensure that @str has at least @len addressable bytes.</doc>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">the newly created reference counted string</doc>
+        <type name="utf8" c:type="char*"/>
+      </return-value>
+      <parameters>
+        <parameter name="str" transfer-ownership="none">
+          <doc xml:space="preserve">a string</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="len" transfer-ownership="none">
+          <doc xml:space="preserve">length of @str to use, or -1 if @str is nul-terminated</doc>
+          <type name="gssize" c:type="gssize"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="ref_string_release" c:identifier="g_ref_string_release" version="2.58">
+      <doc xml:space="preserve">Releases a reference on a string; if it was the last reference, the
+resources allocated by the string are freed as well.</doc>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="str" transfer-ownership="none">
+          <doc xml:space="preserve">a reference counted string</doc>
+          <type name="utf8" c:type="char*"/>
         </parameter>
       </parameters>
     </function>
@@ -38110,12 +38893,12 @@ in @length.</doc>
       <parameters>
         <parameter name="string" transfer-ownership="none">
           <doc xml:space="preserve">the string to escape</doc>
-          <array length="1" zero-terminated="0" c:type="gchar*">
+          <array length="1" zero-terminated="0" c:type="const gchar*">
             <type name="utf8" c:type="gchar"/>
           </array>
         </parameter>
         <parameter name="length" transfer-ownership="none">
-          <doc xml:space="preserve">the length of @string, or -1 if @string is nul-terminated</doc>
+          <doc xml:space="preserve">the length of @string, in bytes, or -1 if @string is nul-terminated</doc>
           <type name="gint" c:type="gint"/>
         </parameter>
       </parameters>
@@ -38307,13 +39090,13 @@ sequences.</doc>
       </parameters>
     </function>
     <function name="sequence_move_range" c:identifier="g_sequence_move_range" moved-to="Sequence.move_range" version="2.14">
-      <doc xml:space="preserve">Inserts the (@begin, @end) range at the destination pointed to by ptr.
+      <doc xml:space="preserve">Inserts the (@begin, @end) range at the destination pointed to by @dest.
 The @begin and @end iters must point into the same sequence. It is
 allowed for @dest to point to a different sequence than the one pointed
 into by @begin and @end.
 
-If @dest is NULL, the range indicated by @begin and @end is
-removed from the sequence. If @dest iter points to a place within
+If @dest is %NULL, the range indicated by @begin and @end is
+removed from the sequence. If @dest points to a place within
 the (@begin, @end) range, the range does not move.</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
@@ -39061,6 +39844,76 @@ are different concepts on Windows.</doc>
         </parameter>
       </parameters>
     </function>
+    <function name="spawn_async_with_fds" c:identifier="g_spawn_async_with_fds" version="2.58" throws="1">
+      <doc xml:space="preserve">Identical to g_spawn_async_with_pipes() but instead of
+creating pipes for the stdin/stdout/stderr, you can pass existing
+file descriptors into this function through the @stdin_fd,
+@stdout_fd and @stderr_fd parameters. The following @flags
+also have their behaviour slightly tweaked as a result:
+
+%G_SPAWN_STDOUT_TO_DEV_NULL means that the child's standard output
+will be discarded, instead of going to the same location as the parent's
+standard output. If you use this flag, @standard_output must be -1.
+%G_SPAWN_STDERR_TO_DEV_NULL means that the child's standard error
+will be discarded, instead of going to the same location as the parent's
+standard error. If you use this flag, @standard_error must be -1.
+%G_SPAWN_CHILD_INHERITS_STDIN means that the child will inherit the parent's
+standard input (by default, the child's standard input is attached to
+/dev/null). If you use this flag, @standard_input must be -1.
+
+It is valid to pass the same fd in multiple parameters (e.g. you can pass
+a single fd for both stdout and stderr).</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">%TRUE on success, %FALSE if an error was set</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="working_directory" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve">child's current working directory, or %NULL to inherit parent's, in the GLib file name encoding</doc>
+          <type name="filename" c:type="const gchar*"/>
+        </parameter>
+        <parameter name="argv" transfer-ownership="none">
+          <doc xml:space="preserve">child's argument vector, in the GLib file name encoding</doc>
+          <array c:type="gchar**">
+            <type name="utf8" c:type="gchar*"/>
+          </array>
+        </parameter>
+        <parameter name="envp" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve">child's environment, or %NULL to inherit parent's, in the GLib file name encoding</doc>
+          <array c:type="gchar**">
+            <type name="utf8" c:type="gchar*"/>
+          </array>
+        </parameter>
+        <parameter name="flags" transfer-ownership="none">
+          <doc xml:space="preserve">flags from #GSpawnFlags</doc>
+          <type name="SpawnFlags" c:type="GSpawnFlags"/>
+        </parameter>
+        <parameter name="child_setup" transfer-ownership="none" nullable="1" allow-none="1" scope="async" closure="5">
+          <doc xml:space="preserve">function to run in the child just before exec()</doc>
+          <type name="SpawnChildSetupFunc" c:type="GSpawnChildSetupFunc"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve">user data for @child_setup</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="child_pid" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
+          <doc xml:space="preserve">return location for child process ID, or %NULL</doc>
+          <type name="Pid" c:type="GPid*"/>
+        </parameter>
+        <parameter name="stdin_fd" transfer-ownership="none">
+          <doc xml:space="preserve">file descriptor to use for child's stdin, or -1</doc>
+          <type name="gint" c:type="gint"/>
+        </parameter>
+        <parameter name="stdout_fd" transfer-ownership="none">
+          <doc xml:space="preserve">file descriptor to use for child's stdout, or -1</doc>
+          <type name="gint" c:type="gint"/>
+        </parameter>
+        <parameter name="stderr_fd" transfer-ownership="none">
+          <doc xml:space="preserve">file descriptor to use for child's stderr, or -1</doc>
+          <type name="gint" c:type="gint"/>
+        </parameter>
+      </parameters>
+    </function>
     <function name="spawn_async_with_pipes" c:identifier="g_spawn_async_with_pipes" throws="1">
       <doc xml:space="preserve">Executes a child program asynchronously (your program will not
 block waiting for the child to exit). The child program is
@@ -39130,10 +39983,11 @@ the %SIGCHLD signal manually. On Windows, calling g_spawn_close_pid()
 is equivalent to calling CloseHandle() on the process handle returned
 in @child_pid). See g_child_watch_add().
 
-%G_SPAWN_LEAVE_DESCRIPTORS_OPEN means that the parent's open file
-descriptors will be inherited by the child; otherwise all descriptors
-except stdin/stdout/stderr will be closed before calling exec() in
-the child. %G_SPAWN_SEARCH_PATH means that @argv[0] need not be an
+Open UNIX file descriptors marked as `FD_CLOEXEC` will be automatically
+closed in the child process. %G_SPAWN_LEAVE_DESCRIPTORS_OPEN means that
+other open file descriptors will be inherited by the child; otherwise all
+descriptors except stdin/stdout/stderr will be closed before calling exec()
+in the child. %G_SPAWN_SEARCH_PATH means that @argv[0] need not be an
 absolute path, it will be looked for in the `PATH` environment
 variable. %G_SPAWN_SEARCH_PATH_FROM_ENVP means need not be an
 absolute path, it will be looked for in the `PATH` variable from
@@ -39207,6 +40061,21 @@ and @standard_error will not be filled with valid values.
 
 If @child_pid is not %NULL and an error does not occur then the returned
 process reference must be closed using g_spawn_close_pid().
+
+On modern UNIX platforms, GLib can use an efficient process launching
+codepath driven internally by posix_spawn(). This has the advantage of
+avoiding the fork-time performance costs of cloning the parent process
+address space, and avoiding associated memory overcommit checks that are
+not relevant in the context of immediately executing a distinct process.
+This optimized codepath will be used provided that the following conditions
+are met:
+
+1. %G_SPAWN_DO_NOT_REAP_CHILD is set
+2. %G_SPAWN_LEAVE_DESCRIPTORS_OPEN is set
+3. %G_SPAWN_SEARCH_PATH_FROM_ENVP is not set
+4. @working_directory is %NULL
+5. @child_setup is %NULL
+6. The program is of a recognised binary format, or has a shebang. Otherwise, GLib will have to execute the program through the shell, which is not done using the optimized codepath.
 
 If you are writing a GTK+ application, and the program you are spawning is a
 graphical application too, then to ensure that the spawned program opens its
@@ -39544,9 +40413,9 @@ if they are equal. It can be passed to g_hash_table_new() as the
 @key_equal_func parameter, when using non-%NULL strings as keys in a
 #GHashTable.
 
-Note that this function is primarily meant as a hash table comparison
-function. For a general-purpose, %NULL-safe string comparison function,
-see g_strcmp0().</doc>
+This function is typically used for hash table comparisons, but can be used
+for general purpose comparisons of non-%NULL strings. For a %NULL-safe string
+comparison function, see g_strcmp0().</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">%TRUE if the two keys match</doc>
         <type name="gboolean" c:type="gboolean"/>
@@ -39690,12 +40559,12 @@ change by version or even by runtime environment.
 If the source language of @str is known, it can used to improve the
 accuracy of the translation by passing it as @from_locale.  It should
 be a valid POSIX locale string (of the form
-"language[_territory][.codeset][@modifier]").
+`language[_territory][.codeset][@modifier]`).
 
 If @from_locale is %NULL then the current locale is used.
 
 If you want to do translation for no specific locale, and you want it
-to be done independently of the currently locale, specify "C" for
+to be done independently of the currently locale, specify `"C"` for
 @from_locale.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">a string in plain ASCII</doc>
@@ -40628,7 +41497,7 @@ point in some locales, causing unexpected results.</doc>
     </function>
     <function name="strv_length" c:identifier="g_strv_length" version="2.6">
       <doc xml:space="preserve">Returns the length of the given %NULL-terminated
-string array @str_array.</doc>
+string array @str_array. @str_array must not be %NULL.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">length of @str_array.</doc>
         <type name="guint" c:type="guint"/>
@@ -41093,7 +41962,13 @@ So far, the following arguments are understood:
 
   `no-undefined`: Avoid tests for undefined behaviour
 
-- `--debug-log`: Debug test logging output.</doc>
+- `--debug-log`: Debug test logging output.
+
+Since 2.58, if tests are compiled with `G_DISABLE_ASSERT` defined,
+g_test_init() will print an error and exit. This is to prevent no-op tests
+from being executed, as g_assert() is commonly (erroneously) used in unit
+tests, and is a no-op when compiled with `G_DISABLE_ASSERT`. Ensure your
+tests are compiled without `G_DISABLE_ASSERT` defined.</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
       </return-value>
@@ -41350,11 +42225,13 @@ on the order that tests are run in. If you need to ensure that some
 particular code runs before or after a given test case, use
 g_test_add(), which lets you specify setup and teardown functions.
 
-If all tests are skipped, this function will return 0 if
-producing TAP output, or 77 (treated as "skip test" by Automake) otherwise.</doc>
+If all tests are skipped or marked as incomplete (expected failures),
+this function will return 0 if producing TAP output, or 77 (treated
+as "skip test" by Automake) otherwise.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">0 on success, 1 on failure (assuming it returns at all),
-  0 or 77 if all tests were skipped with g_test_skip()</doc>
+  0 or 77 if all tests were skipped with g_test_skip() and/or
+  g_test_incomplete()</doc>
         <type name="gint" c:type="int"/>
       </return-value>
     </function>
@@ -41744,7 +42621,9 @@ to a #GTimeVal and puts it into @time_.
 @iso_date must include year, month, day, hours, minutes, and
 seconds. It can optionally include fractions of a second and a time
 zone indicator. (In the absence of any time zone indication, the
-timestamp is assumed to be in local time.)</doc>
+timestamp is assumed to be in local time.)
+
+Any leading or trailing space in @iso_date is ignored.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">%TRUE if the conversion was successful.</doc>
         <type name="gboolean" c:type="gboolean"/>
@@ -41832,7 +42711,7 @@ the callback will be invoked in whichever thread is running that main
 context. You can do these steps manually if you need greater control or to
 use a custom main context.
 
-The interval given in terms of monotonic time, not wall clock time.
+The interval given is in terms of monotonic time, not wall clock time.
 See g_get_monotonic_time().</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the ID (greater than 0) of the event source.</doc>
@@ -41997,7 +42876,7 @@ executed.
 The scheduling granularity/accuracy of this timeout source will be
 in seconds.
 
-The interval given in terms of monotonic time, not wall clock time.
+The interval given is in terms of monotonic time, not wall clock time.
 See g_get_monotonic_time().</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the newly-created timeout source</doc>
@@ -44091,7 +44970,7 @@ doing anything else with it.</doc>
       <parameters>
         <parameter name="str" transfer-ownership="none">
           <doc xml:space="preserve">a pointer to character data</doc>
-          <array length="1" zero-terminated="0" c:type="gchar*">
+          <array length="1" zero-terminated="0" c:type="const gchar*">
             <type name="guint8"/>
           </array>
         </parameter>
@@ -44142,10 +45021,10 @@ as per the aforementioned RFC.</doc>
 should ensure that a string is a valid D-Bus object path before
 passing it to g_variant_new_object_path().
 
-A valid object path starts with '/' followed by zero or more
-sequences of characters separated by '/' characters.  Each sequence
-must contain only the characters "[A-Z][a-z][0-9]_".  No sequence
-(including the one following the final '/' character) may be empty.</doc>
+A valid object path starts with `/` followed by zero or more
+sequences of characters separated by `/` characters.  Each sequence
+must contain only the characters `[A-Z][a-z][0-9]_`.  No sequence
+(including the one following the final `/` character) may be empty.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">%TRUE if @string is a D-Bus object path</doc>
         <type name="gboolean" c:type="gboolean"/>

--- a/GObject-2.0.gir
+++ b/GObject-2.0.gir
@@ -2461,7 +2461,9 @@ converts between #GValue and native C types. The GObject
 library provides the #GCClosure type for this purpose. Bindings for
 other languages need marshallers which convert between #GValues
 and suitable representations in the runtime of the language in
-order to use functions written in that languages as callbacks.
+order to use functions written in that language as callbacks. Use
+g_closure_set_marshal() to set the marshaller on such a custom
+closure implementation.
 
 Within GObject, closures play an important role in the
 implementation of signals. When a signal is registered, the
@@ -2760,7 +2762,7 @@ been invalidated before).</doc>
             <doc xml:space="preserve">an array of
                #GValues holding the arguments on which to
                invoke the callback of @closure</doc>
-            <array length="1" zero-terminated="0" c:type="GValue*">
+            <array length="1" zero-terminated="0" c:type="const GValue*">
               <type name="Value" c:type="GValue"/>
             </array>
           </parameter>
@@ -2976,7 +2978,7 @@ closure, then the closure will be destroyed and freed.</doc>
           <doc xml:space="preserve">an array of
  #GValues holding the arguments on which to invoke the
  callback of @closure</doc>
-          <array length="2" zero-terminated="0" c:type="GValue*">
+          <array length="2" zero-terminated="0" c:type="const GValue*">
             <type name="Value" c:type="GValue"/>
           </array>
         </parameter>
@@ -3357,7 +3359,7 @@ zeros before this function is called.</doc>
     <class name="Object" c:symbol-prefix="object" c:type="GObject" glib:type-name="GObject" glib:get-type="g_object_get_type" glib:type-struct="ObjectClass">
       <doc xml:space="preserve">All the fields in the GObject structure are private
 to the #GObject implementation and should never be accessed directly.</doc>
-      <constructor name="new" c:identifier="g_object_new" shadowed-by="new_with_properties" introspectable="0">
+      <constructor name="new" c:identifier="g_object_new" introspectable="0">
         <doc xml:space="preserve">Creates a new instance of a #GObject subtype and sets its properties.
 
 Construction parameters (see #G_PARAM_CONSTRUCT, #G_PARAM_CONSTRUCT_ONLY)
@@ -3408,7 +3410,7 @@ which are not explicitly specified are set to their default values.</doc>
           </parameter>
         </parameters>
       </constructor>
-      <constructor name="new_with_properties" c:identifier="g_object_new_with_properties" shadows="new" version="2.54">
+      <constructor name="new_with_properties" c:identifier="g_object_new_with_properties" version="2.54" introspectable="0">
         <doc xml:space="preserve">Creates a new instance of a #GObject subtype and sets its properties using
 the provided arrays. Both arrays must have exactly @n_properties elements,
 and the names and values correspond by index.
@@ -3432,7 +3434,7 @@ which are not explicitly specified are set to their default values.</doc>
           <parameter name="names" transfer-ownership="none">
             <doc xml:space="preserve">the names of each property to be set</doc>
             <array length="1" zero-terminated="0" c:type="const char**">
-              <type name="utf8" c:type="char"/>
+              <type name="utf8" c:type="char*"/>
             </array>
           </parameter>
           <parameter name="values" transfer-ownership="none">
@@ -4267,7 +4269,7 @@ properties are passed in.</doc>
           <parameter name="names" transfer-ownership="none">
             <doc xml:space="preserve">the names of each property to get</doc>
             <array length="0" zero-terminated="0" c:type="const gchar**">
-              <type name="utf8" c:type="gchar"/>
+              <type name="utf8" c:type="gchar*"/>
             </array>
           </parameter>
           <parameter name="values" transfer-ownership="none">
@@ -4753,7 +4755,7 @@ properties are passed in.</doc>
           <parameter name="names" transfer-ownership="none">
             <doc xml:space="preserve">the names of each property to be set</doc>
             <array length="0" zero-terminated="0" c:type="const gchar**">
-              <type name="utf8" c:type="gchar"/>
+              <type name="utf8" c:type="gchar*"/>
             </array>
           </parameter>
           <parameter name="values" transfer-ownership="none">
@@ -4955,11 +4957,17 @@ Use #GWeakRef if thread-safety is required.</doc>
         <type name="GLib.Data" c:type="GData*"/>
       </field>
       <glib:signal name="notify" when="first" no-recurse="1" detailed="1" action="1" no-hooks="1">
-        <doc xml:space="preserve">The notify signal is emitted on an object when one of its
-properties has been changed. Note that getting this signal
-doesn't guarantee that the value of the property has actually
-changed, it may also be emitted when the setter for the property
-is called to reinstate the previous value.
+        <doc xml:space="preserve">The notify signal is emitted on an object when one of its properties has
+its value set through g_object_set_property(), g_object_set(), et al.
+
+Note that getting this signal doesn&#x2019;t itself guarantee that the value of
+the property has actually changed. When it is emitted is determined by the
+derived GObject class. If the implementor did not create the property with
+%G_PARAM_EXPLICIT_NOTIFY, then any call to g_object_set_property() results
+in ::notify being emitted, even if the new value is the same as the old.
+If they did pass %G_PARAM_EXPLICIT_NOTIFY, then this signal is emitted only
+when they explicitly call g_object_notify() or g_object_notify_by_pspec(),
+and common practice is to do that only when the value has actually changed.
 
 This signal is typically used to obtain change notification for a
 single property, by specifying the property name as a detail in the
@@ -4970,7 +4978,7 @@ g_signal_connect (text_view-&gt;buffer, "notify::paste-target-list",
                   text_view)
 ]|
 It is important to note that you must use
-[canonical][canonical-parameter-name] parameter names as
+[canonical parameter names][canonical-parameter-names] as
 detail strings for the notify signal.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -6535,7 +6543,13 @@ g_param_type_register_static().</doc>
       </field>
     </class>
     <class name="ParamSpecVariant" c:symbol-prefix="param_spec_variant" c:type="GParamSpecVariant" version="2.26" parent="ParamSpec" glib:type-name="GParamVariant" glib:get-type="intern" glib:fundamental="1">
-      <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for #GVariant properties.</doc>
+      <doc xml:space="preserve">A #GParamSpec derived structure that contains the meta data for #GVariant properties.
+
+When comparing values with g_param_values_cmp(), scalar values with the same
+type will be compared with g_variant_compare(). Other non-%NULL variants will
+be checked for equality with g_variant_equal(), and their sort order is
+otherwise undefined. %NULL is ordered before non-%NULL variants. Two %NULL
+values compare equal.</doc>
       <field name="parent_instance">
         <doc xml:space="preserve">private #GParamSpec portion</doc>
         <type name="ParamSpec" c:type="GParamSpec"/>
@@ -6632,7 +6646,7 @@ You may not attach these to signals created with the #G_SIGNAL_NO_HOOKS flag.</d
         <parameter name="param_values" transfer-ownership="none">
           <doc xml:space="preserve">the instance on which
  the signal was emitted, followed by the parameters of the emission.</doc>
-          <array length="1" zero-terminated="0" c:type="GValue*">
+          <array length="1" zero-terminated="0" c:type="const GValue*">
             <type name="Value" c:type="GValue"/>
           </array>
         </parameter>
@@ -6762,7 +6776,7 @@ filled in by the g_signal_query() function.</doc>
  [param_types param_names,]
  gpointer     data2);
  ]|</doc>
-        <array length="5" zero-terminated="0" c:type="GType*">
+        <array length="5" zero-terminated="0" c:type="const GType*">
           <type name="GType" c:type="GType"/>
         </array>
       </field>
@@ -6855,7 +6869,7 @@ of a toggle reference changes. See g_object_add_toggle_ref().</doc>
       <field name="g_type" readable="0" private="1">
         <type name="GType" c:type="GType"/>
       </field>
-      <method name="add_private" c:identifier="g_type_class_add_private" version="2.4">
+      <method name="add_private" c:identifier="g_type_class_add_private" version="2.4" deprecated="1" deprecated-version="2.58">
         <doc xml:space="preserve">Registers a private structure for an instantiatable type.
 
 When an object is allocated, the private structures for
@@ -6918,6 +6932,8 @@ my_object_get_some_field (MyObject *my_object)
   return priv-&gt;some_field;
 }
 ]|</doc>
+        <doc-deprecated xml:space="preserve">Use the G_ADD_PRIVATE() macro with the `G_DEFINE_*`
+  family of macros to add instance private data to a type</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8526,7 +8542,7 @@ Get the contents of a %G_TYPE_CHAR #GValue.</doc>
       </method>
       <method name="get_variant" c:identifier="g_value_get_variant" version="2.26">
         <doc xml:space="preserve">Get the contents of a variant #GValue.</doc>
-        <return-value transfer-ownership="full" nullable="1">
+        <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">variant contents of @value (may be %NULL)</doc>
           <type name="GLib.Variant" c:type="GVariant*"/>
         </return-value>
@@ -10703,7 +10719,7 @@ pointer casts.</doc>
       <parameters>
         <parameter name="object_ptr" transfer-ownership="none">
           <doc xml:space="preserve">a pointer to a #GObject reference</doc>
-          <type name="Object" c:type="volatile GObject**"/>
+          <type name="Object" c:type="GObject**"/>
         </parameter>
       </parameters>
     </function>
@@ -12058,7 +12074,7 @@ g_signal_override_class_handler().</doc>
           <doc xml:space="preserve">the argument list of the signal emission.
  The first element in the array is a #GValue for the instance the signal
  is being emitted on. The rest are any arguments to be passed to the signal.</doc>
-          <array zero-terminated="0" c:type="GValue*">
+          <array zero-terminated="0" c:type="const GValue*">
             <type name="Value" c:type="GValue"/>
           </array>
         </parameter>
@@ -12317,7 +12333,7 @@ connected, in contrast to g_signal_emit() and g_signal_emit_valist().</doc>
           <doc xml:space="preserve">argument list for the signal emission.
  The first element in the array is a #GValue for the instance the signal
  is being emitted on. The rest are any arguments to be passed to the signal.</doc>
-          <array zero-terminated="0" c:type="GValue*">
+          <array zero-terminated="0" c:type="const GValue*">
             <type name="Value" c:type="GValue"/>
           </array>
         </parameter>
@@ -12804,7 +12820,7 @@ the marshaller for this signal.</doc>
       <doc xml:space="preserve">Creates a new signal. (This is usually done in the class initializer.)
 
 This is a variant of g_signal_new() that takes a C callback instead
-off a class offset for the signal's class handler. This function
+of a class offset for the signal's class handler. This function
 doesn't need a function pointer exposed in the class structure of
 an object definition, instead the function pointer is passed
 directly and can be overriden by derived classes with

--- a/Gdk-3.0.gir
+++ b/Gdk-3.0.gir
@@ -3102,7 +3102,7 @@ according to the
             <doc xml:space="preserve">an array of targets
                    that should be saved, or %NULL
                    if all available targets should be saved.</doc>
-            <array length="3" zero-terminated="0" c:type="GdkAtom*">
+            <array length="3" zero-terminated="0" c:type="const GdkAtom*">
               <type name="Atom" c:type="GdkAtom"/>
             </array>
           </parameter>
@@ -3537,7 +3537,7 @@ gdk_drag_context_get_suggested_action() returns %GDK_ACTION_ASK.</doc>
         </parameters>
       </method>
       <method name="get_dest_window" c:identifier="gdk_drag_context_get_dest_window" version="3.0">
-        <doc xml:space="preserve">Returns the destination windw for the DND operation.</doc>
+        <doc xml:space="preserve">Returns the destination window for the DND operation.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a #GdkWindow</doc>
           <type name="Window" c:type="GdkWindow*"/>
@@ -3581,7 +3581,7 @@ the drag operation is over.</doc>
         </parameters>
       </method>
       <method name="get_protocol" c:identifier="gdk_drag_context_get_protocol" version="3.0">
-        <doc xml:space="preserve">Returns the drag protocol thats used by this context.</doc>
+        <doc xml:space="preserve">Returns the drag protocol that is used by this context.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the drag protocol</doc>
           <type name="DragProtocol" c:type="GdkDragProtocol"/>
@@ -17536,13 +17536,11 @@ the window does not want to receive input focus.</doc>
         </parameters>
       </method>
       <method name="get_background_pattern" c:identifier="gdk_window_get_background_pattern" version="2.22" deprecated="1" deprecated-version="3.22">
-        <doc xml:space="preserve">Gets the pattern used to clear the background on @window. If @window
-does not have its own background and reuses the parent's, %NULL is
-returned and you&#x2019;ll have to query it yourself.</doc>
+        <doc xml:space="preserve">Gets the pattern used to clear the background on @window.</doc>
         <doc-deprecated xml:space="preserve">Don't use this function</doc-deprecated>
         <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">The pattern to use for the
-background or %NULL to use the parent&#x2019;s background.</doc>
+background or %NULL if there is no background.</doc>
           <type name="cairo.Pattern" c:type="cairo_pattern_t*"/>
         </return-value>
         <parameters>
@@ -18856,6 +18854,57 @@ move, then resize, if you don&#x2019;t use gdk_window_move_resize().)</doc>
           </parameter>
         </parameters>
       </method>
+      <method name="move_to_rect" c:identifier="gdk_window_move_to_rect" version="3.24">
+        <doc xml:space="preserve">Moves @window to @rect, aligning their anchor points.
+
+@rect is relative to the top-left corner of the window that @window is
+transient for. @rect_anchor and @window_anchor determine anchor points on
+@rect and @window to pin together. @rect's anchor point can optionally be
+offset by @rect_anchor_dx and @rect_anchor_dy, which is equivalent to
+offsetting the position of @window.
+
+@anchor_hints determines how @window will be moved if the anchor points cause
+it to move off-screen. For example, %GDK_ANCHOR_FLIP_X will replace
+%GDK_GRAVITY_NORTH_WEST with %GDK_GRAVITY_NORTH_EAST and vice versa if
+@window extends beyond the left or right edges of the monitor.
+
+Connect to the #GdkWindow::moved-to-rect signal to find out how it was
+actually positioned.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="window" transfer-ownership="none">
+            <doc xml:space="preserve">the #GdkWindow to move</doc>
+            <type name="Window" c:type="GdkWindow*"/>
+          </instance-parameter>
+          <parameter name="rect" transfer-ownership="none">
+            <doc xml:space="preserve">the destination #GdkRectangle to align @window with</doc>
+            <type name="Rectangle" c:type="const GdkRectangle*"/>
+          </parameter>
+          <parameter name="rect_anchor" transfer-ownership="none">
+            <doc xml:space="preserve">the point on @rect to align with @window's anchor point</doc>
+            <type name="Gravity" c:type="GdkGravity"/>
+          </parameter>
+          <parameter name="window_anchor" transfer-ownership="none">
+            <doc xml:space="preserve">the point on @window to align with @rect's anchor point</doc>
+            <type name="Gravity" c:type="GdkGravity"/>
+          </parameter>
+          <parameter name="anchor_hints" transfer-ownership="none">
+            <doc xml:space="preserve">positioning hints to use when limited on space</doc>
+            <type name="AnchorHints" c:type="GdkAnchorHints"/>
+          </parameter>
+          <parameter name="rect_anchor_dx" transfer-ownership="none">
+            <doc xml:space="preserve">horizontal offset to shift @window, i.e. @rect's anchor
+                 point</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="rect_anchor_dy" transfer-ownership="none">
+            <doc xml:space="preserve">vertical offset to shift @window, i.e. @rect's anchor point</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
       <method name="peek_children" c:identifier="gdk_window_peek_children">
         <doc xml:space="preserve">Like gdk_window_get_children(), but does not copy the list of
 children, so the list does not need to be freed.</doc>
@@ -19102,8 +19151,9 @@ custom widget.</doc>
       <method name="set_background_pattern" c:identifier="gdk_window_set_background_pattern" deprecated="1" deprecated-version="3.22">
         <doc xml:space="preserve">Sets the background of @window.
 
-A background of %NULL means that the window will inherit its
-background from its parent window.
+A background of %NULL means that the window won't have any background. On the
+X11 backend it's also possible to inherit the background from the parent
+window using gdk_x11_get_parent_relative_pattern().
 
 The windowing system will normally fill a window with its background
 when the window is obscured then exposed.</doc>
@@ -22389,7 +22439,7 @@ of text, such as when text is selected.</doc>
           <doc xml:space="preserve">array of byte indexes into the layout,
     where even members of array are start indexes and odd elements
     are end indexes</doc>
-          <array zero-terminated="0" c:type="gint*">
+          <array zero-terminated="0" c:type="const gint*">
             <type name="gint" c:type="gint"/>
           </array>
         </parameter>
@@ -23300,7 +23350,7 @@ a list of UTF-8 strings.</doc>
         </parameter>
         <parameter name="text" transfer-ownership="none">
           <doc xml:space="preserve">the text to convert</doc>
-          <array length="4" zero-terminated="0" c:type="guchar*">
+          <array length="4" zero-terminated="0" c:type="const guchar*">
             <type name="guint8" c:type="guchar"/>
           </array>
         </parameter>

--- a/GdkPixbuf-2.0.gir
+++ b/GdkPixbuf-2.0.gir
@@ -17,15 +17,13 @@ the gdk-pixbuf library.  Currently only RGB is supported.</doc>
     </enumeration>
     <enumeration name="InterpType" glib:type-name="GdkInterpType" glib:get-type="gdk_interp_type_get_type" c:type="GdkInterpType">
       <doc xml:space="preserve">This enumeration describes the different interpolation modes that
- can be used with the scaling functions. @GDK_INTERP_NEAREST is
- the fastest scaling method, but has horrible quality when
- scaling down. @GDK_INTERP_BILINEAR is the best choice if you
- aren't sure what to choose, it has a good speed/quality balance.
+can be used with the scaling functions. @GDK_INTERP_NEAREST is
+the fastest scaling method, but has horrible quality when
+scaling down. @GDK_INTERP_BILINEAR is the best choice if you
+aren't sure what to choose, it has a good speed/quality balance.
 
- &lt;note&gt;
-	Cubic filtering is missing from the list; hyperbolic
-	interpolation is just as fast and results in higher quality.
- &lt;/note&gt;</doc>
+**Note**: Cubic filtering is missing from the list; hyperbolic
+interpolation is just as fast and results in higher quality.</doc>
       <member name="nearest" value="0" c:identifier="GDK_INTERP_NEAREST" glib:nick="nearest">
         <doc xml:space="preserve">Nearest neighbor sampling; this is the fastest
  and lowest quality mode. Quality is normally unacceptable when scaling
@@ -50,14 +48,13 @@ the gdk-pixbuf library.  Currently only RGB is supported.</doc>
  reconstruction function. It is derived from the hyperbolic filters in
  Wolberg's "Digital Image Warping", and is formally defined as the
  hyperbolic-filter sampling the ideal hyperbolic-filter interpolated
- image (the filter is designed to be idempotent for 1:1 pixel mapping).</doc>
+ image (the filter is designed to be idempotent for 1:1 pixel mapping).
+ **Deprecated**: this interpolation filter is deprecated, as in reality
+ it has a lower quality than the @GDK_INTERP_BILINEAR filter
+ (Since: 2.38)</doc>
       </member>
     </enumeration>
     <constant name="PIXBUF_FEATURES_H" value="1" c:type="GDK_PIXBUF_FEATURES_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="PIXBUF_MAGIC_NUMBER" value="1197763408" c:type="GDK_PIXBUF_MAGIC_NUMBER">
-      <doc xml:space="preserve">Magic number for #GdkPixdata structures.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
     <constant name="PIXBUF_MAJOR" value="2" c:type="GDK_PIXBUF_MAJOR">
@@ -65,25 +62,21 @@ the gdk-pixbuf library.  Currently only RGB is supported.</doc>
 "0.8.2" for example.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="PIXBUF_MICRO" value="11" c:type="GDK_PIXBUF_MICRO">
+    <constant name="PIXBUF_MICRO" value="0" c:type="GDK_PIXBUF_MICRO">
       <doc xml:space="preserve">Micro version of gdk-pixbuf library, that is the "2" in
 "0.8.2" for example.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="PIXBUF_MINOR" value="36" c:type="GDK_PIXBUF_MINOR">
+    <constant name="PIXBUF_MINOR" value="38" c:type="GDK_PIXBUF_MINOR">
       <doc xml:space="preserve">Minor version of gdk-pixbuf library, that is the "8" in
 "0.8.2" for example.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="PIXBUF_VERSION" value="2.36.11" c:type="GDK_PIXBUF_VERSION">
+    <constant name="PIXBUF_VERSION" value="2.38.0" c:type="GDK_PIXBUF_VERSION">
       <doc xml:space="preserve">Contains the full version of the gdk-pixbuf header as a string.
 This is the version being compiled against; contrast with
 #gdk_pixbuf_version.</doc>
       <type name="utf8" c:type="gchar*"/>
-    </constant>
-    <constant name="PIXDATA_HEADER_LENGTH" value="24" c:type="GDK_PIXDATA_HEADER_LENGTH">
-      <doc xml:space="preserve">The length of a #GdkPixdata structure without the @pixel_data pointer.</doc>
-      <type name="gint" c:type="gint"/>
     </constant>
     <class name="Pixbuf" c:symbol-prefix="pixbuf" c:type="GdkPixbuf" parent="GObject.Object" glib:type-name="GdkPixbuf" glib:get-type="gdk_pixbuf_get_type">
       <doc xml:space="preserve">This is the main structure in the gdk-pixbuf library.  It is
@@ -97,7 +90,7 @@ one row and the start of the next).</doc>
         <doc xml:space="preserve">Creates a new #GdkPixbuf structure and allocates a buffer for it.  The
 buffer has an optimal rowstride.  Note that the buffer is not cleared;
 you will have to fill it completely yourself.</doc>
-        <return-value transfer-ownership="full">
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">A newly-created #GdkPixbuf with a reference count of 1, or
 %NULL if not enough memory could be allocated for the image buffer.</doc>
           <type name="Pixbuf" c:type="GdkPixbuf*"/>
@@ -182,7 +175,7 @@ See also gdk_pixbuf_new_from_bytes().</doc>
         <parameters>
           <parameter name="data" transfer-ownership="none">
             <doc xml:space="preserve">Image data in 8-bit/sample packed format</doc>
-            <array zero-terminated="0" c:type="guchar*">
+            <array zero-terminated="0" c:type="const guchar*">
               <type name="guint8" c:type="guchar"/>
             </array>
           </parameter>
@@ -234,8 +227,9 @@ allocate the image buffer, or the image file contained invalid data.</doc>
         </return-value>
         <parameters>
           <parameter name="filename" transfer-ownership="none">
-            <doc xml:space="preserve">Name of file to load, in the GLib file name encoding</doc>
-            <type name="utf8" c:type="const char*"/>
+            <doc xml:space="preserve">Name of file to load, in the GLib file
+    name encoding</doc>
+            <type name="filename" c:type="const char*"/>
           </parameter>
         </parameters>
       </constructor>
@@ -261,8 +255,9 @@ allocate the image buffer, or the image file contained invalid data.</doc>
         </return-value>
         <parameters>
           <parameter name="filename" transfer-ownership="none">
-            <doc xml:space="preserve">Name of file to load, in the GLib file name encoding</doc>
-            <type name="utf8" c:type="const char*"/>
+            <doc xml:space="preserve">Name of file to load, in the GLib file
+    name encoding</doc>
+            <type name="filename" c:type="const char*"/>
           </parameter>
           <parameter name="width" transfer-ownership="none">
             <doc xml:space="preserve">The width the image should have or -1 to not constrain the width</doc>
@@ -299,8 +294,9 @@ invalid data.</doc>
         </return-value>
         <parameters>
           <parameter name="filename" transfer-ownership="none">
-            <doc xml:space="preserve">Name of file to load, in the GLib file name encoding</doc>
-            <type name="utf8" c:type="const char*"/>
+            <doc xml:space="preserve">Name of file to load, in the GLib file
+    name encoding</doc>
+            <type name="filename" c:type="const char*"/>
           </parameter>
           <parameter name="width" transfer-ownership="none">
             <doc xml:space="preserve">The width the image should have or -1 to not constrain the width</doc>
@@ -358,7 +354,7 @@ addition.</doc>
           <parameter name="data" transfer-ownership="none">
             <doc xml:space="preserve">Byte data containing a
    serialized #GdkPixdata structure</doc>
-            <array length="0" zero-terminated="0" c:type="guint8*">
+            <array length="0" zero-terminated="0" c:type="const guint8*">
               <type name="guint8" c:type="guint8"/>
             </array>
           </parameter>
@@ -533,7 +529,7 @@ the result of including an XPM file into a program's C source.</doc>
         <parameters>
           <parameter name="data" transfer-ownership="none">
             <doc xml:space="preserve">Pointer to inline XPM data.</doc>
-            <array c:type="char**">
+            <array c:type="const char**">
               <type name="utf8" c:type="char*"/>
             </array>
           </parameter>
@@ -570,27 +566,6 @@ check image values without needing to create them.</doc>
           </parameter>
         </parameters>
       </function>
-      <function name="from_pixdata" c:identifier="gdk_pixbuf_from_pixdata" deprecated="1" deprecated-version="2.32" throws="1">
-        <doc xml:space="preserve">Converts a #GdkPixdata to a #GdkPixbuf. If @copy_pixels is %TRUE or
-if the pixel data is run-length-encoded, the pixel data is copied into
-newly-allocated memory; otherwise it is reused.</doc>
-        <doc-deprecated xml:space="preserve">Use #GResource instead.</doc-deprecated>
-        <return-value transfer-ownership="full">
-          <doc xml:space="preserve">a new #GdkPixbuf.</doc>
-          <type name="Pixbuf" c:type="GdkPixbuf*"/>
-        </return-value>
-        <parameters>
-          <parameter name="pixdata" transfer-ownership="none">
-            <doc xml:space="preserve">a #GdkPixdata to convert into a #GdkPixbuf.</doc>
-            <type name="Pixdata" c:type="const GdkPixdata*"/>
-          </parameter>
-          <parameter name="copy_pixels" transfer-ownership="none">
-            <doc xml:space="preserve">whether to copy raw pixel data; run-length encoded
-    pixel data is always copied.</doc>
-            <type name="gboolean" c:type="gboolean"/>
-          </parameter>
-        </parameters>
-      </function>
       <function name="get_file_info" c:identifier="gdk_pixbuf_get_file_info" version="2.4">
         <doc xml:space="preserve">Parses an image file far enough to determine its format and size.</doc>
         <return-value transfer-ownership="none" nullable="1">
@@ -603,7 +578,7 @@ newly-allocated memory; otherwise it is reused.</doc>
         <parameters>
           <parameter name="filename" transfer-ownership="none">
             <doc xml:space="preserve">The name of the file to identify.</doc>
-            <type name="utf8" c:type="const gchar*"/>
+            <type name="filename" c:type="const gchar*"/>
           </parameter>
           <parameter name="width" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">Return location for the width of the
@@ -633,7 +608,7 @@ get the result of the operation.</doc>
         <parameters>
           <parameter name="filename" transfer-ownership="none">
             <doc xml:space="preserve">The name of the file to identify</doc>
-            <type name="utf8" c:type="const gchar*"/>
+            <type name="filename" c:type="const gchar*"/>
           </parameter>
           <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">optional #GCancellable object, %NULL to ignore</doc>
@@ -990,7 +965,7 @@ function suitable for many tasks.</doc>
         <doc xml:space="preserve">Creates a new #GdkPixbuf by scaling @src to @dest_width x
 @dest_height and alpha blending the result with a checkboard of colors
 @color1 and @color2.</doc>
-        <return-value transfer-ownership="full">
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">the new #GdkPixbuf, or %NULL if not enough memory could be
 allocated for it.</doc>
           <type name="Pixbuf" c:type="GdkPixbuf*"/>
@@ -1034,7 +1009,7 @@ allocated for it.</doc>
         <doc xml:space="preserve">Creates a new #GdkPixbuf with a copy of the information in the specified
 @pixbuf. Note that this does not copy the options set on the original #GdkPixbuf,
 use gdk_pixbuf_copy_options() for this.</doc>
-        <return-value transfer-ownership="full">
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">A newly-created pixbuf with a reference count of 1, or %NULL if
 not enough memory could be allocated.</doc>
           <type name="Pixbuf" c:type="GdkPixbuf*"/>
@@ -1283,7 +1258,7 @@ See gdk_pixbuf_get_option() for more details.</doc>
         <doc xml:space="preserve">Queries a pointer to the pixel data of a pixbuf.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A pointer to the pixbuf's pixel data.
-Please see the section on [image data](image-data) for information
+Please see the section on [image data][image-data] for information
 about how the pixel data is stored in memory.
 
 This function will cause an implicit copy of the pixbuf data if the
@@ -1303,7 +1278,7 @@ pixbuf was created from read-only data.</doc>
         <doc xml:space="preserve">Queries a pointer to the pixel data of a pixbuf.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A pointer to the pixbuf's
-pixel data.  Please see the section on [image data](image-data)
+pixel data.  Please see the section on [image data][image-data]
 for information about how the pixel data is stored in memory.
 
 This function will cause an implicit copy of the pixbuf data if the
@@ -1387,11 +1362,15 @@ to be mutable.</doc>
         </parameters>
       </method>
       <method name="read_pixel_bytes" c:identifier="gdk_pixbuf_read_pixel_bytes" version="2.32">
+        <doc xml:space="preserve">Provides a #GBytes buffer containing the raw pixel data; the data
+must not be modified.  This function allows skipping the implicit
+copy that must be made if gdk_pixbuf_get_pixels() is called on a
+read-only pixbuf.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A new reference to a read-only copy of
-the pixel data.  Note that for mutable pixbufs, this function will
-incur a one-time copy of the pixel data for conversion into the
-returned #GBytes.</doc>
+  the pixel data.  Note that for mutable pixbufs, this function will
+  incur a one-time copy of the pixel data for conversion into the
+  returned #GBytes.</doc>
           <type name="GLib.Bytes" c:type="GBytes*"/>
         </return-value>
         <parameters>
@@ -1402,11 +1381,12 @@ returned #GBytes.</doc>
         </parameters>
       </method>
       <method name="read_pixels" c:identifier="gdk_pixbuf_read_pixels" version="2.32">
-        <doc xml:space="preserve">Returns a read-only pointer to the raw pixel data; must not be
+        <doc xml:space="preserve">Provides a read-only pointer to the raw pixel data; must not be
 modified.  This function allows skipping the implicit copy that
 must be made if gdk_pixbuf_get_pixels() is called on a read-only
 pixbuf.</doc>
         <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a read-only pointer to the raw pixel data</doc>
           <type name="guint8" c:type="const guint8*"/>
         </return-value>
         <parameters>
@@ -1574,7 +1554,7 @@ it produces a CUR instead of an ICO.</doc>
           </instance-parameter>
           <parameter name="filename" transfer-ownership="none">
             <doc xml:space="preserve">name of file to save.</doc>
-            <type name="utf8" c:type="const char*"/>
+            <type name="filename" c:type="const char*"/>
           </parameter>
           <parameter name="type" transfer-ownership="none">
             <doc xml:space="preserve">name of file format.</doc>
@@ -1949,7 +1929,7 @@ See gdk_pixbuf_save () for more details.</doc>
           </instance-parameter>
           <parameter name="filename" transfer-ownership="none">
             <doc xml:space="preserve">name of file to save.</doc>
-            <type name="utf8" c:type="const char*"/>
+            <type name="filename" c:type="const char*"/>
           </parameter>
           <parameter name="type" transfer-ownership="none">
             <doc xml:space="preserve">name of file format.</doc>
@@ -2049,7 +2029,7 @@ copy of @src is returned, avoiding any scaling.
 
 For more complicated scaling/alpha blending see gdk_pixbuf_scale()
 and gdk_pixbuf_composite().</doc>
-        <return-value transfer-ownership="full">
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">the new #GdkPixbuf, or %NULL if not enough memory could be
 allocated for it.</doc>
           <type name="Pixbuf" c:type="GdkPixbuf*"/>
@@ -2180,8 +2160,9 @@ allocate the image buffer, or the image file contained invalid data.</doc>
         </return-value>
         <parameters>
           <parameter name="filename" transfer-ownership="none">
-            <doc xml:space="preserve">Name of file to load, in the GLib file name encoding</doc>
-            <type name="utf8" c:type="const char*"/>
+            <doc xml:space="preserve">Name of file to load, in the GLib file
+    name encoding</doc>
+            <type name="filename" c:type="const char*"/>
           </parameter>
         </parameters>
       </constructor>
@@ -3000,7 +2981,7 @@ cannot parse the buffer.</doc>
           </instance-parameter>
           <parameter name="buf" transfer-ownership="none">
             <doc xml:space="preserve">Pointer to image data.</doc>
-            <array length="1" zero-terminated="0" c:type="guchar*">
+            <array length="1" zero-terminated="0" c:type="const guchar*">
               <type name="guint8" c:type="guchar"/>
             </array>
           </parameter>
@@ -3209,7 +3190,7 @@ will fail with the same error.</doc>
       <parameters>
         <parameter name="buf" transfer-ownership="none">
           <doc xml:space="preserve">bytes to be written.</doc>
-          <array length="1" zero-terminated="0" c:type="gchar*">
+          <array length="1" zero-terminated="0" c:type="const gchar*">
             <type name="guint8"/>
           </array>
         </parameter>
@@ -3306,232 +3287,6 @@ was constructed.</doc>
     </record>
     <class name="PixbufSimpleAnimIter" c:symbol-prefix="pixbuf_simple_anim_iter" parent="PixbufAnimationIter" glib:type-name="GdkPixbufSimpleAnimIter" glib:get-type="gdk_pixbuf_simple_anim_iter_get_type">
     </class>
-    <record name="Pixdata" c:type="GdkPixdata">
-      <doc xml:space="preserve">A #GdkPixdata contains pixbuf information in a form suitable for
-serialization and streaming.</doc>
-      <field name="magic" writable="1">
-        <doc xml:space="preserve">magic number. A valid #GdkPixdata structure must have
-   #GDK_PIXBUF_MAGIC_NUMBER here.</doc>
-        <type name="guint32" c:type="guint32"/>
-      </field>
-      <field name="length" writable="1">
-        <doc xml:space="preserve">less than 1 to disable length checks, otherwise
-   #GDK_PIXDATA_HEADER_LENGTH + length of @pixel_data.</doc>
-        <type name="gint32" c:type="gint32"/>
-      </field>
-      <field name="pixdata_type" writable="1">
-        <doc xml:space="preserve">information about colorspace, sample width and
-   encoding, in a #GdkPixdataType.</doc>
-        <type name="guint32" c:type="guint32"/>
-      </field>
-      <field name="rowstride" writable="1">
-        <doc xml:space="preserve">Distance in bytes between rows.</doc>
-        <type name="guint32" c:type="guint32"/>
-      </field>
-      <field name="width" writable="1">
-        <doc xml:space="preserve">Width of the image in pixels.</doc>
-        <type name="guint32" c:type="guint32"/>
-      </field>
-      <field name="height" writable="1">
-        <doc xml:space="preserve">Height of the image in pixels.</doc>
-        <type name="guint32" c:type="guint32"/>
-      </field>
-      <field name="pixel_data" writable="1">
-        <doc xml:space="preserve">@width x @height pixels, encoded according to @pixdata_type
-  and @rowstride.</doc>
-        <array zero-terminated="0" c:type="guint8*">
-          <type name="guint8"/>
-        </array>
-      </field>
-      <method name="deserialize" c:identifier="gdk_pixdata_deserialize" deprecated="1" deprecated-version="2.32" throws="1">
-        <doc xml:space="preserve">Deserializes (reconstruct) a #GdkPixdata structure from a byte stream.
-The byte stream consists of a straightforward writeout of the
-#GdkPixdata fields in network byte order, plus the @pixel_data
-bytes the structure points to.
-The @pixdata contents are reconstructed byte by byte and are checked
-for validity. This function may fail with %GDK_PIXBUF_ERROR_CORRUPT_IMAGE
-or %GDK_PIXBUF_ERROR_UNKNOWN_TYPE.</doc>
-        <doc-deprecated xml:space="preserve">Use #GResource instead.</doc-deprecated>
-        <return-value transfer-ownership="none">
-          <doc xml:space="preserve">Upon successful deserialization %TRUE is returned,
-%FALSE otherwise.</doc>
-          <type name="gboolean" c:type="gboolean"/>
-        </return-value>
-        <parameters>
-          <instance-parameter name="pixdata" transfer-ownership="none">
-            <doc xml:space="preserve">a #GdkPixdata structure to be filled in.</doc>
-            <type name="Pixdata" c:type="GdkPixdata*"/>
-          </instance-parameter>
-          <parameter name="stream_length" transfer-ownership="none">
-            <doc xml:space="preserve">length of the stream used for deserialization.</doc>
-            <type name="guint" c:type="guint"/>
-          </parameter>
-          <parameter name="stream" transfer-ownership="none">
-            <doc xml:space="preserve">stream of bytes containing a
-  serialized #GdkPixdata structure.</doc>
-            <array length="0" zero-terminated="0" c:type="guint8*">
-              <type name="guint8" c:type="guint8"/>
-            </array>
-          </parameter>
-        </parameters>
-      </method>
-      <method name="from_pixbuf" c:identifier="gdk_pixdata_from_pixbuf" introspectable="0" deprecated="1" deprecated-version="2.32">
-        <doc xml:space="preserve">Converts a #GdkPixbuf to a #GdkPixdata. If @use_rle is %TRUE, the
-pixel data is run-length encoded into newly-allocated memory and a
-pointer to that memory is returned.</doc>
-        <doc-deprecated xml:space="preserve">Use #GResource instead.</doc-deprecated>
-        <return-value transfer-ownership="none" nullable="1">
-          <doc xml:space="preserve">If @use_rle is %TRUE, a pointer to the
-  newly-allocated memory for the run-length encoded pixel data,
-  otherwise %NULL.</doc>
-          <type name="gpointer" c:type="gpointer"/>
-        </return-value>
-        <parameters>
-          <instance-parameter name="pixdata" transfer-ownership="none">
-            <doc xml:space="preserve">a #GdkPixdata to fill.</doc>
-            <type name="Pixdata" c:type="GdkPixdata*"/>
-          </instance-parameter>
-          <parameter name="pixbuf" transfer-ownership="none">
-            <doc xml:space="preserve">the data to fill @pixdata with.</doc>
-            <type name="Pixbuf" c:type="const GdkPixbuf*"/>
-          </parameter>
-          <parameter name="use_rle" transfer-ownership="none">
-            <doc xml:space="preserve">whether to use run-length encoding for the pixel data.</doc>
-            <type name="gboolean" c:type="gboolean"/>
-          </parameter>
-        </parameters>
-      </method>
-      <method name="serialize" c:identifier="gdk_pixdata_serialize" deprecated="1" deprecated-version="2.32">
-        <doc xml:space="preserve">Serializes a #GdkPixdata structure into a byte stream.
-The byte stream consists of a straightforward writeout of the
-#GdkPixdata fields in network byte order, plus the @pixel_data
-bytes the structure points to.</doc>
-        <doc-deprecated xml:space="preserve">Use #GResource instead.</doc-deprecated>
-        <return-value transfer-ownership="full">
-          <doc xml:space="preserve">A
-newly-allocated string containing the serialized #GdkPixdata
-structure.</doc>
-          <array length="0" zero-terminated="0" c:type="guint8*">
-            <type name="guint8" c:type="guint8"/>
-          </array>
-        </return-value>
-        <parameters>
-          <instance-parameter name="pixdata" transfer-ownership="none">
-            <doc xml:space="preserve">a valid #GdkPixdata structure to serialize.</doc>
-            <type name="Pixdata" c:type="const GdkPixdata*"/>
-          </instance-parameter>
-          <parameter name="stream_length_p" direction="out" caller-allocates="0" transfer-ownership="full">
-            <doc xml:space="preserve">location to store the resulting stream length in.</doc>
-            <type name="guint" c:type="guint*"/>
-          </parameter>
-        </parameters>
-      </method>
-      <method name="to_csource" c:identifier="gdk_pixdata_to_csource" deprecated="1" deprecated-version="2.32">
-        <doc xml:space="preserve">Generates C source code suitable for compiling images directly
-into programs.
-
-gdk-pixbuf ships with a program called
-[gdk-pixbuf-csource][gdk-pixbuf-csource], which offers a command
-line interface to this function.</doc>
-        <doc-deprecated xml:space="preserve">Use #GResource instead.</doc-deprecated>
-        <return-value transfer-ownership="full">
-          <doc xml:space="preserve">a newly-allocated string containing the C source form
-  of @pixdata.</doc>
-          <type name="GLib.String" c:type="GString*"/>
-        </return-value>
-        <parameters>
-          <instance-parameter name="pixdata" transfer-ownership="none">
-            <doc xml:space="preserve">a #GdkPixdata to convert to C source.</doc>
-            <type name="Pixdata" c:type="GdkPixdata*"/>
-          </instance-parameter>
-          <parameter name="name" transfer-ownership="none">
-            <doc xml:space="preserve">used for naming generated data structures or macros.</doc>
-            <type name="utf8" c:type="const gchar*"/>
-          </parameter>
-          <parameter name="dump_type" transfer-ownership="none">
-            <doc xml:space="preserve">a #GdkPixdataDumpType determining the kind of C
-  source to be generated.</doc>
-            <type name="PixdataDumpType" c:type="GdkPixdataDumpType"/>
-          </parameter>
-        </parameters>
-      </method>
-    </record>
-    <bitfield name="PixdataDumpType" c:type="GdkPixdataDumpType">
-      <doc xml:space="preserve">An enumeration which is used by gdk_pixdata_to_csource() to
-determine the form of C source to be generated. The three values
-@GDK_PIXDATA_DUMP_PIXDATA_STREAM, @GDK_PIXDATA_DUMP_PIXDATA_STRUCT
-and @GDK_PIXDATA_DUMP_MACROS are mutually exclusive, as are
-@GDK_PIXBUF_DUMP_GTYPES and @GDK_PIXBUF_DUMP_CTYPES. The remaining
-elements are optional flags that can be freely added.</doc>
-      <member name="pixdata_stream" value="0" c:identifier="GDK_PIXDATA_DUMP_PIXDATA_STREAM">
-        <doc xml:space="preserve">Generate pixbuf data stream (a single
-   string containing a serialized #GdkPixdata structure in network byte
-   order).</doc>
-      </member>
-      <member name="pixdata_struct" value="1" c:identifier="GDK_PIXDATA_DUMP_PIXDATA_STRUCT">
-        <doc xml:space="preserve">Generate #GdkPixdata structure (needs
-   the #GdkPixdata structure definition from gdk-pixdata.h).</doc>
-      </member>
-      <member name="macros" value="2" c:identifier="GDK_PIXDATA_DUMP_MACROS">
-        <doc xml:space="preserve">Generate &lt;function&gt;*_ROWSTRIDE&lt;/function&gt;,
-   &lt;function&gt;*_WIDTH&lt;/function&gt;, &lt;function&gt;*_HEIGHT&lt;/function&gt;,
-   &lt;function&gt;*_BYTES_PER_PIXEL&lt;/function&gt; and
-   &lt;function&gt;*_RLE_PIXEL_DATA&lt;/function&gt; or &lt;function&gt;*_PIXEL_DATA&lt;/function&gt;
-   macro definitions for the image.</doc>
-      </member>
-      <member name="gtypes" value="0" c:identifier="GDK_PIXDATA_DUMP_GTYPES">
-        <doc xml:space="preserve">Generate GLib data types instead of
-   standard C data types.</doc>
-      </member>
-      <member name="ctypes" value="256" c:identifier="GDK_PIXDATA_DUMP_CTYPES">
-        <doc xml:space="preserve">Generate standard C data types instead of
-   GLib data types.</doc>
-      </member>
-      <member name="static" value="512" c:identifier="GDK_PIXDATA_DUMP_STATIC">
-        <doc xml:space="preserve">Generate static symbols.</doc>
-      </member>
-      <member name="const" value="1024" c:identifier="GDK_PIXDATA_DUMP_CONST">
-        <doc xml:space="preserve">Generate const symbols.</doc>
-      </member>
-      <member name="rle_decoder" value="65536" c:identifier="GDK_PIXDATA_DUMP_RLE_DECODER">
-        <doc xml:space="preserve">Provide a &lt;function&gt;*_RUN_LENGTH_DECODE(image_buf, rle_data, size, bpp)&lt;/function&gt;
-   macro definition  to  decode  run-length encoded image data.</doc>
-      </member>
-    </bitfield>
-    <bitfield name="PixdataType" c:type="GdkPixdataType">
-      <doc xml:space="preserve">An enumeration containing three sets of flags for a #GdkPixdata struct:
-one for the used colorspace, one for the width of the samples and one
-for the encoding of the pixel data.</doc>
-      <member name="color_type_rgb" value="1" c:identifier="GDK_PIXDATA_COLOR_TYPE_RGB">
-        <doc xml:space="preserve">each pixel has red, green and blue samples.</doc>
-      </member>
-      <member name="color_type_rgba" value="2" c:identifier="GDK_PIXDATA_COLOR_TYPE_RGBA">
-        <doc xml:space="preserve">each pixel has red, green and blue samples
-   and an alpha value.</doc>
-      </member>
-      <member name="color_type_mask" value="255" c:identifier="GDK_PIXDATA_COLOR_TYPE_MASK">
-        <doc xml:space="preserve">mask for the colortype flags of the enum.</doc>
-      </member>
-      <member name="sample_width_8" value="65536" c:identifier="GDK_PIXDATA_SAMPLE_WIDTH_8">
-        <doc xml:space="preserve">each sample has 8 bits.</doc>
-      </member>
-      <member name="sample_width_mask" value="983040" c:identifier="GDK_PIXDATA_SAMPLE_WIDTH_MASK">
-        <doc xml:space="preserve">mask for the sample width flags of the enum.</doc>
-      </member>
-      <member name="encoding_raw" value="16777216" c:identifier="GDK_PIXDATA_ENCODING_RAW">
-        <doc xml:space="preserve">the pixel data is in raw form.</doc>
-      </member>
-      <member name="encoding_rle" value="33554432" c:identifier="GDK_PIXDATA_ENCODING_RLE">
-        <doc xml:space="preserve">the pixel data is run-length encoded. Runs may
-   be up to 127 bytes long; their length is stored in a single byte
-   preceding the pixel data for the run. If a run is constant, its length
-   byte has the high bit set and the pixel data consists of a single pixel
-   which must be repeated.</doc>
-      </member>
-      <member name="encoding_mask" value="251658240" c:identifier="GDK_PIXDATA_ENCODING_MASK">
-        <doc xml:space="preserve">mask for the encoding flags of the enum.</doc>
-      </member>
-    </bitfield>
     <function name="pixbuf_error_quark" c:identifier="gdk_pixbuf_error_quark" moved-to="PixbufError.quark">
       <return-value transfer-ownership="none">
         <type name="GLib.Quark" c:type="GQuark"/>

--- a/GdkPixdata-2.0.gir
+++ b/GdkPixdata-2.0.gir
@@ -1,0 +1,266 @@
+<?xml version="1.0"?>
+<!-- This file was automatically generated from C sources - DO NOT EDIT!
+To affect the contents of this file, edit the original C definitions,
+and/or use gtk-doc annotations.  -->
+<repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0" version="1.2">
+  <include name="GdkPixbuf" version="2.0"/>
+  <package name="gdk-pixbuf-2.0"/>
+  <c:include name="gdk-pixbuf/gdk-pixdata.h"/>
+  <namespace name="GdkPixdata" version="2.0" shared-library="libgdk_pixbuf-2.0.so.0" c:identifier-prefixes="Gdk" c:symbol-prefixes="gdk">
+    <constant name="PIXBUF_MAGIC_NUMBER" value="1197763408" c:type="GDK_PIXBUF_MAGIC_NUMBER">
+      <doc xml:space="preserve">Magic number for #GdkPixdata structures.</doc>
+      <type name="gint" c:type="gint"/>
+    </constant>
+    <constant name="PIXDATA_HEADER_LENGTH" value="24" c:type="GDK_PIXDATA_HEADER_LENGTH">
+      <doc xml:space="preserve">The length of a #GdkPixdata structure without the @pixel_data pointer.</doc>
+      <type name="gint" c:type="gint"/>
+    </constant>
+    <record name="Pixdata" c:type="GdkPixdata">
+      <doc xml:space="preserve">A #GdkPixdata contains pixbuf information in a form suitable for
+serialization and streaming.</doc>
+      <field name="magic" writable="1">
+        <doc xml:space="preserve">magic number. A valid #GdkPixdata structure must have
+   #GDK_PIXBUF_MAGIC_NUMBER here.</doc>
+        <type name="guint32" c:type="guint32"/>
+      </field>
+      <field name="length" writable="1">
+        <doc xml:space="preserve">less than 1 to disable length checks, otherwise
+   #GDK_PIXDATA_HEADER_LENGTH + length of @pixel_data.</doc>
+        <type name="gint32" c:type="gint32"/>
+      </field>
+      <field name="pixdata_type" writable="1">
+        <doc xml:space="preserve">information about colorspace, sample width and
+   encoding, in a #GdkPixdataType.</doc>
+        <type name="guint32" c:type="guint32"/>
+      </field>
+      <field name="rowstride" writable="1">
+        <doc xml:space="preserve">Distance in bytes between rows.</doc>
+        <type name="guint32" c:type="guint32"/>
+      </field>
+      <field name="width" writable="1">
+        <doc xml:space="preserve">Width of the image in pixels.</doc>
+        <type name="guint32" c:type="guint32"/>
+      </field>
+      <field name="height" writable="1">
+        <doc xml:space="preserve">Height of the image in pixels.</doc>
+        <type name="guint32" c:type="guint32"/>
+      </field>
+      <field name="pixel_data" writable="1">
+        <doc xml:space="preserve">@width x @height pixels, encoded according to @pixdata_type
+  and @rowstride.</doc>
+        <array zero-terminated="0" c:type="guint8*">
+          <type name="guint8"/>
+        </array>
+      </field>
+      <method name="deserialize" c:identifier="gdk_pixdata_deserialize" deprecated="1" deprecated-version="2.32" throws="1">
+        <doc xml:space="preserve">Deserializes (reconstruct) a #GdkPixdata structure from a byte stream.
+The byte stream consists of a straightforward writeout of the
+#GdkPixdata fields in network byte order, plus the @pixel_data
+bytes the structure points to.
+The @pixdata contents are reconstructed byte by byte and are checked
+for validity. This function may fail with %GDK_PIXBUF_ERROR_CORRUPT_IMAGE
+or %GDK_PIXBUF_ERROR_UNKNOWN_TYPE.</doc>
+        <doc-deprecated xml:space="preserve">Use #GResource instead.</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">Upon successful deserialization %TRUE is returned,
+%FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="pixdata" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkPixdata structure to be filled in.</doc>
+            <type name="Pixdata" c:type="GdkPixdata*"/>
+          </instance-parameter>
+          <parameter name="stream_length" transfer-ownership="none">
+            <doc xml:space="preserve">length of the stream used for deserialization.</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="stream" transfer-ownership="none">
+            <doc xml:space="preserve">stream of bytes containing a
+  serialized #GdkPixdata structure.</doc>
+            <array length="0" zero-terminated="0" c:type="const guint8*">
+              <type name="guint8" c:type="guint8"/>
+            </array>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="from_pixbuf" c:identifier="gdk_pixdata_from_pixbuf" introspectable="0" deprecated="1" deprecated-version="2.32">
+        <doc xml:space="preserve">Converts a #GdkPixbuf to a #GdkPixdata. If @use_rle is %TRUE, the
+pixel data is run-length encoded into newly-allocated memory and a
+pointer to that memory is returned.</doc>
+        <doc-deprecated xml:space="preserve">Use #GResource instead.</doc-deprecated>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">If @use_rle is %TRUE, a pointer to the
+  newly-allocated memory for the run-length encoded pixel data,
+  otherwise %NULL.</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="pixdata" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkPixdata to fill.</doc>
+            <type name="Pixdata" c:type="GdkPixdata*"/>
+          </instance-parameter>
+          <parameter name="pixbuf" transfer-ownership="none">
+            <doc xml:space="preserve">the data to fill @pixdata with.</doc>
+            <type name="GdkPixbuf.Pixbuf" c:type="const GdkPixbuf*"/>
+          </parameter>
+          <parameter name="use_rle" transfer-ownership="none">
+            <doc xml:space="preserve">whether to use run-length encoding for the pixel data.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="serialize" c:identifier="gdk_pixdata_serialize" deprecated="1" deprecated-version="2.32">
+        <doc xml:space="preserve">Serializes a #GdkPixdata structure into a byte stream.
+The byte stream consists of a straightforward writeout of the
+#GdkPixdata fields in network byte order, plus the @pixel_data
+bytes the structure points to.</doc>
+        <doc-deprecated xml:space="preserve">Use #GResource instead.</doc-deprecated>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">A
+newly-allocated string containing the serialized #GdkPixdata
+structure.</doc>
+          <array length="0" zero-terminated="0" c:type="guint8*">
+            <type name="guint8" c:type="guint8"/>
+          </array>
+        </return-value>
+        <parameters>
+          <instance-parameter name="pixdata" transfer-ownership="none">
+            <doc xml:space="preserve">a valid #GdkPixdata structure to serialize.</doc>
+            <type name="Pixdata" c:type="const GdkPixdata*"/>
+          </instance-parameter>
+          <parameter name="stream_length_p" direction="out" caller-allocates="0" transfer-ownership="full">
+            <doc xml:space="preserve">location to store the resulting stream length in.</doc>
+            <type name="guint" c:type="guint*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="to_csource" c:identifier="gdk_pixdata_to_csource" deprecated="1" deprecated-version="2.32">
+        <doc xml:space="preserve">Generates C source code suitable for compiling images directly
+into programs.
+
+gdk-pixbuf ships with a program called
+[gdk-pixbuf-csource][gdk-pixbuf-csource], which offers a command
+line interface to this function.</doc>
+        <doc-deprecated xml:space="preserve">Use #GResource instead.</doc-deprecated>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a newly-allocated string containing the C source form
+  of @pixdata.</doc>
+          <type name="GLib.String" c:type="GString*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="pixdata" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkPixdata to convert to C source.</doc>
+            <type name="Pixdata" c:type="GdkPixdata*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">used for naming generated data structures or macros.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="dump_type" transfer-ownership="none">
+            <doc xml:space="preserve">a #GdkPixdataDumpType determining the kind of C
+  source to be generated.</doc>
+            <type name="PixdataDumpType" c:type="GdkPixdataDumpType"/>
+          </parameter>
+        </parameters>
+      </method>
+    </record>
+    <bitfield name="PixdataDumpType" c:type="GdkPixdataDumpType">
+      <doc xml:space="preserve">An enumeration which is used by gdk_pixdata_to_csource() to
+determine the form of C source to be generated. The three values
+@GDK_PIXDATA_DUMP_PIXDATA_STREAM, @GDK_PIXDATA_DUMP_PIXDATA_STRUCT
+and @GDK_PIXDATA_DUMP_MACROS are mutually exclusive, as are
+@GDK_PIXBUF_DUMP_GTYPES and @GDK_PIXBUF_DUMP_CTYPES. The remaining
+elements are optional flags that can be freely added.</doc>
+      <member name="pixdata_stream" value="0" c:identifier="GDK_PIXDATA_DUMP_PIXDATA_STREAM">
+        <doc xml:space="preserve">Generate pixbuf data stream (a single
+   string containing a serialized #GdkPixdata structure in network byte
+   order).</doc>
+      </member>
+      <member name="pixdata_struct" value="1" c:identifier="GDK_PIXDATA_DUMP_PIXDATA_STRUCT">
+        <doc xml:space="preserve">Generate #GdkPixdata structure (needs
+   the #GdkPixdata structure definition from gdk-pixdata.h).</doc>
+      </member>
+      <member name="macros" value="2" c:identifier="GDK_PIXDATA_DUMP_MACROS">
+        <doc xml:space="preserve">Generate &lt;function&gt;*_ROWSTRIDE&lt;/function&gt;,
+   &lt;function&gt;*_WIDTH&lt;/function&gt;, &lt;function&gt;*_HEIGHT&lt;/function&gt;,
+   &lt;function&gt;*_BYTES_PER_PIXEL&lt;/function&gt; and
+   &lt;function&gt;*_RLE_PIXEL_DATA&lt;/function&gt; or &lt;function&gt;*_PIXEL_DATA&lt;/function&gt;
+   macro definitions for the image.</doc>
+      </member>
+      <member name="gtypes" value="0" c:identifier="GDK_PIXDATA_DUMP_GTYPES">
+        <doc xml:space="preserve">Generate GLib data types instead of
+   standard C data types.</doc>
+      </member>
+      <member name="ctypes" value="256" c:identifier="GDK_PIXDATA_DUMP_CTYPES">
+        <doc xml:space="preserve">Generate standard C data types instead of
+   GLib data types.</doc>
+      </member>
+      <member name="static" value="512" c:identifier="GDK_PIXDATA_DUMP_STATIC">
+        <doc xml:space="preserve">Generate static symbols.</doc>
+      </member>
+      <member name="const" value="1024" c:identifier="GDK_PIXDATA_DUMP_CONST">
+        <doc xml:space="preserve">Generate const symbols.</doc>
+      </member>
+      <member name="rle_decoder" value="65536" c:identifier="GDK_PIXDATA_DUMP_RLE_DECODER">
+        <doc xml:space="preserve">Provide a &lt;function&gt;*_RUN_LENGTH_DECODE(image_buf, rle_data, size, bpp)&lt;/function&gt;
+   macro definition  to  decode  run-length encoded image data.</doc>
+      </member>
+    </bitfield>
+    <bitfield name="PixdataType" c:type="GdkPixdataType">
+      <doc xml:space="preserve">An enumeration containing three sets of flags for a #GdkPixdata struct:
+one for the used colorspace, one for the width of the samples and one
+for the encoding of the pixel data.</doc>
+      <member name="color_type_rgb" value="1" c:identifier="GDK_PIXDATA_COLOR_TYPE_RGB">
+        <doc xml:space="preserve">each pixel has red, green and blue samples.</doc>
+      </member>
+      <member name="color_type_rgba" value="2" c:identifier="GDK_PIXDATA_COLOR_TYPE_RGBA">
+        <doc xml:space="preserve">each pixel has red, green and blue samples
+   and an alpha value.</doc>
+      </member>
+      <member name="color_type_mask" value="255" c:identifier="GDK_PIXDATA_COLOR_TYPE_MASK">
+        <doc xml:space="preserve">mask for the colortype flags of the enum.</doc>
+      </member>
+      <member name="sample_width_8" value="65536" c:identifier="GDK_PIXDATA_SAMPLE_WIDTH_8">
+        <doc xml:space="preserve">each sample has 8 bits.</doc>
+      </member>
+      <member name="sample_width_mask" value="983040" c:identifier="GDK_PIXDATA_SAMPLE_WIDTH_MASK">
+        <doc xml:space="preserve">mask for the sample width flags of the enum.</doc>
+      </member>
+      <member name="encoding_raw" value="16777216" c:identifier="GDK_PIXDATA_ENCODING_RAW">
+        <doc xml:space="preserve">the pixel data is in raw form.</doc>
+      </member>
+      <member name="encoding_rle" value="33554432" c:identifier="GDK_PIXDATA_ENCODING_RLE">
+        <doc xml:space="preserve">the pixel data is run-length encoded. Runs may
+   be up to 127 bytes long; their length is stored in a single byte
+   preceding the pixel data for the run. If a run is constant, its length
+   byte has the high bit set and the pixel data consists of a single pixel
+   which must be repeated.</doc>
+      </member>
+      <member name="encoding_mask" value="251658240" c:identifier="GDK_PIXDATA_ENCODING_MASK">
+        <doc xml:space="preserve">mask for the encoding flags of the enum.</doc>
+      </member>
+    </bitfield>
+    <function name="pixbuf_from_pixdata" c:identifier="gdk_pixbuf_from_pixdata" deprecated="1" deprecated-version="2.32" throws="1">
+      <doc xml:space="preserve">Converts a #GdkPixdata to a #GdkPixbuf. If @copy_pixels is %TRUE or
+if the pixel data is run-length-encoded, the pixel data is copied into
+newly-allocated memory; otherwise it is reused.</doc>
+      <doc-deprecated xml:space="preserve">Use #GResource instead.</doc-deprecated>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve">a new #GdkPixbuf.</doc>
+        <type name="GdkPixbuf.Pixbuf" c:type="GdkPixbuf*"/>
+      </return-value>
+      <parameters>
+        <parameter name="pixdata" transfer-ownership="none">
+          <doc xml:space="preserve">a #GdkPixdata to convert into a #GdkPixbuf.</doc>
+          <type name="Pixdata" c:type="const GdkPixdata*"/>
+        </parameter>
+        <parameter name="copy_pixels" transfer-ownership="none">
+          <doc xml:space="preserve">whether to copy raw pixel data; run-length encoded
+    pixel data is always copied.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </parameter>
+      </parameters>
+    </function>
+  </namespace>
+</repository>

--- a/GdkX11-3.0.gir
+++ b/GdkX11-3.0.gir
@@ -239,7 +239,7 @@ for the corresponding #GtkSetting).</doc>
             <doc xml:space="preserve">a #GdkDisplay</doc>
             <type name="X11Display" c:type="GdkDisplay*"/>
           </instance-parameter>
-          <parameter name="theme" transfer-ownership="none">
+          <parameter name="theme" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the name of the cursor theme to use, or %NULL to unset
         a previously set value</doc>
             <type name="utf8" c:type="const gchar*"/>
@@ -1027,6 +1027,15 @@ line option or the `DISPLAY` environment variable.</doc>
         <type name="xlib.Display" c:type="Display*"/>
       </return-value>
     </function>
+    <function name="x11_get_parent_relative_pattern" c:identifier="gdk_x11_get_parent_relative_pattern" version="3.24.2" deprecated="1" deprecated-version="3.24">
+      <doc xml:space="preserve">Used with gdk_window_set_background_pattern() to inherit background from
+parent window. Useful for imitating transparency when compositing is not
+available. Otherwise behaves like a transparent pattern.</doc>
+      <doc-deprecated xml:space="preserve">Don't use this function</doc-deprecated>
+      <return-value transfer-ownership="full">
+        <type name="cairo.Pattern" c:type="cairo_pattern_t*"/>
+      </return-value>
+    </function>
     <function name="x11_get_server_time" c:identifier="gdk_x11_get_server_time">
       <doc xml:space="preserve">Routine to get the current X server time stamp.</doc>
       <return-value transfer-ownership="none">
@@ -1180,9 +1189,9 @@ session management and the Inter-Client Communication Conventions Manual</doc>
         <type name="none" c:type="void"/>
       </return-value>
       <parameters>
-        <parameter name="sm_client_id" transfer-ownership="none">
-          <doc xml:space="preserve">the client id assigned by the session manager when the
-   connection was opened, or %NULL to remove the property.</doc>
+        <parameter name="sm_client_id" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve">the client id assigned by the session manager
+   when the connection was opened, or %NULL to remove the property.</doc>
           <type name="utf8" c:type="const gchar*"/>
         </parameter>
       </parameters>

--- a/Gio-2.0.gir
+++ b/Gio-2.0.gir
@@ -1978,7 +1978,7 @@ create_action_group (void)
           <parameter name="entries" transfer-ownership="none">
             <doc xml:space="preserve">a pointer to
           the first item in an array of #GActionEntry structs</doc>
-            <array length="1" zero-terminated="0" c:type="GActionEntry*">
+            <array length="1" zero-terminated="0" c:type="const GActionEntry*">
               <type name="ActionEntry"/>
             </array>
           </parameter>
@@ -2557,7 +2557,7 @@ the application.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">
    a list of content types.</doc>
-          <array c:type="char**">
+          <array c:type="const char**">
             <type name="utf8"/>
           </array>
         </return-value>
@@ -2972,7 +2972,7 @@ the application.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">
    a list of content types.</doc>
-          <array c:type="char**">
+          <array c:type="const char**">
             <type name="utf8"/>
           </array>
         </return-value>
@@ -3556,7 +3556,7 @@ no display name is available.</doc>
           <return-value transfer-ownership="none">
             <doc xml:space="preserve">
    a list of content types.</doc>
-            <array c:type="char**">
+            <array c:type="const char**">
               <type name="utf8"/>
             </array>
           </return-value>
@@ -4562,7 +4562,7 @@ the options with g_variant_dict_lookup():
           <parameter name="entries" transfer-ownership="none">
             <doc xml:space="preserve">a
           %NULL-terminated list of #GOptionEntrys</doc>
-            <array c:type="GOptionEntry*">
+            <array c:type="const GOptionEntry*">
               <type name="GLib.OptionEntry"/>
             </array>
           </parameter>
@@ -6062,7 +6062,7 @@ in the value of a single environment variable.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">
     the environment strings, or %NULL if they were not sent</doc>
-          <array c:type="gchar**">
+          <array c:type="const gchar* const*">
             <type name="filename"/>
           </array>
         </return-value>
@@ -6424,6 +6424,9 @@ situation.</doc>
       </member>
       <member name="anonymous_supported" value="16" c:identifier="G_ASK_PASSWORD_ANONYMOUS_SUPPORTED" glib:nick="anonymous-supported">
         <doc xml:space="preserve">operation supports anonymous users.</doc>
+      </member>
+      <member name="tcrypt" value="32" c:identifier="G_ASK_PASSWORD_TCRYPT" glib:nick="tcrypt">
+        <doc xml:space="preserve">operation takes TCRYPT parameters (Since: 2.58)</doc>
       </member>
     </bitfield>
     <interface name="AsyncInitable" c:symbol-prefix="async_initable" c:type="GAsyncInitable" version="2.22" glib:type-name="GAsyncInitable" glib:get-type="g_async_initable_get_type" glib:type-struct="AsyncInitableIface">
@@ -9907,7 +9910,7 @@ If a filter consumes an incoming message the message is not
 dispatched anywhere else - not even the standard dispatch machinery
 (that API such as g_dbus_connection_signal_subscribe() and
 g_dbus_connection_send_message_with_reply() relies on) will see the
-message. Similary, if a filter consumes an outgoing message, the
+message. Similarly, if a filter consumes an outgoing message, the
 message will not be sent to the other peer.
 
 If @user_data_free_func is non-%NULL, it will be called (in the
@@ -10373,7 +10376,7 @@ version.</doc>
         </parameters>
       </method>
       <method name="close_sync" c:identifier="g_dbus_connection_close_sync" version="2.26" throws="1">
-        <doc xml:space="preserve">Synchronously closees @connection. The calling thread is blocked
+        <doc xml:space="preserve">Synchronously closes @connection. The calling thread is blocked
 until this is done. See g_dbus_connection_close() for the
 asynchronous version of this method and more details about what it
 does.</doc>
@@ -11745,7 +11748,7 @@ exists.</doc>
           </parameter>
           <parameter name="entries" transfer-ownership="none">
             <doc xml:space="preserve">A pointer to @num_entries #GDBusErrorEntry struct items.</doc>
-            <array length="3" zero-terminated="0" c:type="GDBusErrorEntry*">
+            <array length="3" zero-terminated="0" c:type="const GDBusErrorEntry*">
               <type name="DBusErrorEntry" c:type="GDBusErrorEntry"/>
             </array>
           </parameter>
@@ -12932,7 +12935,10 @@ on a #GDBusConnection.</doc>
       <constructor name="new_from_blob" c:identifier="g_dbus_message_new_from_blob" version="2.26" throws="1">
         <doc xml:space="preserve">Creates a new #GDBusMessage from the data stored at @blob. The byte
 order that the message was in can be retrieved using
-g_dbus_message_get_byte_order().</doc>
+g_dbus_message_get_byte_order().
+
+If the @blob cannot be parsed, contains invalid fields, or contains invalid
+headers, %G_IO_ERROR_INVALID_ARGUMENT will be returned.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A new #GDBusMessage or %NULL if @error is set. Free with
 g_object_unref().</doc>
@@ -12940,7 +12946,7 @@ g_object_unref().</doc>
         </return-value>
         <parameters>
           <parameter name="blob" transfer-ownership="none">
-            <doc xml:space="preserve">A blob represent a binary D-Bus message.</doc>
+            <doc xml:space="preserve">A blob representing a binary D-Bus message.</doc>
             <array length="1" zero-terminated="0" c:type="guchar*">
               <type name="guint8"/>
             </array>
@@ -13012,7 +13018,7 @@ determine the size).</doc>
         </return-value>
         <parameters>
           <parameter name="blob" transfer-ownership="none">
-            <doc xml:space="preserve">A blob represent a binary D-Bus message.</doc>
+            <doc xml:space="preserve">A blob representing a binary D-Bus message.</doc>
             <array length="1" zero-terminated="0" c:type="guchar*">
               <type name="guint8"/>
             </array>
@@ -13123,8 +13129,11 @@ empty. Do not free, it is owned by @message.</doc>
         </parameters>
       </method>
       <method name="get_header" c:identifier="g_dbus_message_get_header" version="2.26">
-        <doc xml:space="preserve">Gets a header field on @message.</doc>
-        <return-value transfer-ownership="full">
+        <doc xml:space="preserve">Gets a header field on @message.
+
+The caller is responsible for checking the type of the returned #GVariant
+matches what is expected.</doc>
+        <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">A #GVariant with the value if the header was found, %NULL
 otherwise. Do not free, it is owned by @message.</doc>
           <type name="GLib.Variant" c:type="GVariant*"/>
@@ -15539,7 +15548,7 @@ that @manager was constructed in.</doc>
             <type name="DBusProxy"/>
           </parameter>
           <parameter name="changed_properties" transfer-ownership="none">
-            <doc xml:space="preserve">A #GVariant containing the properties that changed.</doc>
+            <doc xml:space="preserve">A #GVariant containing the properties that changed (type: `a{sv}`).</doc>
             <type name="GLib.Variant"/>
           </parameter>
           <parameter name="invalidated_properties" transfer-ownership="none">
@@ -17262,7 +17271,7 @@ This signal corresponds to the
         </return-value>
         <parameters>
           <parameter name="changed_properties" transfer-ownership="none">
-            <doc xml:space="preserve">A #GVariant containing the properties that changed</doc>
+            <doc xml:space="preserve">A #GVariant containing the properties that changed (type: `a{sv}`)</doc>
             <type name="GLib.Variant"/>
           </parameter>
           <parameter name="invalidated_properties" transfer-ownership="none">
@@ -17891,6 +17900,10 @@ case.</doc>
     <constant name="DESKTOP_APP_INFO_LOOKUP_EXTENSION_POINT_NAME" value="gio-desktop-app-info-lookup" c:type="G_DESKTOP_APP_INFO_LOOKUP_EXTENSION_POINT_NAME">
       <doc xml:space="preserve">Extension point for default handler to URI association. See
 [Extending GIO][extending-gio].</doc>
+      <type name="utf8" c:type="gchar*"/>
+    </constant>
+    <constant name="DRIVE_IDENTIFIER_KIND_UNIX_DEVICE" value="unix-device" c:type="G_DRIVE_IDENTIFIER_KIND_UNIX_DEVICE" version="2.58">
+      <doc xml:space="preserve">The string used to obtain a Unix device path with g_drive_get_identifier().</doc>
       <type name="utf8" c:type="gchar*"/>
     </constant>
     <class name="DataInputStream" c:symbol-prefix="data_input_stream" c:type="GDataInputStream" parent="BufferedInputStream" glib:type-name="GDataInputStream" glib:get-type="g_data_input_stream_get_type" glib:type-struct="DataInputStreamClass">
@@ -19701,8 +19714,9 @@ prefix-to-subdirectory mapping that is described in the
 [Menu Spec](http://standards.freedesktop.org/menu-spec/latest/)
 (i.e. a desktop id of kde-foo.desktop will match
 `/usr/share/applications/kde/foo.desktop`).</doc>
-        <return-value transfer-ownership="full">
-          <doc xml:space="preserve">a new #GDesktopAppInfo, or %NULL if no desktop file with that id</doc>
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">a new #GDesktopAppInfo, or %NULL if no desktop
+    file with that id exists.</doc>
           <type name="DesktopAppInfo" c:type="GDesktopAppInfo*"/>
         </return-value>
         <parameters>
@@ -19714,7 +19728,7 @@ prefix-to-subdirectory mapping that is described in the
       </constructor>
       <constructor name="new_from_filename" c:identifier="g_desktop_app_info_new_from_filename">
         <doc xml:space="preserve">Creates a new #GDesktopAppInfo.</doc>
-        <return-value transfer-ownership="full">
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">a new #GDesktopAppInfo or %NULL on error.</doc>
           <type name="DesktopAppInfo" c:type="GDesktopAppInfo*"/>
         </return-value>
@@ -19728,7 +19742,7 @@ prefix-to-subdirectory mapping that is described in the
       </constructor>
       <constructor name="new_from_keyfile" c:identifier="g_desktop_app_info_new_from_keyfile" version="2.18">
         <doc xml:space="preserve">Creates a new #GDesktopAppInfo.</doc>
-        <return-value transfer-ownership="full">
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">a new #GDesktopAppInfo or %NULL on error.</doc>
           <type name="DesktopAppInfo" c:type="GDesktopAppInfo*"/>
         </return-value>
@@ -20078,11 +20092,12 @@ but is intended primarily for operating system components that
 launch applications.  Ordinary applications should use
 g_app_info_launch_uris().
 
-If the application is launched via traditional UNIX fork()/exec()
-then @spawn_flags, @user_setup and @user_setup_data are used for the
-call to g_spawn_async().  Additionally, @pid_callback (with
-@pid_callback_data) will be called to inform about the PID of the
-created process.
+If the application is launched via GSpawn, then @spawn_flags, @user_setup
+and @user_setup_data are used for the call to g_spawn_async().
+Additionally, @pid_callback (with @pid_callback_data) will be called to
+inform about the PID of the created process. See g_spawn_async_with_pipes()
+for information on certain parameter conditions that can enable an
+optimized posix_spawn() codepath to be used.
 
 If application launching occurs via some other mechanism (eg: D-Bus
 activation) then @spawn_flags, @user_setup, @user_setup_data,
@@ -20129,6 +20144,67 @@ activation) then @spawn_flags, @user_setup, @user_setup_data,
           </parameter>
         </parameters>
       </method>
+      <method name="launch_uris_as_manager_with_fds" c:identifier="g_desktop_app_info_launch_uris_as_manager_with_fds" version="2.58" throws="1">
+        <doc xml:space="preserve">Equivalent to g_desktop_app_info_launch_uris_as_manager() but allows
+you to pass in file descriptors for the stdin, stdout and stderr streams
+of the launched process.
+
+If application launching occurs via some non-spawn mechanism (e.g. D-Bus
+activation) then @stdin_fd, @stdout_fd and @stderr_fd are ignored.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE on successful launch, %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="appinfo" transfer-ownership="none">
+            <doc xml:space="preserve">a #GDesktopAppInfo</doc>
+            <type name="DesktopAppInfo" c:type="GDesktopAppInfo*"/>
+          </instance-parameter>
+          <parameter name="uris" transfer-ownership="none">
+            <doc xml:space="preserve">List of URIs</doc>
+            <type name="GLib.List" c:type="GList*">
+              <type name="utf8"/>
+            </type>
+          </parameter>
+          <parameter name="launch_context" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">a #GAppLaunchContext</doc>
+            <type name="AppLaunchContext" c:type="GAppLaunchContext*"/>
+          </parameter>
+          <parameter name="spawn_flags" transfer-ownership="none">
+            <doc xml:space="preserve">#GSpawnFlags, used for each process</doc>
+            <type name="GLib.SpawnFlags" c:type="GSpawnFlags"/>
+          </parameter>
+          <parameter name="user_setup" transfer-ownership="none" nullable="1" allow-none="1" scope="async" closure="4">
+            <doc xml:space="preserve">a #GSpawnChildSetupFunc, used once
+    for each process.</doc>
+            <type name="GLib.SpawnChildSetupFunc" c:type="GSpawnChildSetupFunc"/>
+          </parameter>
+          <parameter name="user_setup_data" transfer-ownership="none" nullable="1" allow-none="1" closure="3">
+            <doc xml:space="preserve">User data for @user_setup</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="pid_callback" transfer-ownership="none" nullable="1" allow-none="1" scope="call" closure="6">
+            <doc xml:space="preserve">Callback for child processes</doc>
+            <type name="DesktopAppLaunchCallback" c:type="GDesktopAppLaunchCallback"/>
+          </parameter>
+          <parameter name="pid_callback_data" transfer-ownership="none" nullable="1" allow-none="1" closure="5">
+            <doc xml:space="preserve">User data for @callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="stdin_fd" transfer-ownership="none">
+            <doc xml:space="preserve">file descriptor to use for child's stdin, or -1</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="stdout_fd" transfer-ownership="none">
+            <doc xml:space="preserve">file descriptor to use for child's stdout, or -1</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+          <parameter name="stderr_fd" transfer-ownership="none">
+            <doc xml:space="preserve">file descriptor to use for child's stderr, or -1</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </method>
       <method name="list_actions" c:identifier="g_desktop_app_info_list_actions" version="2.38">
         <doc xml:space="preserve">Returns the list of "additional application actions" supported on the
 desktop file, as per the desktop file specification.
@@ -20137,7 +20213,7 @@ As per the specification, this is the list of actions that are
 explicitly listed in the "Actions" key of the [Desktop Entry] group.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a list of strings, always non-%NULL</doc>
-          <array c:type="gchar**">
+          <array c:type="const gchar* const*">
             <type name="utf8"/>
           </array>
         </return-value>
@@ -20521,10 +20597,12 @@ themselves.</doc>
         </parameters>
       </virtual-method>
       <virtual-method name="get_identifier" invoker="get_identifier">
-        <doc xml:space="preserve">Gets the identifier of the given kind for @drive.</doc>
-        <return-value transfer-ownership="full">
+        <doc xml:space="preserve">Gets the identifier of the given kind for @drive. The only
+identifier currently available is
+#G_DRIVE_IDENTIFIER_KIND_UNIX_DEVICE.</doc>
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">a newly allocated string containing the
-    requested identfier, or %NULL if the #GDrive
+    requested identifier, or %NULL if the #GDrive
     doesn't have this kind of identifier.</doc>
           <type name="utf8" c:type="char*"/>
         </return-value>
@@ -20555,7 +20633,7 @@ themselves.</doc>
       </virtual-method>
       <virtual-method name="get_sort_key" invoker="get_sort_key" version="2.32">
         <doc xml:space="preserve">Gets the sort key for @drive, if any.</doc>
-        <return-value transfer-ownership="none">
+        <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">Sorting key for @drive or %NULL if no such key is available.</doc>
           <type name="utf8" c:type="const gchar*"/>
         </return-value>
@@ -21051,10 +21129,12 @@ themselves.</doc>
         </parameters>
       </method>
       <method name="get_identifier" c:identifier="g_drive_get_identifier">
-        <doc xml:space="preserve">Gets the identifier of the given kind for @drive.</doc>
-        <return-value transfer-ownership="full">
+        <doc xml:space="preserve">Gets the identifier of the given kind for @drive. The only
+identifier currently available is
+#G_DRIVE_IDENTIFIER_KIND_UNIX_DEVICE.</doc>
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">a newly allocated string containing the
-    requested identfier, or %NULL if the #GDrive
+    requested identifier, or %NULL if the #GDrive
     doesn't have this kind of identifier.</doc>
           <type name="utf8" c:type="char*"/>
         </return-value>
@@ -21085,7 +21165,7 @@ themselves.</doc>
       </method>
       <method name="get_sort_key" c:identifier="g_drive_get_sort_key" version="2.32">
         <doc xml:space="preserve">Gets the sort key for @drive, if any.</doc>
-        <return-value transfer-ownership="none">
+        <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">Sorting key for @drive or %NULL if no such key is available.</doc>
           <type name="utf8" c:type="const gchar*"/>
         </return-value>
@@ -21664,9 +21744,9 @@ been pressed.</doc>
       </field>
       <field name="get_identifier">
         <callback name="get_identifier">
-          <return-value transfer-ownership="full">
+          <return-value transfer-ownership="full" nullable="1">
             <doc xml:space="preserve">a newly allocated string containing the
-    requested identfier, or %NULL if the #GDrive
+    requested identifier, or %NULL if the #GDrive
     doesn't have this kind of identifier.</doc>
             <type name="utf8" c:type="char*"/>
           </return-value>
@@ -21928,7 +22008,7 @@ been pressed.</doc>
       </field>
       <field name="get_sort_key">
         <callback name="get_sort_key">
-          <return-value transfer-ownership="none">
+          <return-value transfer-ownership="none" nullable="1">
             <doc xml:space="preserve">Sorting key for @drive or %NULL if no such key is available.</doc>
             <type name="utf8" c:type="const gchar*"/>
           </return-value>
@@ -22040,7 +22120,7 @@ CA DNs. You should unref each element with g_byte_array_unref() and then
 the free the list with g_list_free().</doc>
           <type name="GLib.List" c:type="GList*">
             <array name="GLib.ByteArray">
-              <type name="gpointer" c:type="gpointer"/>
+              <type name="guint8" c:type="guint8"/>
             </array>
           </type>
         </return-value>
@@ -23926,7 +24006,8 @@ This attribute is only available for UNIX file systems. Corresponding
     <constant name="FILE_ATTRIBUTE_UNIX_IS_MOUNTPOINT" value="unix::is-mountpoint" c:type="G_FILE_ATTRIBUTE_UNIX_IS_MOUNTPOINT">
       <doc xml:space="preserve">A key in the "unix" namespace for checking if the file represents a
 UNIX mount point. This attribute is %TRUE if the file is a UNIX mount
-point. This attribute is only available for UNIX file systems.
+point. Since 2.58, `/` is considered to be a mount point.
+This attribute is only available for UNIX file systems.
 Corresponding #GFileAttributeType is %G_FILE_ATTRIBUTE_TYPE_BOOLEAN.</doc>
       <type name="utf8" c:type="gchar*"/>
     </constant>
@@ -24725,6 +24806,11 @@ g_unlink().</doc>
 the actual file or directory represented by the #GFile; see
 g_file_copy() if attempting to copy a file.
 
+g_file_dup() is useful when a second handle is needed to the same underlying
+file, for use in a separate thread (#GFile is not thread-safe). For use
+within the same thread, use g_object_ref() to increment the existing object&#x2019;s
+reference count.
+
 This call does no blocking I/O.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a new #GFile that is a duplicate
@@ -25268,7 +25354,7 @@ This call does no blocking I/O.</doc>
       <virtual-method name="is_native" invoker="is_native">
         <doc xml:space="preserve">Checks to see if a file is native to the platform.
 
-A native file s one expressed in the platform-native filename format,
+A native file is one expressed in the platform-native filename format,
 e.g. "C:\Windows" or "/usr/bin/". This does not mean the file is local,
 as it might be on a locally mounted remote filesystem.
 
@@ -27759,6 +27845,11 @@ g_unlink().</doc>
 the actual file or directory represented by the #GFile; see
 g_file_copy() if attempting to copy a file.
 
+g_file_dup() is useful when a second handle is needed to the same underlying
+file, for use in a separate thread (#GFile is not thread-safe). For use
+within the same thread, use g_object_ref() to increment the existing object&#x2019;s
+reference count.
+
 This call does no blocking I/O.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a new #GFile that is a duplicate
@@ -28413,7 +28504,7 @@ This call does no blocking I/O.</doc>
       <method name="is_native" c:identifier="g_file_is_native">
         <doc xml:space="preserve">Checks to see if a file is native to the platform.
 
-A native file s one expressed in the platform-native filename format,
+A native file is one expressed in the platform-native filename format,
 e.g. "C:\Windows" or "/usr/bin/". This does not mean the file is local,
 as it might be on a locally mounted remote filesystem.
 
@@ -30075,7 +30166,7 @@ changed the next time it is saved over.</doc>
           </instance-parameter>
           <parameter name="contents" transfer-ownership="none">
             <doc xml:space="preserve">a string containing the new contents for @file</doc>
-            <array length="1" zero-terminated="0" c:type="char*">
+            <array length="1" zero-terminated="0" c:type="const char*">
               <type name="guint8"/>
             </array>
           </parameter>
@@ -30138,7 +30229,7 @@ contents (without copying) for the duration of the call.</doc>
           </instance-parameter>
           <parameter name="contents" transfer-ownership="none">
             <doc xml:space="preserve">string of contents to replace the file with</doc>
-            <array length="1" zero-terminated="0" c:type="char*">
+            <array length="1" zero-terminated="0" c:type="const char*">
               <type name="guint8"/>
             </array>
           </parameter>
@@ -36001,7 +36092,7 @@ types for the given @name_space, or %NULL on error.</doc>
       </method>
       <method name="set_attribute" c:identifier="g_file_info_set_attribute">
         <doc xml:space="preserve">Sets the @attribute to contain the given value, if possible. To unset the
-attribute, use %G_ATTRIBUTE_TYPE_INVALID for @type.</doc>
+attribute, use %G_FILE_ATTRIBUTE_TYPE_INVALID for @type.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -39537,8 +39628,8 @@ in the following two cases
   native, the returned string is the result of g_file_get_uri()
   (such as `sftp://path/to/my%20icon.png`).
 
-- If @icon is a #GThemedIcon with exactly one name, the encoding is
-   simply the name (such as `network-server`).</doc>
+- If @icon is a #GThemedIcon with exactly one name and no fallbacks,
+  the encoding is simply the name (such as `network-server`).</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">An allocated NUL-terminated UTF8 string or
 %NULL if @icon can't be serialized. Use g_free() to free.</doc>
@@ -39608,8 +39699,8 @@ in the following two cases
   native, the returned string is the result of g_file_get_uri()
   (such as `sftp://path/to/my%20icon.png`).
 
-- If @icon is a #GThemedIcon with exactly one name, the encoding is
-   simply the name (such as `network-server`).</doc>
+- If @icon is a #GThemedIcon with exactly one name and no fallbacks,
+  the encoding is simply the name (such as `network-server`).</doc>
         <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">An allocated NUL-terminated UTF8 string or
 %NULL if @icon can't be serialized. Use g_free() to free.</doc>
@@ -39759,7 +39850,7 @@ for @family.
         <parameters>
           <parameter name="bytes" transfer-ownership="none">
             <doc xml:space="preserve">raw address data</doc>
-            <array zero-terminated="0" c:type="guint8*">
+            <array zero-terminated="0" c:type="const guint8*">
               <type name="guint8"/>
             </array>
           </parameter>
@@ -45221,8 +45312,9 @@ the home directory, or the root of the volume).</doc>
 
 This is a convenience method for getting the #GVolume and then
 using that object to get the #GDrive.</doc>
-        <return-value transfer-ownership="full">
-          <doc xml:space="preserve">a #GDrive or %NULL if @mount is not associated with a volume or a drive.
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">a #GDrive or %NULL if @mount is not
+     associated with a volume or a drive.
      The returned object should be unreffed with
      g_object_unref() when no longer needed.</doc>
           <type name="Drive" c:type="GDrive*"/>
@@ -45281,7 +45373,7 @@ using that object to get the #GDrive.</doc>
       </virtual-method>
       <virtual-method name="get_sort_key" invoker="get_sort_key" version="2.32">
         <doc xml:space="preserve">Gets the sort key for @mount, if any.</doc>
-        <return-value transfer-ownership="none">
+        <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">Sorting key for @mount or %NULL if no such key is available.</doc>
           <type name="utf8" c:type="const gchar*"/>
         </return-value>
@@ -45312,8 +45404,9 @@ using that object to get the #GDrive.</doc>
 the file system UUID for the mount in question and should be
 considered an opaque string. Returns %NULL if there is no UUID
 available.</doc>
-        <return-value transfer-ownership="full">
-          <doc xml:space="preserve">the UUID for @mount or %NULL if no UUID can be computed.
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">the UUID for @mount or %NULL if no UUID
+    can be computed.
     The returned string should be freed with g_free()
     when no longer needed.</doc>
           <type name="utf8" c:type="char*"/>
@@ -45327,8 +45420,9 @@ available.</doc>
       </virtual-method>
       <virtual-method name="get_volume" invoker="get_volume">
         <doc xml:space="preserve">Gets the volume for the @mount.</doc>
-        <return-value transfer-ownership="full">
-          <doc xml:space="preserve">a #GVolume or %NULL if @mount is not associated with a volume.
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">a #GVolume or %NULL if @mount is not
+     associated with a volume.
      The returned object should be unreffed with
      g_object_unref() when no longer needed.</doc>
           <type name="Volume" c:type="GVolume*"/>
@@ -45769,8 +45863,9 @@ the home directory, or the root of the volume).</doc>
 
 This is a convenience method for getting the #GVolume and then
 using that object to get the #GDrive.</doc>
-        <return-value transfer-ownership="full">
-          <doc xml:space="preserve">a #GDrive or %NULL if @mount is not associated with a volume or a drive.
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">a #GDrive or %NULL if @mount is not
+     associated with a volume or a drive.
      The returned object should be unreffed with
      g_object_unref() when no longer needed.</doc>
           <type name="Drive" c:type="GDrive*"/>
@@ -45829,7 +45924,7 @@ using that object to get the #GDrive.</doc>
       </method>
       <method name="get_sort_key" c:identifier="g_mount_get_sort_key" version="2.32">
         <doc xml:space="preserve">Gets the sort key for @mount, if any.</doc>
-        <return-value transfer-ownership="none">
+        <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">Sorting key for @mount or %NULL if no such key is available.</doc>
           <type name="utf8" c:type="const gchar*"/>
         </return-value>
@@ -45860,8 +45955,9 @@ using that object to get the #GDrive.</doc>
 the file system UUID for the mount in question and should be
 considered an opaque string. Returns %NULL if there is no UUID
 available.</doc>
-        <return-value transfer-ownership="full">
-          <doc xml:space="preserve">the UUID for @mount or %NULL if no UUID can be computed.
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">the UUID for @mount or %NULL if no UUID
+    can be computed.
     The returned string should be freed with g_free()
     when no longer needed.</doc>
           <type name="utf8" c:type="char*"/>
@@ -45875,8 +45971,9 @@ available.</doc>
       </method>
       <method name="get_volume" c:identifier="g_mount_get_volume">
         <doc xml:space="preserve">Gets the volume for the @mount.</doc>
-        <return-value transfer-ownership="full">
-          <doc xml:space="preserve">a #GVolume or %NULL if @mount is not associated with a volume.
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">a #GVolume or %NULL if @mount is not
+     associated with a volume.
      The returned object should be unreffed with
      g_object_unref() when no longer needed.</doc>
           <type name="Volume" c:type="GVolume*"/>
@@ -46317,8 +46414,9 @@ finalized.</doc>
       </field>
       <field name="get_uuid">
         <callback name="get_uuid">
-          <return-value transfer-ownership="full">
-            <doc xml:space="preserve">the UUID for @mount or %NULL if no UUID can be computed.
+          <return-value transfer-ownership="full" nullable="1">
+            <doc xml:space="preserve">the UUID for @mount or %NULL if no UUID
+    can be computed.
     The returned string should be freed with g_free()
     when no longer needed.</doc>
             <type name="utf8" c:type="char*"/>
@@ -46333,8 +46431,9 @@ finalized.</doc>
       </field>
       <field name="get_volume">
         <callback name="get_volume">
-          <return-value transfer-ownership="full">
-            <doc xml:space="preserve">a #GVolume or %NULL if @mount is not associated with a volume.
+          <return-value transfer-ownership="full" nullable="1">
+            <doc xml:space="preserve">a #GVolume or %NULL if @mount is not
+     associated with a volume.
      The returned object should be unreffed with
      g_object_unref() when no longer needed.</doc>
             <type name="Volume" c:type="GVolume*"/>
@@ -46349,8 +46448,9 @@ finalized.</doc>
       </field>
       <field name="get_drive">
         <callback name="get_drive">
-          <return-value transfer-ownership="full">
-            <doc xml:space="preserve">a #GDrive or %NULL if @mount is not associated with a volume or a drive.
+          <return-value transfer-ownership="full" nullable="1">
+            <doc xml:space="preserve">a #GDrive or %NULL if @mount is not
+     associated with a volume or a drive.
      The returned object should be unreffed with
      g_object_unref() when no longer needed.</doc>
             <type name="Drive" c:type="GDrive*"/>
@@ -46748,7 +46848,7 @@ finalized.</doc>
       </field>
       <field name="get_sort_key">
         <callback name="get_sort_key">
-          <return-value transfer-ownership="none">
+          <return-value transfer-ownership="none" nullable="1">
             <doc xml:space="preserve">Sorting key for @mount or %NULL if no such key is available.</doc>
             <type name="utf8" c:type="const gchar*"/>
           </return-value>
@@ -46798,7 +46898,13 @@ Users should instantiate a subclass of this that implements all the
 various callbacks to show the required dialogs, such as
 #GtkMountOperation. If no user interaction is desired (for example
 when automounting filesystems at login time), usually %NULL can be
-passed, see each method taking a #GMountOperation for details.</doc>
+passed, see each method taking a #GMountOperation for details.
+
+The term &#x2018;TCRYPT&#x2019; is used to mean &#x2018;compatible with TrueCrypt and VeraCrypt&#x2019;.
+[TrueCrypt](https://en.wikipedia.org/wiki/TrueCrypt) is a discontinued system for
+encrypting file containers, partitions or whole disks, typically used with Windows.
+[VeraCrypt](https://www.veracrypt.fr/) is a maintained fork of TrueCrypt with various
+improvements and auditing fixes.</doc>
       <constructor name="new" c:identifier="g_mount_operation_new">
         <doc xml:space="preserve">Creates a new mount operation.</doc>
         <return-value transfer-ownership="full">
@@ -46850,7 +46956,7 @@ passed, see each method taking a #GMountOperation for details.</doc>
             <type name="utf8" c:type="const char*"/>
           </parameter>
           <parameter name="choices" transfer-ownership="none">
-            <array c:type="char*">
+            <array c:type="const char**">
               <type name="utf8"/>
             </array>
           </parameter>
@@ -46889,7 +46995,7 @@ passed, see each method taking a #GMountOperation for details.</doc>
             </array>
           </parameter>
           <parameter name="choices" transfer-ownership="none">
-            <array c:type="gchar*">
+            <array c:type="const gchar**">
               <type name="utf8"/>
             </array>
           </parameter>
@@ -46955,6 +47061,34 @@ the choice's list, or %0.</doc>
           </instance-parameter>
         </parameters>
       </method>
+      <method name="get_is_tcrypt_hidden_volume" c:identifier="g_mount_operation_get_is_tcrypt_hidden_volume" version="2.58">
+        <doc xml:space="preserve">Check to see whether the mount operation is being used
+for a TCRYPT hidden volume.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if mount operation is for hidden volume.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="op" transfer-ownership="none">
+            <doc xml:space="preserve">a #GMountOperation.</doc>
+            <type name="MountOperation" c:type="GMountOperation*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_is_tcrypt_system_volume" c:identifier="g_mount_operation_get_is_tcrypt_system_volume" version="2.58">
+        <doc xml:space="preserve">Check to see whether the mount operation is being used
+for a TCRYPT system volume.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if mount operation is for system volume.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="op" transfer-ownership="none">
+            <doc xml:space="preserve">a #GMountOperation.</doc>
+            <type name="MountOperation" c:type="GMountOperation*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
       <method name="get_password" c:identifier="g_mount_operation_get_password">
         <doc xml:space="preserve">Gets a password from the mount operation.</doc>
         <return-value transfer-ownership="none">
@@ -46973,6 +47107,19 @@ the choice's list, or %0.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a #GPasswordSave flag.</doc>
           <type name="PasswordSave" c:type="GPasswordSave"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="op" transfer-ownership="none">
+            <doc xml:space="preserve">a #GMountOperation.</doc>
+            <type name="MountOperation" c:type="GMountOperation*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_pim" c:identifier="g_mount_operation_get_pim" version="2.58">
+        <doc xml:space="preserve">Gets a PIM from the mount operation.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">The VeraCrypt PIM within @op.</doc>
+          <type name="guint" c:type="guint"/>
         </return-value>
         <parameters>
           <instance-parameter name="op" transfer-ownership="none">
@@ -47058,6 +47205,38 @@ the choice's list, or %0.</doc>
           </parameter>
         </parameters>
       </method>
+      <method name="set_is_tcrypt_hidden_volume" c:identifier="g_mount_operation_set_is_tcrypt_hidden_volume" version="2.58">
+        <doc xml:space="preserve">Sets the mount operation to use a hidden volume if @hidden_volume is %TRUE.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="op" transfer-ownership="none">
+            <doc xml:space="preserve">a #GMountOperation.</doc>
+            <type name="MountOperation" c:type="GMountOperation*"/>
+          </instance-parameter>
+          <parameter name="hidden_volume" transfer-ownership="none">
+            <doc xml:space="preserve">boolean value.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_is_tcrypt_system_volume" c:identifier="g_mount_operation_set_is_tcrypt_system_volume" version="2.58">
+        <doc xml:space="preserve">Sets the mount operation to use a system volume if @system_volume is %TRUE.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="op" transfer-ownership="none">
+            <doc xml:space="preserve">a #GMountOperation.</doc>
+            <type name="MountOperation" c:type="GMountOperation*"/>
+          </instance-parameter>
+          <parameter name="system_volume" transfer-ownership="none">
+            <doc xml:space="preserve">boolean value.</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
       <method name="set_password" c:identifier="g_mount_operation_set_password">
         <doc xml:space="preserve">Sets the mount operation's password to @password.</doc>
         <return-value transfer-ownership="none">
@@ -47090,6 +47269,22 @@ the choice's list, or %0.</doc>
           </parameter>
         </parameters>
       </method>
+      <method name="set_pim" c:identifier="g_mount_operation_set_pim" version="2.58">
+        <doc xml:space="preserve">Sets the mount operation's PIM to @pim.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="op" transfer-ownership="none">
+            <doc xml:space="preserve">a #GMountOperation.</doc>
+            <type name="MountOperation" c:type="GMountOperation*"/>
+          </instance-parameter>
+          <parameter name="pim" transfer-ownership="none">
+            <doc xml:space="preserve">an unsigned integer.</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
       <method name="set_username" c:identifier="g_mount_operation_set_username">
         <doc xml:space="preserve">Sets the user name within @op to @username.</doc>
         <return-value transfer-ownership="none">
@@ -47119,6 +47314,19 @@ mount operation. See the #GMountOperation::ask-question signal.</doc>
         <doc xml:space="preserve">The domain to use for the mount operation.</doc>
         <type name="utf8" c:type="gchar*"/>
       </property>
+      <property name="is-tcrypt-hidden-volume" version="2.58" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">Whether the device to be unlocked is a TCRYPT hidden volume.
+See https://www.veracrypt.fr/en/Hidden%20Volume.html.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="is-tcrypt-system-volume" version="2.58" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">Whether the device to be unlocked is a TCRYPT system volume.
+In this context, a system volume is a volume with a bootloader
+and operating system installed. This is only supported for Windows
+operating systems. For further documentation, see
+https://www.veracrypt.fr/en/System%20Encryption.html.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
       <property name="password" writable="1" transfer-ownership="none">
         <doc xml:space="preserve">The password that is used for authentication when carrying out
 the mount operation.</doc>
@@ -47127,6 +47335,11 @@ the mount operation.</doc>
       <property name="password-save" writable="1" transfer-ownership="none">
         <doc xml:space="preserve">Determines if and how the password information should be saved.</doc>
         <type name="PasswordSave"/>
+      </property>
+      <property name="pim" version="2.58" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">The VeraCrypt PIM value, when unlocking a VeraCrypt volume. See
+https://www.veracrypt.fr/en/Personal%20Iterations%20Multiplier%20(PIM).html.</doc>
+        <type name="guint" c:type="guint"/>
       </property>
       <property name="username" writable="1" transfer-ownership="none">
         <doc xml:space="preserve">The user name that is used for authentication when carrying out
@@ -47328,7 +47541,7 @@ primary text in a #GtkMessageDialog.</doc>
               <type name="utf8" c:type="const char*"/>
             </parameter>
             <parameter name="choices" transfer-ownership="none">
-              <array c:type="char*">
+              <array c:type="const char**">
                 <type name="utf8"/>
               </array>
             </parameter>
@@ -47382,7 +47595,7 @@ primary text in a #GtkMessageDialog.</doc>
               </array>
             </parameter>
             <parameter name="choices" transfer-ownership="none">
-              <array c:type="gchar*">
+              <array c:type="const gchar**">
                 <type name="utf8"/>
               </array>
             </parameter>
@@ -54107,7 +54320,9 @@ to register it with g_resources_register().
 
 Note: @data must be backed by memory that is at least pointer aligned.
 Otherwise this function will internally create a copy of the memory since
-GLib 2.56, or in older versions fail and exit the process.</doc>
+GLib 2.56, or in older versions fail and exit the process.
+
+If @data is empty or corrupt, %G_RESOURCE_ERROR_INTERNAL will be returned.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a new #GResource, or %NULL on error</doc>
           <type name="Resource" c:type="GResource*"/>
@@ -54303,7 +54518,12 @@ thread.</doc>
 you to query it for data.
 
 If you want to use this resource in the global resource namespace you need
-to register it with g_resources_register().</doc>
+to register it with g_resources_register().
+
+If @filename is empty or the data in it is corrupt,
+%G_RESOURCE_ERROR_INTERNAL will be returned. If @filename doesn&#x2019;t exist, or
+there is an error in reading it, an error from g_mapped_file_new() will be
+returned.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a new #GResource, or %NULL on error</doc>
           <type name="Resource" c:type="GResource*"/>
@@ -55924,8 +56144,7 @@ The list is exactly the list of strings for which it is not an error
 to call g_settings_get_child().
 
 For GSettings objects that are lists, this value can change at any
-time and you should connect to the "children-changed" signal to watch
-for those changes.  Note that there is a race condition here: you may
+time. Note that there is a race condition here: you may
 request a child after listing it only for it to have been destroyed
 in the meantime.  For this reason, g_settings_get_child() may return
 %NULL even for a child that was listed by this function.
@@ -56285,7 +56504,7 @@ having an array of strings type in the schema for @settings.</doc>
           </parameter>
           <parameter name="value" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the value to set it to, or %NULL</doc>
-            <array c:type="gchar**">
+            <array c:type="const gchar* const*">
               <type name="utf8" c:type="gchar*"/>
             </array>
           </parameter>
@@ -56582,7 +56801,7 @@ g_free().  You should not attempt to free or unref the contents of
           <parameter name="keys" direction="out" caller-allocates="0" transfer-ownership="container">
             <doc xml:space="preserve">the
        location to save the relative keys</doc>
-            <array c:type="gchar***">
+            <array c:type="const gchar***">
               <type name="utf8" c:type="gchar**"/>
             </array>
           </parameter>
@@ -56853,7 +57072,7 @@ keys that were changed) but this is not strictly required.</doc>
           </parameter>
           <parameter name="items" transfer-ownership="none">
             <doc xml:space="preserve">the %NULL-terminated list of changed keys</doc>
-            <array c:type="gchar**">
+            <array c:type="const gchar* const*">
               <type name="utf8" c:type="gchar*"/>
             </array>
           </parameter>
@@ -57745,6 +57964,9 @@ in crashes or inconsistent behaviour in the case of a corrupted file.
 Generally, you should set @trusted to %TRUE for files installed by the
 system and to %FALSE for files in the home directory.
 
+In either case, an empty file or some types of corruption in the file will
+result in %G_FILE_ERROR_INVAL being returned.
+
 If @parent is non-%NULL then there are two effects.
 
 First, if g_settings_schema_source_lookup() is called with the
@@ -57902,7 +58124,8 @@ See also #GtkAction.</doc>
       <constructor name="new" c:identifier="g_simple_action_new" version="2.28">
         <doc xml:space="preserve">Creates a new action.
 
-The created action is stateless.  See g_simple_action_new_stateful().</doc>
+The created action is stateless. See g_simple_action_new_stateful() to create
+an action that has state.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a new #GSimpleAction</doc>
           <type name="SimpleAction" c:type="GSimpleAction*"/>
@@ -57913,7 +58136,8 @@ The created action is stateless.  See g_simple_action_new_stateful().</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
           <parameter name="parameter_type" transfer-ownership="none" nullable="1" allow-none="1">
-            <doc xml:space="preserve">the type of parameter to the activate function</doc>
+            <doc xml:space="preserve">the type of parameter that will be passed to
+  handlers for the #GSimpleAction::activate signal, or %NULL for no parameter</doc>
             <type name="GLib.VariantType" c:type="const GVariantType*"/>
           </parameter>
         </parameters>
@@ -57921,10 +58145,10 @@ The created action is stateless.  See g_simple_action_new_stateful().</doc>
       <constructor name="new_stateful" c:identifier="g_simple_action_new_stateful" version="2.28">
         <doc xml:space="preserve">Creates a new stateful action.
 
-@state is the initial state of the action.  All future state values
-must have the same #GVariantType as the initial state.
+All future state values must have the same #GVariantType as the initial
+@state.
 
-If the @state GVariant is floating, it is consumed.</doc>
+If the @state #GVariant is floating, it is consumed.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a new #GSimpleAction</doc>
           <type name="SimpleAction" c:type="GSimpleAction*"/>
@@ -57935,7 +58159,8 @@ If the @state GVariant is floating, it is consumed.</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
           <parameter name="parameter_type" transfer-ownership="none" nullable="1" allow-none="1">
-            <doc xml:space="preserve">the type of the parameter to the activate function</doc>
+            <doc xml:space="preserve">the type of the parameter that will be passed to
+  handlers for the #GSimpleAction::activate signal, or %NULL for no parameter</doc>
             <type name="GLib.VariantType" c:type="const GVariantType*"/>
           </parameter>
           <parameter name="state" transfer-ownership="none">
@@ -58039,8 +58264,9 @@ action is stateless.</doc>
       <glib:signal name="activate" when="last" version="2.28">
         <doc xml:space="preserve">Indicates that the action was just activated.
 
-@parameter will always be of the expected type.  In the event that
-an incorrect type was given, no signal will be emitted.
+@parameter will always be of the expected type, i.e. the parameter type
+specified when the action was created. If an incorrect type is given when
+activating the action, this signal is not emitted.
 
 Since GLib 2.40, if no handler is connected to this signal then the
 default behaviour for boolean-stated actions with a %NULL parameter
@@ -58054,7 +58280,8 @@ of #GSimpleAction to connect only one handler or the other.</doc>
         </return-value>
         <parameters>
           <parameter name="parameter" transfer-ownership="none" nullable="1" allow-none="1">
-            <doc xml:space="preserve">the parameter to the activation</doc>
+            <doc xml:space="preserve">the parameter to the activation, or %NULL if it has
+  no parameter</doc>
             <type name="GLib.Variant"/>
           </parameter>
         </parameters>
@@ -58063,8 +58290,10 @@ of #GSimpleAction to connect only one handler or the other.</doc>
         <doc xml:space="preserve">Indicates that the action just received a request to change its
 state.
 
-@value will always be of the correct state type.  In the event that
-an incorrect type was given, no signal will be emitted.
+@value will always be of the correct state type, i.e. the type of the
+initial state passed to g_simple_action_new_stateful(). If an incorrect
+type is given when requesting to change the state, this signal is not
+emitted.
 
 If no handler is connected to this signal then the default
 behaviour is to call g_simple_action_set_state() to set the state
@@ -58129,7 +58358,7 @@ and adding them to the action group.</doc>
           <parameter name="entries" transfer-ownership="none">
             <doc xml:space="preserve">a pointer to the first item in
           an array of #GActionEntry structs</doc>
-            <array length="1" zero-terminated="0" c:type="GActionEntry*">
+            <array length="1" zero-terminated="0" c:type="const GActionEntry*">
               <type name="ActionEntry" c:type="GActionEntry"/>
             </array>
           </parameter>
@@ -60433,7 +60662,7 @@ on error</doc>
           <parameter name="buffer" transfer-ownership="none">
             <doc xml:space="preserve">the buffer
     containing the data to send.</doc>
-            <array length="1" zero-terminated="0" c:type="gchar*">
+            <array length="1" zero-terminated="0" c:type="const gchar*">
               <type name="guint8"/>
             </array>
           </parameter>
@@ -60620,7 +60849,7 @@ on error</doc>
           <parameter name="buffer" transfer-ownership="none">
             <doc xml:space="preserve">the buffer
     containing the data to send.</doc>
-            <array length="2" zero-terminated="0" c:type="gchar*">
+            <array length="2" zero-terminated="0" c:type="const gchar*">
               <type name="guint8"/>
             </array>
           </parameter>
@@ -60651,7 +60880,7 @@ on error</doc>
           <parameter name="buffer" transfer-ownership="none">
             <doc xml:space="preserve">the buffer
     containing the data to send.</doc>
-            <array length="1" zero-terminated="0" c:type="gchar*">
+            <array length="1" zero-terminated="0" c:type="const gchar*">
               <type name="guint8"/>
             </array>
           </parameter>
@@ -63299,9 +63528,16 @@ if available.)</doc>
 of server sockets and helps you accept sockets from any of the
 socket, either sync or async.
 
+Add addresses and ports to listen on using g_socket_listener_add_address()
+and g_socket_listener_add_inet_port(). These will be listened on until
+g_socket_listener_close() is called. Dropping your final reference to the
+#GSocketListener will not cause g_socket_listener_close() to be called
+implicitly, as some references to the #GSocketListener may be held
+internally.
+
 If you want to implement a network server, also look at #GSocketService
-and #GThreadedSocketService which are subclass of #GSocketListener
-that makes this even easier.</doc>
+and #GThreadedSocketService which are subclasses of #GSocketListener
+that make this even easier.</doc>
       <constructor name="new" c:identifier="g_socket_listener_new" version="2.22">
         <doc xml:space="preserve">Creates a new #GSocketListener with no sockets to listen for.
 New listeners can be added with e.g. g_socket_listener_add_address()
@@ -63519,7 +63755,11 @@ If successful and @effective_address is non-%NULL then it will
 be set to the address that the binding actually occurred at.  This
 is helpful for determining the port number that was used for when
 requesting a binding to port 0 (ie: "any port").  This address, if
-requested, belongs to the caller and must be freed.</doc>
+requested, belongs to the caller and must be freed.
+
+Call g_socket_listener_close() to stop listening on @address; this will not
+be done automatically when you drop your final reference to @listener, as
+references may be held internally.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE on success, %FALSE on error.</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -63585,7 +63825,11 @@ supported) on the specified port on all interfaces.
 @source_object will be passed out in the various calls
 to accept to identify this particular source, which is
 useful if you're listening on multiple addresses and do
-different things depending on what address is connected to.</doc>
+different things depending on what address is connected to.
+
+Call g_socket_listener_close() to stop listening on @port; this will not
+be done automatically when you drop your final reference to @listener, as
+references may be held internally.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE on success, %FALSE on error.</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -64410,7 +64654,7 @@ The argument list is expected to be %NULL-terminated.</doc>
         <parameters>
           <parameter name="argv" transfer-ownership="none">
             <doc xml:space="preserve">commandline arguments for the subprocess</doc>
-            <array c:type="gchar**">
+            <array c:type="const gchar* const*">
               <type name="filename"/>
             </array>
           </parameter>
@@ -65353,7 +65597,7 @@ On Windows, they should be in UTF-8.</doc>
           </instance-parameter>
           <parameter name="argv" transfer-ownership="none">
             <doc xml:space="preserve">Command line arguments</doc>
-            <array c:type="gchar**">
+            <array c:type="const gchar* const*">
               <type name="filename"/>
             </array>
           </parameter>
@@ -65545,7 +65789,7 @@ function in the
 where it was created (waiting until the next iteration of the main
 loop first, if necessary). The caller will pass the #GTask back to
 the operation's finish function (as a #GAsyncResult), and you can
-can use g_task_propagate_pointer() or the like to extract the
+use g_task_propagate_pointer() or the like to extract the
 return value.
 
 Here is an example for using GTask as a GAsyncResult:
@@ -67912,7 +68156,7 @@ as appropriate.)</doc>
 This property and the #GTlsCertificate:certificate-pem property
 represent the same data, just in different forms.</doc>
         <array name="GLib.ByteArray">
-          <type name="gpointer" c:type="gpointer"/>
+          <type name="guint8" c:type="guint8"/>
         </array>
       </property>
       <property name="certificate-pem" version="2.28" writable="1" construct-only="1" transfer-ownership="none">
@@ -67939,7 +68183,7 @@ PKCS#8 format is supported since 2.32; earlier releases only
 support PKCS#1. You can use the `openssl rsa`
 tool to convert PKCS#8 keys to PKCS#1.</doc>
         <array name="GLib.ByteArray">
-          <type name="gpointer" c:type="gpointer"/>
+          <type name="guint8" c:type="guint8"/>
         </array>
       </property>
       <property name="private-key-pem" version="2.28" readable="0" writable="1" construct-only="1" transfer-ownership="none">
@@ -68126,7 +68370,7 @@ CA DNs. You should unref each element with g_byte_array_unref() and then
 the free the list with g_list_free().</doc>
           <type name="GLib.List" c:type="GList*">
             <array name="GLib.ByteArray">
-              <type name="gpointer" c:type="gpointer"/>
+              <type name="guint8" c:type="guint8"/>
             </array>
           </type>
         </return-value>
@@ -68202,14 +68446,19 @@ performing %G_TLS_CERTIFICATE_BAD_IDENTITY validation, if enabled.</doc>
         </parameters>
       </method>
       <method name="set_use_ssl3" c:identifier="g_tls_client_connection_set_use_ssl3" version="2.28" deprecated="1" deprecated-version="2.56">
-        <doc xml:space="preserve">If @use_ssl3 is %TRUE, this forces @conn to use the lowest-supported
-TLS protocol version rather than trying to properly negotiate the
-highest mutually-supported protocol version with the peer. This can
-be used when talking to broken TLS servers that exhibit protocol
-version intolerance.
+        <doc xml:space="preserve">Since 2.42.1, if @use_ssl3 is %TRUE, this forces @conn to use the
+lowest-supported TLS protocol version rather than trying to properly
+negotiate the highest mutually-supported protocol version with the
+peer. Be aware that SSL 3.0 is generally disabled by the
+#GTlsBackend, so the lowest-supported protocol version is probably
+not SSL 3.0.
 
-Be aware that SSL 3.0 is generally disabled by the #GTlsBackend, so
-the lowest-supported protocol version is probably not SSL 3.0.</doc>
+Since 2.58, this may additionally cause an RFC 7507 fallback SCSV to
+be sent to the server, causing modern TLS servers to immediately
+terminate the connection. You should generally only use this function
+if you need to connect to broken servers that exhibit TLS protocol
+version intolerance, and when an initial attempt to connect to a
+server normally has already failed.</doc>
         <doc-deprecated xml:space="preserve">SSL 3.0 is insecure, and this function does not
 generally enable or disable it, despite its name.</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -68276,14 +68525,7 @@ virtual hosts.</doc>
       <property name="use-ssl3" version="2.28" deprecated="1" deprecated-version="2.56" writable="1" construct="1" transfer-ownership="none">
         <doc xml:space="preserve">If %TRUE, forces the connection to use a fallback version of TLS
 or SSL, rather than trying to negotiate the best version of TLS
-to use. This can be used when talking to servers that don't
-implement version negotiation correctly and therefore refuse to
-handshake at all with a modern TLS handshake.
-
-Despite the property name, the fallback version is usually not
-SSL 3.0, because SSL 3.0 is generally disabled by the #GTlsBackend.
-#GTlsClientConnection will use the next-highest available version
-as the fallback version.</doc>
+to use. See g_tls_client_connection_set_use_ssl3().</doc>
         <doc-deprecated xml:space="preserve">SSL 3.0 is insecure, and this property does not
 generally enable or disable it, despite its name.</doc-deprecated>
         <type name="gboolean" c:type="gboolean"/>
@@ -68362,7 +68604,10 @@ Likewise, on the server side, although a handshake is necessary at
 the beginning of the communication, you do not need to call this
 function explicitly unless you want clearer error reporting.
 However, you may call g_tls_connection_handshake() later on to
-renegotiate parameters (encryption methods, etc) with the client.
+rehandshake, if TLS 1.2 or older is in use. With TLS 1.3, the
+behavior is undefined but guaranteed to be reasonable and
+nondestructive, so most older code should be expected to continue to
+work without changes.
 
 #GTlsConnection::accept_certificate may be emitted during the
 handshake.</doc>
@@ -68589,7 +68834,10 @@ Likewise, on the server side, although a handshake is necessary at
 the beginning of the communication, you do not need to call this
 function explicitly unless you want clearer error reporting.
 However, you may call g_tls_connection_handshake() later on to
-renegotiate parameters (encryption methods, etc) with the client.
+rehandshake, if TLS 1.2 or older is in use. With TLS 1.3, the
+behavior is undefined but guaranteed to be reasonable and
+nondestructive, so most older code should be expected to continue to
+work without changes.
 
 #GTlsConnection::accept_certificate may be emitted during the
 handshake.</doc>
@@ -68734,7 +68982,8 @@ should occur for this connection.</doc>
         </parameters>
       </method>
       <method name="set_rehandshake_mode" c:identifier="g_tls_connection_set_rehandshake_mode" version="2.28">
-        <doc xml:space="preserve">Sets how @conn behaves with respect to rehandshaking requests.
+        <doc xml:space="preserve">Sets how @conn behaves with respect to rehandshaking requests, when
+TLS 1.2 or older is in use.
 
 %G_TLS_REHANDSHAKE_NEVER means that it will never agree to
 rehandshake after the initial handshake is complete. (For a client,
@@ -71398,7 +71647,7 @@ considered part of the password in this case.)</doc>
           </instance-parameter>
           <parameter name="value" transfer-ownership="none">
             <doc xml:space="preserve">the new password value</doc>
-            <array length="1" zero-terminated="0" c:type="guchar*">
+            <array length="1" zero-terminated="0" c:type="const guchar*">
               <type name="guint8" c:type="guchar"/>
             </array>
           </parameter>
@@ -71961,7 +72210,7 @@ If @n_fds is -1 then @fds must be terminated with -1.</doc>
         <parameters>
           <parameter name="fds" transfer-ownership="none">
             <doc xml:space="preserve">the initial list of file descriptors</doc>
-            <array length="1" zero-terminated="0" c:type="gint*">
+            <array length="1" zero-terminated="0" c:type="const gint*">
               <type name="gint" c:type="gint"/>
             </array>
           </parameter>
@@ -72059,7 +72308,7 @@ descriptors contained in @list, an empty array is returned.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">an array of file
     descriptors</doc>
-          <array length="0" zero-terminated="0" c:type="gint*">
+          <array length="0" zero-terminated="0" c:type="const gint*">
             <type name="gint" c:type="gint"/>
           </array>
         </return-value>
@@ -72876,7 +73125,7 @@ use g_unix_socket_address_new_abstract().</doc>
         <parameters>
           <parameter name="path" transfer-ownership="none">
             <doc xml:space="preserve">the abstract name</doc>
-            <array length="1" zero-terminated="0" c:type="gchar*">
+            <array length="1" zero-terminated="0" c:type="const gchar*">
               <type name="gchar"/>
             </array>
           </parameter>
@@ -72925,7 +73174,7 @@ its listening socket.</doc>
         <parameters>
           <parameter name="path" transfer-ownership="none">
             <doc xml:space="preserve">the name</doc>
-            <array length="1" zero-terminated="0" c:type="gchar*">
+            <array length="1" zero-terminated="0" c:type="const gchar*">
               <type name="gchar"/>
             </array>
           </parameter>
@@ -73021,7 +73270,7 @@ abstract addresses.</doc-deprecated>
       </property>
       <property name="path-as-array" writable="1" construct-only="1" transfer-ownership="none">
         <array name="GLib.ByteArray">
-          <type name="gpointer" c:type="gpointer"/>
+          <type name="guint8" c:type="guint8"/>
         </array>
       </property>
       <field name="parent_instance">
@@ -73086,8 +73335,9 @@ file chooser can use this information to show `network` volumes under
 a "Network" heading and `device` volumes under a "Devices" heading.</doc>
       <type name="utf8" c:type="gchar*"/>
     </constant>
-    <constant name="VOLUME_IDENTIFIER_KIND_HAL_UDI" value="hal-udi" c:type="G_VOLUME_IDENTIFIER_KIND_HAL_UDI">
+    <constant name="VOLUME_IDENTIFIER_KIND_HAL_UDI" value="hal-udi" c:type="G_VOLUME_IDENTIFIER_KIND_HAL_UDI" deprecated="1" deprecated-version="2.58">
       <doc xml:space="preserve">The string used to obtain a Hal UDI with g_volume_get_identifier().</doc>
+      <doc-deprecated xml:space="preserve">Do not use, HAL is deprecated.</doc-deprecated>
       <type name="utf8" c:type="gchar*"/>
     </constant>
     <constant name="VOLUME_IDENTIFIER_KIND_LABEL" value="label" c:type="G_VOLUME_IDENTIFIER_KIND_LABEL">
@@ -73823,7 +74073,7 @@ allows to obtain an 'identifier' for the volume. There can be
 different kinds of identifiers, such as Hal UDIs, filesystem labels,
 traditional Unix devices (e.g. `/dev/sda2`), UUIDs. GIO uses predefined
 strings as names for the different kinds of identifiers:
-#G_VOLUME_IDENTIFIER_KIND_HAL_UDI, #G_VOLUME_IDENTIFIER_KIND_LABEL, etc.
+#G_VOLUME_IDENTIFIER_KIND_UUID, #G_VOLUME_IDENTIFIER_KIND_LABEL, etc.
 Use g_volume_get_identifier() to obtain an identifier for a volume.
 
 
@@ -74029,7 +74279,7 @@ g_mount_is_shadowed() for more details.</doc>
       </virtual-method>
       <virtual-method name="get_drive" invoker="get_drive">
         <doc xml:space="preserve">Gets the drive for the @volume.</doc>
-        <return-value transfer-ownership="full">
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">a #GDrive or %NULL if @volume is not
     associated with a drive. The returned object should be unreffed
     with g_object_unref() when no longer needed.</doc>
@@ -74061,9 +74311,9 @@ g_mount_is_shadowed() for more details.</doc>
         <doc xml:space="preserve">Gets the identifier of the given kind for @volume.
 See the [introduction][volume-identifier] for more
 information about volume identifiers.</doc>
-        <return-value transfer-ownership="full">
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">a newly allocated string containing the
-    requested identfier, or %NULL if the #GVolume
+    requested identifier, or %NULL if the #GVolume
     doesn't have this kind of identifier</doc>
           <type name="utf8" c:type="char*"/>
         </return-value>
@@ -74080,7 +74330,7 @@ information about volume identifiers.</doc>
       </virtual-method>
       <virtual-method name="get_mount" invoker="get_mount">
         <doc xml:space="preserve">Gets the mount for the @volume.</doc>
-        <return-value transfer-ownership="full">
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">a #GMount or %NULL if @volume isn't mounted.
     The returned object should be unreffed with g_object_unref()
     when no longer needed.</doc>
@@ -74109,7 +74359,7 @@ information about volume identifiers.</doc>
       </virtual-method>
       <virtual-method name="get_sort_key" invoker="get_sort_key" version="2.32">
         <doc xml:space="preserve">Gets the sort key for @volume, if any.</doc>
-        <return-value transfer-ownership="none">
+        <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">Sorting key for @volume or %NULL if no such key is available</doc>
           <type name="utf8" c:type="const gchar*"/>
         </return-value>
@@ -74140,8 +74390,9 @@ information about volume identifiers.</doc>
 the file system UUID for the volume in question and should be
 considered an opaque string. Returns %NULL if there is no UUID
 available.</doc>
-        <return-value transfer-ownership="full">
-          <doc xml:space="preserve">the UUID for @volume or %NULL if no UUID can be computed.
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">the UUID for @volume or %NULL if no UUID
+    can be computed.
     The returned string should be freed with g_free()
     when no longer needed.</doc>
           <type name="utf8" c:type="char*"/>
@@ -74420,7 +74671,7 @@ g_mount_is_shadowed() for more details.</doc>
       </method>
       <method name="get_drive" c:identifier="g_volume_get_drive">
         <doc xml:space="preserve">Gets the drive for the @volume.</doc>
-        <return-value transfer-ownership="full">
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">a #GDrive or %NULL if @volume is not
     associated with a drive. The returned object should be unreffed
     with g_object_unref() when no longer needed.</doc>
@@ -74452,9 +74703,9 @@ g_mount_is_shadowed() for more details.</doc>
         <doc xml:space="preserve">Gets the identifier of the given kind for @volume.
 See the [introduction][volume-identifier] for more
 information about volume identifiers.</doc>
-        <return-value transfer-ownership="full">
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">a newly allocated string containing the
-    requested identfier, or %NULL if the #GVolume
+    requested identifier, or %NULL if the #GVolume
     doesn't have this kind of identifier</doc>
           <type name="utf8" c:type="char*"/>
         </return-value>
@@ -74471,7 +74722,7 @@ information about volume identifiers.</doc>
       </method>
       <method name="get_mount" c:identifier="g_volume_get_mount">
         <doc xml:space="preserve">Gets the mount for the @volume.</doc>
-        <return-value transfer-ownership="full">
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">a #GMount or %NULL if @volume isn't mounted.
     The returned object should be unreffed with g_object_unref()
     when no longer needed.</doc>
@@ -74500,7 +74751,7 @@ information about volume identifiers.</doc>
       </method>
       <method name="get_sort_key" c:identifier="g_volume_get_sort_key" version="2.32">
         <doc xml:space="preserve">Gets the sort key for @volume, if any.</doc>
-        <return-value transfer-ownership="none">
+        <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">Sorting key for @volume or %NULL if no such key is available</doc>
           <type name="utf8" c:type="const gchar*"/>
         </return-value>
@@ -74531,8 +74782,9 @@ information about volume identifiers.</doc>
 the file system UUID for the volume in question and should be
 considered an opaque string. Returns %NULL if there is no UUID
 available.</doc>
-        <return-value transfer-ownership="full">
-          <doc xml:space="preserve">the UUID for @volume or %NULL if no UUID can be computed.
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">the UUID for @volume or %NULL if no UUID
+    can be computed.
     The returned string should be freed with g_free()
     when no longer needed.</doc>
           <type name="utf8" c:type="char*"/>
@@ -74692,8 +74944,9 @@ release them so the object can be finalized.</doc>
       </field>
       <field name="get_uuid">
         <callback name="get_uuid">
-          <return-value transfer-ownership="full">
-            <doc xml:space="preserve">the UUID for @volume or %NULL if no UUID can be computed.
+          <return-value transfer-ownership="full" nullable="1">
+            <doc xml:space="preserve">the UUID for @volume or %NULL if no UUID
+    can be computed.
     The returned string should be freed with g_free()
     when no longer needed.</doc>
             <type name="utf8" c:type="char*"/>
@@ -74708,7 +74961,7 @@ release them so the object can be finalized.</doc>
       </field>
       <field name="get_drive">
         <callback name="get_drive">
-          <return-value transfer-ownership="full">
+          <return-value transfer-ownership="full" nullable="1">
             <doc xml:space="preserve">a #GDrive or %NULL if @volume is not
     associated with a drive. The returned object should be unreffed
     with g_object_unref() when no longer needed.</doc>
@@ -74724,7 +74977,7 @@ release them so the object can be finalized.</doc>
       </field>
       <field name="get_mount">
         <callback name="get_mount">
-          <return-value transfer-ownership="full">
+          <return-value transfer-ownership="full" nullable="1">
             <doc xml:space="preserve">a #GMount or %NULL if @volume isn't mounted.
     The returned object should be unreffed with g_object_unref()
     when no longer needed.</doc>
@@ -74866,9 +75119,9 @@ release them so the object can be finalized.</doc>
       </field>
       <field name="get_identifier">
         <callback name="get_identifier">
-          <return-value transfer-ownership="full">
+          <return-value transfer-ownership="full" nullable="1">
             <doc xml:space="preserve">a newly allocated string containing the
-    requested identfier, or %NULL if the #GVolume
+    requested identifier, or %NULL if the #GVolume
     doesn't have this kind of identifier</doc>
             <type name="utf8" c:type="char*"/>
           </return-value>
@@ -74984,7 +75237,7 @@ release them so the object can be finalized.</doc>
       </field>
       <field name="get_sort_key">
         <callback name="get_sort_key">
-          <return-value transfer-ownership="none">
+          <return-value transfer-ownership="none" nullable="1">
             <doc xml:space="preserve">Sorting key for @volume or %NULL if no such key is available</doc>
             <type name="utf8" c:type="const gchar*"/>
           </return-value>
@@ -75034,7 +75287,7 @@ it in its g_mount_get_volume() implementation. The caller must
 also listen for the "removed" signal on the returned object
 and give up its reference when handling that signal
 
-Similary, if implementing g_volume_monitor_adopt_orphan_mount(),
+Similarly, if implementing g_volume_monitor_adopt_orphan_mount(),
 the implementor must take a reference to @mount and return it in
 its g_volume_get_mount() implemented. Also, the implementor must
 listen for the "unmounted" signal on @mount and give up its
@@ -76966,8 +77219,8 @@ specification for more on the generic icon name.</doc>
     <function name="content_type_get_mime_type" c:identifier="g_content_type_get_mime_type">
       <doc xml:space="preserve">Gets the mime type for the content type, if one is registered.</doc>
       <return-value transfer-ownership="full" nullable="1">
-        <doc xml:space="preserve">the registered mime type for the given @type,
-    or %NULL if unknown.</doc>
+        <doc xml:space="preserve">the registered mime type for the
+    given @type, or %NULL if unknown; free with g_free().</doc>
         <type name="utf8" c:type="gchar*"/>
       </return-value>
       <parameters>
@@ -77008,7 +77261,7 @@ on the other argument.</doc>
         </parameter>
         <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
           <doc xml:space="preserve">a stream of data, or %NULL</doc>
-          <array length="2" zero-terminated="0" c:type="guchar*">
+          <array length="2" zero-terminated="0" c:type="const guchar*">
             <type name="guint8" c:type="guchar"/>
           </array>
         </parameter>
@@ -77404,7 +77657,7 @@ exists.</doc>
         </parameter>
         <parameter name="entries" transfer-ownership="none">
           <doc xml:space="preserve">A pointer to @num_entries #GDBusErrorEntry struct items.</doc>
-          <array length="3" zero-terminated="0" c:type="GDBusErrorEntry*">
+          <array length="3" zero-terminated="0" c:type="const GDBusErrorEntry*">
             <type name="DBusErrorEntry" c:type="GDBusErrorEntry"/>
           </array>
         </parameter>
@@ -78442,7 +78695,12 @@ specified protocol.</doc>
 you to query it for data.
 
 If you want to use this resource in the global resource namespace you need
-to register it with g_resources_register().</doc>
+to register it with g_resources_register().
+
+If @filename is empty or the data in it is corrupt,
+%G_RESOURCE_ERROR_INTERNAL will be returned. If @filename doesn&#x2019;t exist, or
+there is an error in reading it, an error from g_mapped_file_new() will be
+returned.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">a new #GResource, or %NULL on error</doc>
         <type name="Resource" c:type="GResource*"/>
@@ -78966,6 +79224,24 @@ if the mounts have changed since with g_unix_mounts_changed_since().</doc>
       <parameters>
         <parameter name="mount_entry" transfer-ownership="none">
           <doc xml:space="preserve">input #GUnixMountEntry to get the mount path for.</doc>
+          <type name="UnixMountEntry" c:type="GUnixMountEntry*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="unix_mount_get_options" c:identifier="g_unix_mount_get_options" version="2.58">
+      <doc xml:space="preserve">Gets a comma-separated list of mount options for the unix mount. For example,
+`rw,relatime,seclabel,data=ordered`.
+
+This is similar to g_unix_mount_point_get_options(), but it takes
+a #GUnixMountEntry as an argument.</doc>
+      <return-value transfer-ownership="none" nullable="1">
+        <doc xml:space="preserve">a string containing the options, or %NULL if not
+available.</doc>
+        <type name="utf8" c:type="const char*"/>
+      </return-value>
+      <parameters>
+        <parameter name="mount_entry" transfer-ownership="none">
+          <doc xml:space="preserve">a #GUnixMountEntry.</doc>
           <type name="UnixMountEntry" c:type="GUnixMountEntry*"/>
         </parameter>
       </parameters>

--- a/GtkSource-3.0.gir
+++ b/GtkSource-3.0.gir
@@ -6381,7 +6381,7 @@ a %NULL-terminated array of strings containing the ids of the available
 languages or %NULL if no language is available.
 The array is sorted alphabetically according to the language name.
 The array is owned by @lm and must not be modified.</doc>
-          <array c:type="gchar**">
+          <array c:type="const gchar* const*">
             <type name="utf8"/>
           </array>
         </return-value>
@@ -6398,7 +6398,7 @@ The array is owned by @lm and must not be modified.</doc>
           <doc xml:space="preserve">%NULL-terminated array
 containg a list of language files directories.
 The array is owned by @lm and must not be modified.</doc>
-          <array c:type="gchar**">
+          <array c:type="const gchar* const*">
             <type name="utf8"/>
           </array>
         </return-value>
@@ -9534,7 +9534,7 @@ when you are done with it.</doc>
           <doc xml:space="preserve">a
 %NULL-terminated array containing the @scheme authors or %NULL if
 no author is specified by the style scheme.</doc>
-          <array c:type="gchar**">
+          <array c:type="const gchar* const*">
             <type name="utf8"/>
           </array>
         </return-value>
@@ -9879,7 +9879,7 @@ a %NULL-terminated array of strings containing the ids of the available
 style schemes or %NULL if no style scheme is available.
 The array is sorted alphabetically according to the scheme name.
 The array is owned by the @manager and must not be modified.</doc>
-          <array c:type="gchar**">
+          <array c:type="const gchar* const*">
             <type name="utf8"/>
           </array>
         </return-value>
@@ -9897,7 +9897,7 @@ See gtk_source_style_scheme_manager_set_search_path() for details.</doc>
           <doc xml:space="preserve">a %NULL-terminated array
 of string containing the search path.
 The array is owned by the @manager and must not be modified.</doc>
-          <array c:type="gchar**">
+          <array c:type="const gchar* const*">
             <type name="utf8"/>
           </array>
         </return-value>

--- a/JavaScriptCore-4.0.gir
+++ b/JavaScriptCore-4.0.gir
@@ -1,7 +1,2482 @@
 <?xml version="1.0"?>
-<repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" version="1.2">
-  <namespace name="JavaScriptCore" version="4.0" shared-library="javascriptcoregtk-4.0" c:identifier-prefixes="JS" c:symbol-prefixes="JS">
-    <record name="GlobalContext" c:type="JSGlobalContextRef" foreign="1"/>
-    <record name="Value" c:type="JSValueRef" foreign="1"/>
+<!-- This file was automatically generated from C sources - DO NOT EDIT!
+To affect the contents of this file, edit the original C definitions,
+and/or use gtk-doc annotations.  -->
+<repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0" version="1.2">
+  <include name="GObject" version="2.0"/>
+  <package name="javascriptcoregtk-4.0"/>
+  <c:include name="jsc/jsc.h"/>
+  <namespace name="JavaScriptCore" version="4.0" shared-library="libjavascriptcoregtk-4.0.so.18" c:identifier-prefixes="JSC" c:symbol-prefixes="jsc">
+    <enumeration name="CheckSyntaxMode" c:type="JSCCheckSyntaxMode">
+      <doc xml:space="preserve">Enum values to specify a mode to check for syntax errors in jsc_context_check_syntax().</doc>
+      <member name="script" value="0" c:identifier="JSC_CHECK_SYNTAX_MODE_SCRIPT">
+        <doc xml:space="preserve">mode to check syntax of a script</doc>
+      </member>
+      <member name="module" value="1" c:identifier="JSC_CHECK_SYNTAX_MODE_MODULE">
+        <doc xml:space="preserve">mode to check syntax of a module</doc>
+      </member>
+    </enumeration>
+    <enumeration name="CheckSyntaxResult" c:type="JSCCheckSyntaxResult">
+      <doc xml:space="preserve">Enum values to specify the result of jsc_context_check_syntax().</doc>
+      <member name="success" value="0" c:identifier="JSC_CHECK_SYNTAX_RESULT_SUCCESS">
+        <doc xml:space="preserve">no errors</doc>
+      </member>
+      <member name="recoverable_error" value="1" c:identifier="JSC_CHECK_SYNTAX_RESULT_RECOVERABLE_ERROR">
+        <doc xml:space="preserve">recoverable syntax error</doc>
+      </member>
+      <member name="irrecoverable_error" value="2" c:identifier="JSC_CHECK_SYNTAX_RESULT_IRRECOVERABLE_ERROR">
+        <doc xml:space="preserve">irrecoverable syntax error</doc>
+      </member>
+      <member name="unterminated_literal_error" value="3" c:identifier="JSC_CHECK_SYNTAX_RESULT_UNTERMINATED_LITERAL_ERROR">
+        <doc xml:space="preserve">unterminated literal error</doc>
+      </member>
+      <member name="out_of_memory_error" value="4" c:identifier="JSC_CHECK_SYNTAX_RESULT_OUT_OF_MEMORY_ERROR">
+        <doc xml:space="preserve">out of memory error</doc>
+      </member>
+      <member name="stack_overflow_error" value="5" c:identifier="JSC_CHECK_SYNTAX_RESULT_STACK_OVERFLOW_ERROR">
+        <doc xml:space="preserve">stack overflow error</doc>
+      </member>
+    </enumeration>
+    <class name="Class" c:symbol-prefix="class" c:type="JSCClass" parent="GObject.Object" glib:type-name="JSCClass" glib:get-type="jsc_class_get_type" glib:type-struct="ClassClass">
+      <method name="add_constructor" c:identifier="jsc_class_add_constructor" shadowed-by="add_constructorv" introspectable="0">
+        <doc xml:space="preserve">Add a constructor to @jsc_class. If @name is %NULL, the class name will be used. When &lt;function&gt;new&lt;/function&gt;
+is used with the constructor or jsc_value_constructor_call() is called, @callback is invoked receiving the
+parameters and @user_data as the last parameter. When the constructor object is cleared in the #JSCClass context,
+@destroy_notify is called with @user_data as parameter.
+
+This function creates the constructor, which needs to be added to an object as a property to be able to use it. Use
+jsc_context_set_value() to make the constructor available in the global object.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue representing the class constructor.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">the constructor name or %NULL</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="2" destroy="3">
+            <doc xml:space="preserve">a #GCallback to be called to create an instance of @jsc_class</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">user data to pass to @callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve">the #GType of the constructor return value</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="n_params" transfer-ownership="none">
+            <doc xml:space="preserve">the number of parameter types to follow or 0 if constructor doesn't receive parameters.</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve">a list of #GType&lt;!-- --&gt;s, one for each parameter.</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_constructor_variadic" c:identifier="jsc_class_add_constructor_variadic">
+        <doc xml:space="preserve">Add a constructor to @jsc_class. If @name is %NULL, the class name will be used. When &lt;function&gt;new&lt;/function&gt;
+is used with the constructor or jsc_value_constructor_call() is called, @callback is invoked receiving
+a #GPtrArray of #JSCValue&lt;!-- --&gt;s as arguments and @user_data as the last parameter. When the constructor object
+is cleared in the #JSCClass context, @destroy_notify is called with @user_data as parameter.
+
+This function creates the constructor, which needs to be added to an object as a property to be able to use it. Use
+jsc_context_set_value() to make the constructor available in the global object.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue representing the class constructor.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">the constructor name or %NULL</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="2" destroy="3">
+            <doc xml:space="preserve">a #GCallback to be called to create an instance of @jsc_class</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">user data to pass to @callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve">the #GType of the constructor return value</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_constructorv" c:identifier="jsc_class_add_constructorv" shadows="add_constructor">
+        <doc xml:space="preserve">Add a constructor to @jsc_class. If @name is %NULL, the class name will be used. When &lt;function&gt;new&lt;/function&gt;
+is used with the constructor or jsc_value_constructor_call() is called, @callback is invoked receiving the
+parameters and @user_data as the last parameter. When the constructor object is cleared in the #JSCClass context,
+@destroy_notify is called with @user_data as parameter.
+
+This function creates the constructor, which needs to be added to an object as a property to be able to use it. Use
+jsc_context_set_value() to make the constructor available in the global object.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue representing the class constructor.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">the constructor name or %NULL</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="2" destroy="3">
+            <doc xml:space="preserve">a #GCallback to be called to create an instance of @jsc_class</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">user data to pass to @callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve">the #GType of the constructor return value</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="n_parameters" transfer-ownership="none">
+            <doc xml:space="preserve">the number of parameters</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="parameter_types" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">a list of #GType&lt;!-- --&gt;s, one for each parameter, or %NULL</doc>
+            <array length="5" zero-terminated="0" c:type="GType*">
+              <type name="GType"/>
+            </array>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_method" c:identifier="jsc_class_add_method" shadowed-by="add_methodv" introspectable="0">
+        <doc xml:space="preserve">Add method with @name to @jsc_class. When the method is called by JavaScript or jsc_value_object_invoke_method(),
+@callback is called receiving the class instance as first parameter, followed by the method parameters and then
+@user_data as last parameter. When the method is cleared in the #JSCClass context, @destroy_notify is called with
+@user_data as parameter.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the method name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="2" destroy="3">
+            <doc xml:space="preserve">a #GCallback to be called to invoke method @name of @jsc_class</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">user data to pass to @callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve">the #GType of the method return value, or %G_TYPE_NONE if the method is void.</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="n_params" transfer-ownership="none">
+            <doc xml:space="preserve">the number of parameter types to follow or 0 if the method doesn't receive parameters.</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve">a list of #GType&lt;!-- --&gt;s, one for each parameter.</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_method_variadic" c:identifier="jsc_class_add_method_variadic">
+        <doc xml:space="preserve">Add method with @name to @jsc_class. When the method is called by JavaScript or jsc_value_object_invoke_method(),
+@callback is called receiving the class instance as first parameter, followed by a #GPtrArray of #JSCValue&lt;!-- --&gt;s
+with the method arguments and then @user_data as last parameter. When the method is cleared in the #JSCClass context,
+@destroy_notify is called with @user_data as parameter.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the method name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="2" destroy="3">
+            <doc xml:space="preserve">a #GCallback to be called to invoke method @name of @jsc_class</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">user data to pass to @callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve">the #GType of the method return value, or %G_TYPE_NONE if the method is void.</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_methodv" c:identifier="jsc_class_add_methodv" shadows="add_method">
+        <doc xml:space="preserve">Add method with @name to @jsc_class. When the method is called by JavaScript or jsc_value_object_invoke_method(),
+@callback is called receiving the class instance as first parameter, followed by the method parameters and then
+@user_data as last parameter. When the method is cleared in the #JSCClass context, @destroy_notify is called with
+@user_data as parameter.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the method name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="2" destroy="3">
+            <doc xml:space="preserve">a #GCallback to be called to invoke method @name of @jsc_class</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">user data to pass to @callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve">the #GType of the method return value, or %G_TYPE_NONE if the method is void.</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="n_parameters" transfer-ownership="none">
+            <doc xml:space="preserve">the number of parameter types to follow or 0 if the method doesn't receive parameters.</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="parameter_types" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">a list of #GType&lt;!-- --&gt;s, one for each parameter, or %NULL</doc>
+            <array length="5" zero-terminated="0" c:type="GType*">
+              <type name="GType"/>
+            </array>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_property" c:identifier="jsc_class_add_property">
+        <doc xml:space="preserve">Add a property with @name to @jsc_class. When the property value needs to be getted, @getter is called
+receiving the the class instance as first parameter and @user_data as last parameter. When the property
+value needs to be set, @setter is called receiving the the class instance as first parameter, followed
+by the value to be set and then @user_data as the last parameter. When the property is cleared in the
+#JSCClass context, @destroy_notify is called with @user_data as parameter.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the property name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="property_type" transfer-ownership="none">
+            <doc xml:space="preserve">the #GType of the property value</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="getter" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">a #GCallback to be called to get the property value</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="setter" transfer-ownership="none" nullable="1" allow-none="1" scope="notified" closure="4" destroy="5">
+            <doc xml:space="preserve">a #GCallback to be called to set the property value</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">user data to pass to @getter and @setter</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_name" c:identifier="jsc_class_get_name">
+        <doc xml:space="preserve">Get the class name of @jsc_class</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the name of @jsc_class</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve">a @JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_parent" c:identifier="jsc_class_get_parent">
+        <doc xml:space="preserve">Get the parent class of @jsc_class</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the parent class of @jsc_class</doc>
+          <type name="Class" c:type="JSCClass*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve">a @JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <property name="context" writable="1" construct-only="1" transfer-ownership="none">
+        <doc xml:space="preserve">The #JSCContext in which the class was registered.</doc>
+        <type name="Context"/>
+      </property>
+      <property name="name" writable="1" construct-only="1" transfer-ownership="none">
+        <doc xml:space="preserve">The name of the class.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="parent" writable="1" construct-only="1" transfer-ownership="none">
+        <doc xml:space="preserve">The parent class or %NULL in case of final classes.</doc>
+        <type name="Class"/>
+      </property>
+    </class>
+    <record name="ClassClass" c:type="JSCClassClass" disguised="1" glib:is-gtype-struct-for="Class">
+    </record>
+    <callback name="ClassDeletePropertyFunction" c:type="JSCClassDeletePropertyFunction">
+      <doc xml:space="preserve">The type of delete_property in #JSCClassVTable. This is only required when you need to handle
+external properties not added to the prototype.</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">%TRUE if handled or %FALSE to to forward the request to the parent class or prototype chain.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="jsc_class" transfer-ownership="none">
+          <doc xml:space="preserve">a #JSCClass</doc>
+          <type name="Class" c:type="JSCClass*"/>
+        </parameter>
+        <parameter name="context" transfer-ownership="none">
+          <doc xml:space="preserve">a #JSCContext</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </parameter>
+        <parameter name="instance" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve">the @jsc_class instance</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="name" transfer-ownership="none">
+          <doc xml:space="preserve">the property name</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="ClassEnumeratePropertiesFunction" c:type="JSCClassEnumeratePropertiesFunction">
+      <doc xml:space="preserve">The type of enumerate_properties in #JSCClassVTable. This is only required when you need to handle
+external properties not added to the prototype.</doc>
+      <return-value transfer-ownership="full" nullable="1">
+        <doc xml:space="preserve">a %NULL-terminated array of strings
+   containing the property names, or %NULL if @instance doesn't have enumerable properties.</doc>
+        <array c:type="gchar**">
+          <type name="utf8"/>
+        </array>
+      </return-value>
+      <parameters>
+        <parameter name="jsc_class" transfer-ownership="none">
+          <doc xml:space="preserve">a #JSCClass</doc>
+          <type name="Class" c:type="JSCClass*"/>
+        </parameter>
+        <parameter name="context" transfer-ownership="none">
+          <doc xml:space="preserve">a #JSCContext</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </parameter>
+        <parameter name="instance" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve">the @jsc_class instance</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="ClassGetPropertyFunction" c:type="JSCClassGetPropertyFunction">
+      <doc xml:space="preserve">The type of get_property in #JSCClassVTable. This is only required when you need to handle
+external properties not added to the prototype.</doc>
+      <return-value transfer-ownership="full" nullable="1">
+        <doc xml:space="preserve">a #JSCValue or %NULL to forward the request to
+   the parent class or prototype chain</doc>
+        <type name="Value" c:type="JSCValue*"/>
+      </return-value>
+      <parameters>
+        <parameter name="jsc_class" transfer-ownership="none">
+          <doc xml:space="preserve">a #JSCClass</doc>
+          <type name="Class" c:type="JSCClass*"/>
+        </parameter>
+        <parameter name="context" transfer-ownership="none">
+          <doc xml:space="preserve">a #JSCContext</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </parameter>
+        <parameter name="instance" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve">the @jsc_class instance</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="name" transfer-ownership="none">
+          <doc xml:space="preserve">the property name</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="ClassHasPropertyFunction" c:type="JSCClassHasPropertyFunction">
+      <doc xml:space="preserve">The type of has_property in #JSCClassVTable. This is only required when you need to handle
+external properties not added to the prototype.</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">%TRUE if @instance has a property with @name or %FALSE to forward the request
+   to the parent class or prototype chain.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="jsc_class" transfer-ownership="none">
+          <doc xml:space="preserve">a #JSCClass</doc>
+          <type name="Class" c:type="JSCClass*"/>
+        </parameter>
+        <parameter name="context" transfer-ownership="none">
+          <doc xml:space="preserve">a #JSCContext</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </parameter>
+        <parameter name="instance" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve">the @jsc_class instance</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="name" transfer-ownership="none">
+          <doc xml:space="preserve">the property name</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="ClassSetPropertyFunction" c:type="JSCClassSetPropertyFunction">
+      <doc xml:space="preserve">The type of set_property in #JSCClassVTable. This is only required when you need to handle
+external properties not added to the prototype.</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">%TRUE if handled or %FALSE to forward the request to the parent class or prototype chain.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="jsc_class" transfer-ownership="none">
+          <doc xml:space="preserve">a #JSCClass</doc>
+          <type name="Class" c:type="JSCClass*"/>
+        </parameter>
+        <parameter name="context" transfer-ownership="none">
+          <doc xml:space="preserve">a #JSCContext</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </parameter>
+        <parameter name="instance" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve">the @jsc_class instance</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="name" transfer-ownership="none">
+          <doc xml:space="preserve">the property name</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" transfer-ownership="none">
+          <doc xml:space="preserve">the #JSCValue to set</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <record name="ClassVTable" c:type="JSCClassVTable">
+      <doc xml:space="preserve">Virtual table for a JSCClass. This can be optionally used when registering a #JSCClass in a #JSCContext
+to provide a custom implementation for the class. All virtual functions are optional and can be set to
+%NULL to fallback to the default implementation.</doc>
+      <field name="get_property" writable="1">
+        <doc xml:space="preserve">a #JSCClassGetPropertyFunction for getting a property.</doc>
+        <type name="ClassGetPropertyFunction" c:type="JSCClassGetPropertyFunction"/>
+      </field>
+      <field name="set_property" writable="1">
+        <doc xml:space="preserve">a #JSCClassSetPropertyFunction for setting a property.</doc>
+        <type name="ClassSetPropertyFunction" c:type="JSCClassSetPropertyFunction"/>
+      </field>
+      <field name="has_property" writable="1">
+        <doc xml:space="preserve">a #JSCClassHasPropertyFunction for querying a property.</doc>
+        <type name="ClassHasPropertyFunction" c:type="JSCClassHasPropertyFunction"/>
+      </field>
+      <field name="delete_property" writable="1">
+        <doc xml:space="preserve">a #JSCClassDeletePropertyFunction for deleting a property.</doc>
+        <type name="ClassDeletePropertyFunction" c:type="JSCClassDeletePropertyFunction"/>
+      </field>
+      <field name="enumerate_properties" writable="1">
+        <doc xml:space="preserve">a #JSCClassEnumeratePropertiesFunction for enumerating properties.</doc>
+        <type name="ClassEnumeratePropertiesFunction" c:type="JSCClassEnumeratePropertiesFunction"/>
+      </field>
+      <field name="_jsc_reserved0" introspectable="0">
+        <callback name="_jsc_reserved0">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved1" introspectable="0">
+        <callback name="_jsc_reserved1">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved2" introspectable="0">
+        <callback name="_jsc_reserved2">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved3" introspectable="0">
+        <callback name="_jsc_reserved3">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <class name="Context" c:symbol-prefix="context" c:type="JSCContext" parent="GObject.Object" glib:type-name="JSCContext" glib:get-type="jsc_context_get_type" glib:type-struct="ContextClass">
+      <constructor name="new" c:identifier="jsc_context_new">
+        <doc xml:space="preserve">Create a new #JSCContext. The context is created in a new #JSCVirtualMachine.
+Use jsc_context_new_with_virtual_machine() to create a new #JSCContext in an
+existing #JSCVirtualMachine.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">the newly created #JSCContext.</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </return-value>
+      </constructor>
+      <constructor name="new_with_virtual_machine" c:identifier="jsc_context_new_with_virtual_machine">
+        <doc xml:space="preserve">Create a new #JSCContext in @virtual_machine.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">the newly created #JSCContext.</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </return-value>
+        <parameters>
+          <parameter name="vm" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCVirtualMachine</doc>
+            <type name="VirtualMachine" c:type="JSCVirtualMachine*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <function name="get_current" c:identifier="jsc_context_get_current">
+        <doc xml:space="preserve">Get the #JSCContext that is currently executing a function. This should only be
+called within a function or method callback, otherwise %NULL will be returned.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the #JSCContext that is currently executing.</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </return-value>
+      </function>
+      <method name="check_syntax" c:identifier="jsc_context_check_syntax">
+        <doc xml:space="preserve">Check the given @code in @context for syntax errors. The @line_number is the starting line number in @uri;
+the value is one-based so the first line is 1. @uri and @line_number are only used to fill the @exception.
+In case of errors @exception will be set to a new #JSCException with the details. You can pass %NULL to
+@exception to ignore the error details.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #JSCCheckSyntaxResult</doc>
+          <type name="CheckSyntaxResult" c:type="JSCCheckSyntaxResult"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="code" transfer-ownership="none">
+            <doc xml:space="preserve">a JavaScript script to check</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="length" transfer-ownership="none">
+            <doc xml:space="preserve">length of @code, or -1 if @code is a nul-terminated string</doc>
+            <type name="gssize" c:type="gssize"/>
+          </parameter>
+          <parameter name="mode" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCCheckSyntaxMode</doc>
+            <type name="CheckSyntaxMode" c:type="JSCCheckSyntaxMode"/>
+          </parameter>
+          <parameter name="uri" transfer-ownership="none">
+            <doc xml:space="preserve">the source URI</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="line_number" transfer-ownership="none">
+            <doc xml:space="preserve">the starting line number</doc>
+            <type name="guint" c:type="unsigned"/>
+          </parameter>
+          <parameter name="exception" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
+            <doc xml:space="preserve">return location for a #JSCException, or %NULL to ignore</doc>
+            <type name="Exception" c:type="JSCException**"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="clear_exception" c:identifier="jsc_context_clear_exception">
+        <doc xml:space="preserve">Clear the uncaught exception in @context if any.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="evaluate" c:identifier="jsc_context_evaluate">
+        <doc xml:space="preserve">Evaluate @code in @context.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue representing the last value generated by the script.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="code" transfer-ownership="none">
+            <doc xml:space="preserve">a JavaScript script to evaluate</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="length" transfer-ownership="none">
+            <doc xml:space="preserve">length of @code, or -1 if @code is a nul-terminated string</doc>
+            <type name="gssize" c:type="gssize"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="evaluate_in_object" c:identifier="jsc_context_evaluate_in_object">
+        <doc xml:space="preserve">Evaluate @code and create an new object where symbols defined in @code will be added as properties,
+instead of being added to @context global object. The new object is returned as @object parameter.
+Similar to how jsc_value_new_object() works, if @object_instance is not %NULL @object_class must be provided too.
+The @line_number is the starting line number in @uri; the value is one-based so the first line is 1.
+@uri and @line_number will be shown in exceptions and they don't affect the behavior of the script.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue representing the last value generated by the script.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="code" transfer-ownership="none">
+            <doc xml:space="preserve">a JavaScript script to evaluate</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="length" transfer-ownership="none">
+            <doc xml:space="preserve">length of @code, or -1 if @code is a nul-terminated string</doc>
+            <type name="gssize" c:type="gssize"/>
+          </parameter>
+          <parameter name="object_instance" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">an object instance</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="object_class" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">a #JSCClass or %NULL to use the default</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </parameter>
+          <parameter name="uri" transfer-ownership="none">
+            <doc xml:space="preserve">the source URI</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="line_number" transfer-ownership="none">
+            <doc xml:space="preserve">the starting line number</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="object" direction="out" caller-allocates="0" transfer-ownership="full">
+            <doc xml:space="preserve">return location for a #JSCValue.</doc>
+            <type name="Value" c:type="JSCValue**"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="evaluate_with_source_uri" c:identifier="jsc_context_evaluate_with_source_uri">
+        <doc xml:space="preserve">Evaluate @code in @context using @uri as the source URI. The @line_number is the starting line number
+in @uri; the value is one-based so the first line is 1. @uri and @line_number will be shown in exceptions and
+they don't affect the behavior of the script.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue representing the last value generated by the script.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="code" transfer-ownership="none">
+            <doc xml:space="preserve">a JavaScript script to evaluate</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="length" transfer-ownership="none">
+            <doc xml:space="preserve">length of @code, or -1 if @code is a nul-terminated string</doc>
+            <type name="gssize" c:type="gssize"/>
+          </parameter>
+          <parameter name="uri" transfer-ownership="none">
+            <doc xml:space="preserve">the source URI</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="line_number" transfer-ownership="none">
+            <doc xml:space="preserve">the starting line number</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_exception" c:identifier="jsc_context_get_exception">
+        <doc xml:space="preserve">Get the last unhandled exception thrown in @context by API functions calls.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">a #JSCException or %NULL if there isn't any
+   unhandled exception in the #JSCContext.</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_global_object" c:identifier="jsc_context_get_global_object">
+        <doc xml:space="preserve">Get a #JSCValue referencing the @context global object</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_value" c:identifier="jsc_context_get_value">
+        <doc xml:space="preserve">Get a property of @context global object with @name.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the value name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_virtual_machine" c:identifier="jsc_context_get_virtual_machine">
+        <doc xml:space="preserve">Get the #JSCVirtualMachine where @context was created.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #JSCVirtualMachine where the #JSCContext was created.</doc>
+          <type name="VirtualMachine" c:type="JSCVirtualMachine*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="pop_exception_handler" c:identifier="jsc_context_pop_exception_handler">
+        <doc xml:space="preserve">Remove the last #JSCExceptionHandler previously pushed to @context with
+jsc_context_push_exception_handler().</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="push_exception_handler" c:identifier="jsc_context_push_exception_handler">
+        <doc xml:space="preserve">Push an exception handler in @context. Whenever a JavaScript exception happens in
+the #JSCContext, the given @handler will be called. The default #JSCExceptionHandler
+simply calls jsc_context_throw_exception() to throw the exception to the #JSCContext.
+If you don't want to catch the exception, but only get notified about it, call
+jsc_context_throw_exception() in @handler like the default one does.
+The last exception handler pushed is the only one used by the #JSCContext, use
+jsc_context_pop_exception_handler() to remove it and set the previous one. When @handler
+is removed from the context, @destroy_notify i called with @user_data as parameter.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="handler" transfer-ownership="none" scope="notified" closure="1" destroy="2">
+            <doc xml:space="preserve">a #JSCExceptionHandler</doc>
+            <type name="ExceptionHandler" c:type="JSCExceptionHandler"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">user data to pass to @handler</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="register_class" c:identifier="jsc_context_register_class">
+        <doc xml:space="preserve">Register a custom class in @context using the given @name. If the new class inherits from
+another #JSCClass, the parent should be passed as @parent_class, otherwise %NULL should be
+used. The optional @vtable parameter allows to provide a custom implementation for handling
+the class, for example, to handle external properties not added to the prototype.
+When an instance of the #JSCClass is cleared in the context, @destroy_notify is called with
+the instance as parameter.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #JSCClass</doc>
+          <type name="Class" c:type="JSCClass*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the class name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="parent_class" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">a #JSCClass or %NULL</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </parameter>
+          <parameter name="vtable" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">an optional #JSCClassVTable or %NULL</doc>
+            <type name="ClassVTable" c:type="JSCClassVTable*"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">a destroy notifier for class instances</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_value" c:identifier="jsc_context_set_value">
+        <doc xml:space="preserve">Set a property of @context global object with @name and @value.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the value name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="throw" c:identifier="jsc_context_throw">
+        <doc xml:space="preserve">Throw an exception to @context using the given error message. The created #JSCException
+can be retrieved with jsc_context_get_exception().</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="error_message" transfer-ownership="none">
+            <doc xml:space="preserve">an error message</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="throw_exception" c:identifier="jsc_context_throw_exception">
+        <doc xml:space="preserve">Throw @exception to @context.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="throw_printf" c:identifier="jsc_context_throw_printf" introspectable="0">
+        <doc xml:space="preserve">Throw an exception to @context using the given formatted string as error message.
+The created #JSCException can be retrieved with jsc_context_get_exception().</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="format" transfer-ownership="none">
+            <doc xml:space="preserve">the string format</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve">the parameters to insert into the format string</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="throw_with_name" c:identifier="jsc_context_throw_with_name">
+        <doc xml:space="preserve">Throw an exception to @context using the given error name and message. The created #JSCException
+can be retrieved with jsc_context_get_exception().</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="error_name" transfer-ownership="none">
+            <doc xml:space="preserve">the error name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="error_message" transfer-ownership="none">
+            <doc xml:space="preserve">an error message</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="throw_with_name_printf" c:identifier="jsc_context_throw_with_name_printf" introspectable="0">
+        <doc xml:space="preserve">Throw an exception to @context using the given error name and the formatted string as error message.
+The created #JSCException can be retrieved with jsc_context_get_exception().</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="error_name" transfer-ownership="none">
+            <doc xml:space="preserve">the error name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="format" transfer-ownership="none">
+            <doc xml:space="preserve">the string format</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve">the parameters to insert into the format string</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="virtual-machine" writable="1" construct-only="1" transfer-ownership="none">
+        <doc xml:space="preserve">The #JSCVirtualMachine in which the context was created.</doc>
+        <type name="VirtualMachine"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv" readable="0" private="1">
+        <type name="ContextPrivate" c:type="JSCContextPrivate*"/>
+      </field>
+    </class>
+    <record name="ContextClass" c:type="JSCContextClass" glib:is-gtype-struct-for="Context">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_jsc_reserved0" introspectable="0">
+        <callback name="_jsc_reserved0">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved1" introspectable="0">
+        <callback name="_jsc_reserved1">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved2" introspectable="0">
+        <callback name="_jsc_reserved2">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved3" introspectable="0">
+        <callback name="_jsc_reserved3">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <record name="ContextPrivate" c:type="JSCContextPrivate" disguised="1">
+    </record>
+    <class name="Exception" c:symbol-prefix="exception" c:type="JSCException" parent="GObject.Object" glib:type-name="JSCException" glib:get-type="jsc_exception_get_type" glib:type-struct="ExceptionClass">
+      <constructor name="new" c:identifier="jsc_exception_new">
+        <doc xml:space="preserve">Create a new #JSCException in @context with @message.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #JSCException.</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="message" transfer-ownership="none">
+            <doc xml:space="preserve">the error message</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_printf" c:identifier="jsc_exception_new_printf" introspectable="0">
+        <doc xml:space="preserve">Create a new #JSCException in @context using a formatted string
+for the message.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #JSCException.</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="format" transfer-ownership="none">
+            <doc xml:space="preserve">the string format</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve">the parameters to insert into the format string</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_vprintf" c:identifier="jsc_exception_new_vprintf" introspectable="0">
+        <doc xml:space="preserve">Create a new #JSCException in @context using a formatted string
+for the message. This is similar to jsc_exception_new_printf()
+except that the arguments to the format string are passed as a va_list.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #JSCException.</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="format" transfer-ownership="none">
+            <doc xml:space="preserve">the string format</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="args" transfer-ownership="none">
+            <doc xml:space="preserve">the parameters to insert into the format string</doc>
+            <type name="va_list" c:type="va_list"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_with_name" c:identifier="jsc_exception_new_with_name">
+        <doc xml:space="preserve">Create a new #JSCException in @context with @name and @message.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #JSCException.</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the error name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="message" transfer-ownership="none">
+            <doc xml:space="preserve">the error message</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_with_name_printf" c:identifier="jsc_exception_new_with_name_printf" introspectable="0">
+        <doc xml:space="preserve">Create a new #JSCException in @context with @name and using a formatted string
+for the message.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #JSCException.</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the error name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="format" transfer-ownership="none">
+            <doc xml:space="preserve">the string format</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve">the parameters to insert into the format string</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_with_name_vprintf" c:identifier="jsc_exception_new_with_name_vprintf" introspectable="0">
+        <doc xml:space="preserve">Create a new #JSCException in @context with @name and using a formatted string
+for the message. This is similar to jsc_exception_new_with_name_printf()
+except that the arguments to the format string are passed as a va_list.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #JSCException.</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the error name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="format" transfer-ownership="none">
+            <doc xml:space="preserve">the string format</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="args" transfer-ownership="none">
+            <doc xml:space="preserve">the parameters to insert into the format string</doc>
+            <type name="va_list" c:type="va_list"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="get_backtrace_string" c:identifier="jsc_exception_get_backtrace_string">
+        <doc xml:space="preserve">Get a string with the exception backtrace.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the exception backtrace string or %NULL.</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_column_number" c:identifier="jsc_exception_get_column_number">
+        <doc xml:space="preserve">Get the column number at which @exception happened.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the column number of @exception.</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_line_number" c:identifier="jsc_exception_get_line_number">
+        <doc xml:space="preserve">Get the line number at which @exception happened.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the line number of @exception.</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_message" c:identifier="jsc_exception_get_message">
+        <doc xml:space="preserve">Get the error message of @exception.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the @exception error message.</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_name" c:identifier="jsc_exception_get_name">
+        <doc xml:space="preserve">Get the error name of @exception</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the @exception error name.</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_source_uri" c:identifier="jsc_exception_get_source_uri">
+        <doc xml:space="preserve">Get the source URI of @exception.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the the source URI of @exception, or %NULL.</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="report" c:identifier="jsc_exception_report">
+        <doc xml:space="preserve">Return a report message of @exception, containing all the possible details such us
+source URI, line, column and backtrace, and formatted to be printed.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new string with the exception report</doc>
+          <type name="utf8" c:type="char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="to_string" c:identifier="jsc_exception_to_string">
+        <doc xml:space="preserve">Get the string representation of @exception error.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">the string representation of @exception.</doc>
+          <type name="utf8" c:type="char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv" readable="0" private="1">
+        <type name="ExceptionPrivate" c:type="JSCExceptionPrivate*"/>
+      </field>
+    </class>
+    <record name="ExceptionClass" c:type="JSCExceptionClass" glib:is-gtype-struct-for="Exception">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_jsc_reserved0" introspectable="0">
+        <callback name="_jsc_reserved0">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved1" introspectable="0">
+        <callback name="_jsc_reserved1">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved2" introspectable="0">
+        <callback name="_jsc_reserved2">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved3" introspectable="0">
+        <callback name="_jsc_reserved3">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <callback name="ExceptionHandler" c:type="JSCExceptionHandler">
+      <doc xml:space="preserve">Function used to handle JavaScript exceptions in a #JSCContext.</doc>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="context" transfer-ownership="none">
+          <doc xml:space="preserve">a #JSCContext</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </parameter>
+        <parameter name="exception" transfer-ownership="none">
+          <doc xml:space="preserve">a #JSCException</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="2">
+          <doc xml:space="preserve">user data</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <record name="ExceptionPrivate" c:type="JSCExceptionPrivate" disguised="1">
+    </record>
+    <constant name="MAJOR_VERSION" value="2" c:type="JSC_MAJOR_VERSION">
+      <doc xml:space="preserve">Like jsc_get_major_version(), but from the headers used at
+application compile time, rather than from the library linked
+against at application run time.</doc>
+      <type name="gint" c:type="gint"/>
+    </constant>
+    <constant name="MICRO_VERSION" value="5" c:type="JSC_MICRO_VERSION">
+      <doc xml:space="preserve">Like jsc_get_micro_version(), but from the headers used at
+application compile time, rather than from the library linked
+against at application run time.</doc>
+      <type name="gint" c:type="gint"/>
+    </constant>
+    <constant name="MINOR_VERSION" value="22" c:type="JSC_MINOR_VERSION">
+      <doc xml:space="preserve">Like jsc_get_minor_version(), but from the headers used at
+application compile time, rather than from the library linked
+against at application run time.</doc>
+      <type name="gint" c:type="gint"/>
+    </constant>
+    <class name="Value" c:symbol-prefix="value" c:type="JSCValue" parent="GObject.Object" glib:type-name="JSCValue" glib:get-type="jsc_value_get_type" glib:type-struct="ValueClass">
+      <constructor name="new_array" c:identifier="jsc_value_new_array" introspectable="0">
+        <doc xml:space="preserve">Create a new #JSCValue referencing an array with the given items. If @first_item_type
+is %G_TYPE_NONE an empty array is created.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="first_item_type" transfer-ownership="none">
+            <doc xml:space="preserve">#GType of first item, or %G_TYPE_NONE</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve">value of the first item, followed optionally by more type/value pairs, followed by %G_TYPE_NONE.</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_array_from_garray" c:identifier="jsc_value_new_array_from_garray">
+        <doc xml:space="preserve">Create a new #JSCValue referencing an array with the items from @array. If @array
+is %NULL or empty a new empty array will be created. Elements of @array should be
+pointers to a #JSCValue.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="array" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">a #GPtrArray</doc>
+            <array name="GLib.PtrArray" c:type="GPtrArray*">
+              <type name="Value"/>
+            </array>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_array_from_strv" c:identifier="jsc_value_new_array_from_strv">
+        <doc xml:space="preserve">Create a new #JSCValue referencing an array of strings with the items from @strv. If @array
+is %NULL or empty a new empty array will be created.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="strv" transfer-ownership="none">
+            <doc xml:space="preserve">a %NULL-terminated array of strings</doc>
+            <array c:type="const char* const*">
+              <type name="utf8"/>
+            </array>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_boolean" c:identifier="jsc_value_new_boolean">
+        <doc xml:space="preserve">Create a new #JSCValue from @value</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #gboolean</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_function" c:identifier="jsc_value_new_function" shadowed-by="new_functionv" introspectable="0">
+        <doc xml:space="preserve">Create a function in @context. If @name is %NULL an anonymous function will be created.
+When the function is called by JavaScript or jsc_value_function_call(), @callback is called
+receiving the function parameters and then @user_data as last parameter. When the function is
+cleared in @context, @destroy_notify is called with @user_data as parameter.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext:</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="name" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">the function name or %NULL</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="3" destroy="4">
+            <doc xml:space="preserve">a #GCallback.</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">user data to pass to @callback.</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve">the #GType of the function return value, or %G_TYPE_NONE if the function is void.</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="n_params" transfer-ownership="none">
+            <doc xml:space="preserve">the number of parameter types to follow or 0 if the function doesn't receive parameters.</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve">a list of #GType&lt;!-- --&gt;s, one for each parameter.</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_function_variadic" c:identifier="jsc_value_new_function_variadic">
+        <doc xml:space="preserve">Create a function in @context. If @name is %NULL an anonymous function will be created.
+When the function is called by JavaScript or jsc_value_function_call(), @callback is called
+receiving an #GPtrArray of #JSCValue&lt;!-- --&gt;s with the arguments and then @user_data as last parameter.
+When the function is cleared in @context, @destroy_notify is called with @user_data as parameter.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="name" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">the function name or %NULL</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="3" destroy="4">
+            <doc xml:space="preserve">a #GCallback.</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">user data to pass to @callback.</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve">the #GType of the function return value, or %G_TYPE_NONE if the function is void.</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_functionv" c:identifier="jsc_value_new_functionv" shadows="new_function">
+        <doc xml:space="preserve">Create a function in @context. If @name is %NULL an anonymous function will be created.
+When the function is called by JavaScript or jsc_value_function_call(), @callback is called
+receiving the function parameters and then @user_data as last parameter. When the function is
+cleared in @context, @destroy_notify is called with @user_data as parameter.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="name" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">the function name or %NULL</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="3" destroy="4">
+            <doc xml:space="preserve">a #GCallback.</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">user data to pass to @callback.</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve">the #GType of the function return value, or %G_TYPE_NONE if the function is void.</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="n_parameters" transfer-ownership="none">
+            <doc xml:space="preserve">the number of parameters</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="parameter_types" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">a list of #GType&lt;!-- --&gt;s, one for each parameter, or %NULL</doc>
+            <array length="6" zero-terminated="0" c:type="GType*">
+              <type name="GType"/>
+            </array>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_null" c:identifier="jsc_value_new_null">
+        <doc xml:space="preserve">Create a new #JSCValue referencing &lt;function&gt;null&lt;/function&gt; in @context.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_number" c:identifier="jsc_value_new_number">
+        <doc xml:space="preserve">Create a new #JSCValue from @number.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="number" transfer-ownership="none">
+            <doc xml:space="preserve">a number</doc>
+            <type name="gdouble" c:type="double"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_object" c:identifier="jsc_value_new_object">
+        <doc xml:space="preserve">Create a new #JSCValue from @instance. If @instance is %NULL a new empty object is created.
+When @instance is provided, @jsc_class must be provided too.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="instance" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">an object instance or %NULL</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="jsc_class" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">the #JSCClass of @instance</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_string" c:identifier="jsc_value_new_string">
+        <doc xml:space="preserve">Create a new #JSCValue from @string. If you need to create a #JSCValue from a
+string containing null characters, use jsc_value_new_string_from_bytes() instead.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="string" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">a null-terminated string</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_string_from_bytes" c:identifier="jsc_value_new_string_from_bytes">
+        <doc xml:space="preserve">Create a new #JSCValue from @bytes.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="bytes" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">a #GBytes</doc>
+            <type name="GLib.Bytes" c:type="GBytes*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_undefined" c:identifier="jsc_value_new_undefined">
+        <doc xml:space="preserve">Create a new #JSCValue referencing &lt;function&gt;undefined&lt;/function&gt; in @context.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="constructor_call" c:identifier="jsc_value_constructor_call" shadowed-by="constructor_callv" introspectable="0">
+        <doc xml:space="preserve">Invoke &lt;function&gt;new&lt;/function&gt; with constructor referenced by @value. If @first_parameter_type
+is %G_TYPE_NONE no parameters will be passed to the constructor.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue referencing the newly created object instance.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="first_parameter_type" transfer-ownership="none">
+            <doc xml:space="preserve">#GType of first parameter, or %G_TYPE_NONE</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve">value of the first parameter, followed optionally by more type/value pairs, followed by %G_TYPE_NONE</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="constructor_callv" c:identifier="jsc_value_constructor_callv" shadows="constructor_call">
+        <doc xml:space="preserve">Invoke &lt;function&gt;new&lt;/function&gt; with constructor referenced by @value. If @n_parameters
+is 0 no parameters will be passed to the constructor.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue referencing the newly created object instance.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="n_parameters" transfer-ownership="none">
+            <doc xml:space="preserve">the number of parameters</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="parameters" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">the #JSCValue&lt;!-- --&gt;s to pass as parameters to the constructor, or %NULL</doc>
+            <array length="0" zero-terminated="0" c:type="JSCValue**">
+              <type name="Value"/>
+            </array>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="function_call" c:identifier="jsc_value_function_call" shadowed-by="function_callv" introspectable="0">
+        <doc xml:space="preserve">Call function referenced by @value, passing the given parameters. If @first_parameter_type
+is %G_TYPE_NONE no parameters will be passed to the function.
+
+This function always returns a #JSCValue, in case of void functions a #JSCValue referencing
+&lt;function&gt;undefined&lt;/function&gt; is returned</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue with the return value of the function.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="first_parameter_type" transfer-ownership="none">
+            <doc xml:space="preserve">#GType of first parameter, or %G_TYPE_NONE</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve">value of the first parameter, followed optionally by more type/value pairs, followed by %G_TYPE_NONE</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="function_callv" c:identifier="jsc_value_function_callv" shadows="function_call">
+        <doc xml:space="preserve">Call function referenced by @value, passing the given @parameters. If @n_parameters
+is 0 no parameters will be passed to the function.
+
+This function always returns a #JSCValue, in case of void functions a #JSCValue referencing
+&lt;function&gt;undefined&lt;/function&gt; is returned</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue with the return value of the function.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="n_parameters" transfer-ownership="none">
+            <doc xml:space="preserve">the number of parameters</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="parameters" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">the #JSCValue&lt;!-- --&gt;s to pass as parameters to the function, or %NULL</doc>
+            <array length="0" zero-terminated="0" c:type="JSCValue**">
+              <type name="Value"/>
+            </array>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_context" c:identifier="jsc_value_get_context">
+        <doc xml:space="preserve">Get the #JSCContext in which @value was created.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #JSCValue context.</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_array" c:identifier="jsc_value_is_array">
+        <doc xml:space="preserve">Get whether the value referenced by @value is an array.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the value is an array.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_boolean" c:identifier="jsc_value_is_boolean">
+        <doc xml:space="preserve">Get whether the value referenced by @value is a boolean.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the value is a boolean.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_constructor" c:identifier="jsc_value_is_constructor">
+        <doc xml:space="preserve">Get whether the value referenced by @value is a constructor.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the value is a constructor.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_function" c:identifier="jsc_value_is_function">
+        <doc xml:space="preserve">Get whether the value referenced by @value is a function</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the value is a function.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_null" c:identifier="jsc_value_is_null">
+        <doc xml:space="preserve">Get whether the value referenced by @value is &lt;function&gt;null&lt;/function&gt;.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the value is null.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_number" c:identifier="jsc_value_is_number">
+        <doc xml:space="preserve">Get whether the value referenced by @value is a number.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the value is a number.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_object" c:identifier="jsc_value_is_object">
+        <doc xml:space="preserve">Get whether the value referenced by @value is an object.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the value is an object.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_string" c:identifier="jsc_value_is_string">
+        <doc xml:space="preserve">Get whether the value referenced by @value is a string</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the value is a string</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_undefined" c:identifier="jsc_value_is_undefined">
+        <doc xml:space="preserve">Get whether the value referenced by @value is &lt;function&gt;undefined&lt;/function&gt;.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the value is undefined.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="object_define_property_accessor" c:identifier="jsc_value_object_define_property_accessor">
+        <doc xml:space="preserve">Define or modify a property with @property_name in object referenced by @value. When the
+property value needs to be getted or set, @getter and @setter callbacks will be called.
+When the property is cleared in the #JSCClass context, @destroy_notify is called with
+@user_data as parameter. This is equivalent to JavaScript &lt;function&gt;Object.defineProperty()&lt;/function&gt;
+when used with an accessor descriptor.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="property_name" transfer-ownership="none">
+            <doc xml:space="preserve">the name of the property to define</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="flags" transfer-ownership="none">
+            <doc xml:space="preserve">#JSCValuePropertyFlags</doc>
+            <type name="ValuePropertyFlags" c:type="JSCValuePropertyFlags"/>
+          </parameter>
+          <parameter name="property_type" transfer-ownership="none">
+            <doc xml:space="preserve">the #GType of the property</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="getter" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">a #GCallback to be called to get the property value</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="setter" transfer-ownership="none" nullable="1" allow-none="1" scope="notified" closure="5" destroy="6">
+            <doc xml:space="preserve">a #GCallback to be called to set the property value</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">user data to pass to @getter and @setter</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_define_property_data" c:identifier="jsc_value_object_define_property_data">
+        <doc xml:space="preserve">Define or modify a property with @property_name in object referenced by @value. This is equivalent to
+JavaScript &lt;function&gt;Object.defineProperty()&lt;/function&gt; when used with a data descriptor.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="property_name" transfer-ownership="none">
+            <doc xml:space="preserve">the name of the property to define</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="flags" transfer-ownership="none">
+            <doc xml:space="preserve">#JSCValuePropertyFlags</doc>
+            <type name="ValuePropertyFlags" c:type="JSCValuePropertyFlags"/>
+          </parameter>
+          <parameter name="property_value" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">the default property value</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_delete_property" c:identifier="jsc_value_object_delete_property">
+        <doc xml:space="preserve">Try to delete property with @name from @value. This function will return %FALSE if
+the property was defined without %JSC_VALUE_PROPERTY_CONFIGURABLE flag.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if the property was deleted, or %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the property name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_enumerate_properties" c:identifier="jsc_value_object_enumerate_properties">
+        <doc xml:space="preserve">Get the list of property names of @value. Only properties defined with %JSC_VALUE_PROPERTY_ENUMERABLE
+flag will be collected.</doc>
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve">a %NULL-terminated array of strings containing the
+   property names, or %NULL if @value doesn't have enumerable properties.  Use g_strfreev() to free.</doc>
+          <array c:type="gchar**">
+            <type name="utf8"/>
+          </array>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="object_get_property" c:identifier="jsc_value_object_get_property">
+        <doc xml:space="preserve">Get property with @name from @value.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">the property #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the property name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_get_property_at_index" c:identifier="jsc_value_object_get_property_at_index">
+        <doc xml:space="preserve">Get property at @index from @value.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">the property #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="index" transfer-ownership="none">
+            <doc xml:space="preserve">the property index</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_has_property" c:identifier="jsc_value_object_has_property">
+        <doc xml:space="preserve">Get whether @value has property with @name.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if @value has a property with @name, or %FALSE otherwise</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the property name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_invoke_method" c:identifier="jsc_value_object_invoke_method" shadowed-by="object_invoke_methodv" introspectable="0">
+        <doc xml:space="preserve">Invoke method with @name on object referenced by @value, passing the given parameters. If
+@first_parameter_type is %G_TYPE_NONE no parameters will be passed to the method.
+The object instance will be handled automatically even when the method is a custom one
+registered with jsc_class_add_method(), so it should never be passed explicitly as parameter
+of this function.
+
+This function always returns a #JSCValue, in case of void methods a #JSCValue referencing
+&lt;function&gt;undefined&lt;/function&gt; is returned.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue with the return value of the method.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the method name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="first_parameter_type" transfer-ownership="none">
+            <doc xml:space="preserve">#GType of first parameter, or %G_TYPE_NONE</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve">value of the first parameter, followed optionally by more type/value pairs, followed by %G_TYPE_NONE</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_invoke_methodv" c:identifier="jsc_value_object_invoke_methodv" shadows="object_invoke_method">
+        <doc xml:space="preserve">Invoke method with @name on object referenced by @value, passing the given @parameters. If
+@n_parameters is 0 no parameters will be passed to the method.
+The object instance will be handled automatically even when the method is a custom one
+registered with jsc_class_add_method(), so it should never be passed explicitly as parameter
+of this function.
+
+This function always returns a #JSCValue, in case of void methods a #JSCValue referencing
+&lt;function&gt;undefined&lt;/function&gt; is returned.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #JSCValue with the return value of the method.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the method name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="n_parameters" transfer-ownership="none">
+            <doc xml:space="preserve">the number of parameters</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="parameters" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">the #JSCValue&lt;!-- --&gt;s to pass as parameters to the method, or %NULL</doc>
+            <array length="1" zero-terminated="0" c:type="JSCValue**">
+              <type name="Value"/>
+            </array>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_is_instance_of" c:identifier="jsc_value_object_is_instance_of">
+        <doc xml:space="preserve">Get whether the value referenced by @value is an instance of class @name.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether the value is an object instance of class @name.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">a class name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_set_property" c:identifier="jsc_value_object_set_property">
+        <doc xml:space="preserve">Set @property with @name on @value.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">the property name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="property" transfer-ownership="none">
+            <doc xml:space="preserve">the #JSCValue to set</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_set_property_at_index" c:identifier="jsc_value_object_set_property_at_index">
+        <doc xml:space="preserve">Set @property at @index on @value.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="index" transfer-ownership="none">
+            <doc xml:space="preserve">the property index</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="property" transfer-ownership="none">
+            <doc xml:space="preserve">the #JSCValue to set</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="to_boolean" c:identifier="jsc_value_to_boolean">
+        <doc xml:space="preserve">Convert @value to a boolean.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #gboolean result of the conversion.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="to_double" c:identifier="jsc_value_to_double">
+        <doc xml:space="preserve">Convert @value to a double.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #gdouble result of the conversion.</doc>
+          <type name="gdouble" c:type="double"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="to_int32" c:identifier="jsc_value_to_int32">
+        <doc xml:space="preserve">Convert @value to a #gint32.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #gint32 result of the conversion.</doc>
+          <type name="gint32" c:type="gint32"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="to_string" c:identifier="jsc_value_to_string">
+        <doc xml:space="preserve">Convert @value to a string. Use jsc_value_to_string_as_bytes() instead, if you need to
+handle strings containing null characters.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a null-terminated string result of the conversion.</doc>
+          <type name="utf8" c:type="char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="to_string_as_bytes" c:identifier="jsc_value_to_string_as_bytes">
+        <doc xml:space="preserve">Convert @value to a string and return the results as #GBytes. This is needed
+to handle strings with null characters.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #GBytes with the result of the conversion.</doc>
+          <type name="GLib.Bytes" c:type="GBytes*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <property name="context" writable="1" construct-only="1" transfer-ownership="none">
+        <doc xml:space="preserve">The #JSCContext in which the value was created.</doc>
+        <type name="Context"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv" readable="0" private="1">
+        <type name="ValuePrivate" c:type="JSCValuePrivate*"/>
+      </field>
+    </class>
+    <record name="ValueClass" c:type="JSCValueClass" glib:is-gtype-struct-for="Value">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_jsc_reserved0" introspectable="0">
+        <callback name="_jsc_reserved0">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved1" introspectable="0">
+        <callback name="_jsc_reserved1">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved2" introspectable="0">
+        <callback name="_jsc_reserved2">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved3" introspectable="0">
+        <callback name="_jsc_reserved3">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <record name="ValuePrivate" c:type="JSCValuePrivate" disguised="1">
+    </record>
+    <bitfield name="ValuePropertyFlags" c:type="JSCValuePropertyFlags">
+      <doc xml:space="preserve">Flags used when defining properties with jsc_value_object_define_property_data() and
+jsc_value_object_define_property_accessor().</doc>
+      <member name="configurable" value="1" c:identifier="JSC_VALUE_PROPERTY_CONFIGURABLE">
+        <doc xml:space="preserve">the type of the property descriptor may be changed and the
+ property may be deleted from the corresponding object.</doc>
+      </member>
+      <member name="enumerable" value="2" c:identifier="JSC_VALUE_PROPERTY_ENUMERABLE">
+        <doc xml:space="preserve">the property shows up during enumeration of the properties on
+ the corresponding object.</doc>
+      </member>
+      <member name="writable" value="4" c:identifier="JSC_VALUE_PROPERTY_WRITABLE">
+        <doc xml:space="preserve">the value associated with the property may be changed with an
+ assignment operator. This doesn't have any effect when passed to jsc_value_object_define_property_accessor().</doc>
+      </member>
+    </bitfield>
+    <class name="VirtualMachine" c:symbol-prefix="virtual_machine" c:type="JSCVirtualMachine" parent="GObject.Object" glib:type-name="JSCVirtualMachine" glib:get-type="jsc_virtual_machine_get_type" glib:type-struct="VirtualMachineClass">
+      <constructor name="new" c:identifier="jsc_virtual_machine_new">
+        <doc xml:space="preserve">Create a new #JSCVirtualMachine.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">the newly created #JSCVirtualMachine.</doc>
+          <type name="VirtualMachine" c:type="JSCVirtualMachine*"/>
+        </return-value>
+      </constructor>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv" readable="0" private="1">
+        <type name="VirtualMachinePrivate" c:type="JSCVirtualMachinePrivate*"/>
+      </field>
+    </class>
+    <record name="VirtualMachineClass" c:type="JSCVirtualMachineClass" glib:is-gtype-struct-for="VirtualMachine">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_jsc_reserved0" introspectable="0">
+        <callback name="_jsc_reserved0">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved1" introspectable="0">
+        <callback name="_jsc_reserved1">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved2" introspectable="0">
+        <callback name="_jsc_reserved2">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved3" introspectable="0">
+        <callback name="_jsc_reserved3">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <record name="VirtualMachinePrivate" c:type="JSCVirtualMachinePrivate" disguised="1">
+    </record>
+    <class name="WeakValue" c:symbol-prefix="weak_value" c:type="JSCWeakValue" parent="GObject.Object" glib:type-name="JSCWeakValue" glib:get-type="jsc_weak_value_get_type" glib:type-struct="WeakValueClass">
+      <constructor name="new" c:identifier="jsc_weak_value_new">
+        <doc xml:space="preserve">Create a new #JSCWeakValue for the JavaScript value referenced by @value.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #JSCWeakValue</doc>
+          <type name="WeakValue" c:type="JSCWeakValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="get_value" c:identifier="jsc_weak_value_get_value">
+        <doc xml:space="preserve">Get a #JSCValue referencing the JavaScript value of @weak_value.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new #JSCValue or %NULL if @weak_value was cleared.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="weak_value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCWeakValue</doc>
+            <type name="WeakValue" c:type="JSCWeakValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <property name="value" readable="0" writable="1" construct-only="1" transfer-ownership="none">
+        <doc xml:space="preserve">The #JSCValue referencing the JavaScript value.</doc>
+        <type name="Value"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv" readable="0" private="1">
+        <type name="WeakValuePrivate" c:type="JSCWeakValuePrivate*"/>
+      </field>
+      <glib:signal name="cleared" when="last">
+        <doc xml:space="preserve">This signal is emitted when the JavaScript value is destroyed.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+    </class>
+    <record name="WeakValueClass" c:type="JSCWeakValueClass" glib:is-gtype-struct-for="WeakValue">
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_jsc_reserved0" introspectable="0">
+        <callback name="_jsc_reserved0">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved1" introspectable="0">
+        <callback name="_jsc_reserved1">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved2" introspectable="0">
+        <callback name="_jsc_reserved2">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved3" introspectable="0">
+        <callback name="_jsc_reserved3">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <record name="WeakValuePrivate" c:type="JSCWeakValuePrivate" disguised="1">
+    </record>
+    <function name="get_major_version" c:identifier="jsc_get_major_version">
+      <doc xml:space="preserve">Returns the major version number of the JavaScriptCore library.
+(e.g. in JavaScriptCore version 1.8.3 this is 1.)
+
+This function is in the library, so it represents the JavaScriptCore library
+your code is running against. Contrast with the #JSC_MAJOR_VERSION
+macro, which represents the major version of the JavaScriptCore headers you
+have included when compiling your code.</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">the major version number of the JavaScriptCore library</doc>
+        <type name="guint" c:type="guint"/>
+      </return-value>
+    </function>
+    <function name="get_micro_version" c:identifier="jsc_get_micro_version">
+      <doc xml:space="preserve">Returns the micro version number of the JavaScriptCore library.
+(e.g. in JavaScriptCore version 1.8.3 this is 3.)
+
+This function is in the library, so it represents the JavaScriptCore library
+your code is running against. Contrast with the #JSC_MICRO_VERSION
+macro, which represents the micro version of the JavaScriptCore headers you
+have included when compiling your code.</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">the micro version number of the JavaScriptCore library</doc>
+        <type name="guint" c:type="guint"/>
+      </return-value>
+    </function>
+    <function name="get_minor_version" c:identifier="jsc_get_minor_version">
+      <doc xml:space="preserve">Returns the minor version number of the JavaScriptCore library.
+(e.g. in JavaScriptCore version 1.8.3 this is 8.)
+
+This function is in the library, so it represents the JavaScriptCore library
+your code is running against. Contrast with the #JSC_MINOR_VERSION
+macro, which represents the minor version of the JavaScriptCore headers you
+have included when compiling your code.</doc>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve">the minor version number of the JavaScriptCore library</doc>
+        <type name="guint" c:type="guint"/>
+      </return-value>
+    </function>
   </namespace>
 </repository>

--- a/Pango-1.0.gir
+++ b/Pango-1.0.gir
@@ -2805,6 +2805,23 @@ pango_font_description_set_variant().</doc>
           </instance-parameter>
         </parameters>
       </method>
+      <method name="get_variations" c:identifier="pango_font_description_get_variations" version="1.42">
+        <doc xml:space="preserve">Gets the variations field of a font description. See
+pango_font_description_set_variations().</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the varitions field for the font
+              description, or %NULL if not previously set.  This
+              has the same life-time as the font description itself
+              and should not be freed.</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="desc" transfer-ownership="none">
+            <doc xml:space="preserve">a #PangoFontDescription</doc>
+            <type name="FontDescription" c:type="const PangoFontDescription*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
       <method name="get_weight" c:identifier="pango_font_description_get_weight">
         <doc xml:space="preserve">Gets the weight field of a font description. See
 pango_font_description_set_weight().</doc>
@@ -3048,6 +3065,51 @@ can either be %PANGO_VARIANT_NORMAL or %PANGO_VARIANT_SMALL_CAPS.</doc>
           <parameter name="variant" transfer-ownership="none">
             <doc xml:space="preserve">the variant type for the font description.</doc>
             <type name="Variant" c:type="PangoVariant"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_variations" c:identifier="pango_font_description_set_variations" version="1.42">
+        <doc xml:space="preserve">Sets the variations field of a font description. OpenType
+font variations allow to select a font instance by specifying
+values for a number of axes, such as width or weight.
+
+The format of the variations string is AXIS1=VALUE,AXIS2=VALUE...,
+with each AXIS a 4 character tag that identifies a font axis,
+and each VALUE a floating point number. Unknown axes are ignored,
+and values are clamped to their allowed range.
+
+Pango does not currently have a way to find supported axes of
+a font. Both harfbuzz or freetype have API for this.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="desc" transfer-ownership="none">
+            <doc xml:space="preserve">a #PangoFontDescription.</doc>
+            <type name="FontDescription" c:type="PangoFontDescription*"/>
+          </instance-parameter>
+          <parameter name="settings" transfer-ownership="none">
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_variations_static" c:identifier="pango_font_description_set_variations_static" version="1.42">
+        <doc xml:space="preserve">Like pango_font_description_set_variations(), except that no
+copy of @variations is made. The caller must make sure that the
+string passed in stays around until @desc has been freed
+or the name is set again. This function can be used if
+@variations is a static string such as a C string literal, or
+if @desc is only needed temporarily.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="desc" transfer-ownership="none">
+            <doc xml:space="preserve">a #PangoFontDescription</doc>
+            <type name="FontDescription" c:type="PangoFontDescription*"/>
+          </instance-parameter>
+          <parameter name="settings" transfer-ownership="none">
+            <type name="utf8" c:type="const char*"/>
           </parameter>
         </parameters>
       </method>
@@ -4047,6 +4109,9 @@ can handle fonts of this fonts loaded with this fontmap.</doc>
       </member>
       <member name="gravity" value="64" c:identifier="PANGO_FONT_MASK_GRAVITY" glib:nick="gravity">
         <doc xml:space="preserve">the font gravity is specified (Since: 1.16.)</doc>
+      </member>
+      <member name="variations" value="128" c:identifier="PANGO_FONT_MASK_VARIATIONS" glib:nick="variations">
+        <doc xml:space="preserve">OpenType font variations are specified (Since: 1.42)</doc>
       </member>
     </bitfield>
     <record name="FontMetrics" c:type="PangoFontMetrics" glib:type-name="PangoFontMetrics" glib:get-type="pango_font_metrics_get_type" c:symbol-prefix="font_metrics">
@@ -5591,7 +5656,7 @@ in @num_scripts, or %NULL if Pango does not have any information
 about this particular language tag (also the case if @language is
 %NULL).  The returned array is owned by Pango and should not be
 modified or freed.</doc>
-          <array length="0" zero-terminated="0" c:type="PangoScript*">
+          <array length="0" zero-terminated="0" c:type="const PangoScript*">
             <type name="Script" c:type="PangoScript"/>
           </array>
         </return-value>
@@ -6196,7 +6261,7 @@ need to be attributes corresponding to both the position before
 the first character and the position after the last character.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">an array of logical attributes</doc>
-          <array length="0" zero-terminated="0" c:type="PangoLogAttr*">
+          <array length="0" zero-terminated="0" c:type="const PangoLogAttr*">
             <type name="LogAttr" c:type="PangoLogAttr"/>
           </array>
         </return-value>
@@ -9590,18 +9655,6 @@ of the script, or %NULL if no such language exists.</doc>
         </parameters>
       </function>
     </enumeration>
-    <record name="ScriptForLang" c:type="PangoScriptForLang">
-      <field name="lang" writable="1">
-        <array zero-terminated="0" c:type="const char" fixed-size="7">
-          <type name="gchar" c:type="const char"/>
-        </array>
-      </field>
-      <field name="scripts" writable="1">
-        <array zero-terminated="0" c:type="PangoScript" fixed-size="3">
-          <type name="Script" c:type="PangoScript"/>
-        </array>
-      </field>
-    </record>
     <record name="ScriptIter" c:type="PangoScriptIter" disguised="1">
       <doc xml:space="preserve">A #PangoScriptIter is used to iterate through a string
 and identify ranges in different scripts.</doc>

--- a/PangoCairo-1.0.gir
+++ b/PangoCairo-1.0.gir
@@ -5,18 +5,10 @@ and/or use gtk-doc annotations.  -->
 <repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0" version="1.2">
   <include name="GObject" version="2.0"/>
   <include name="Pango" version="1.0"/>
-  <include name="PangoFT2" version="1.0"/>
   <include name="cairo" version="1.0"/>
   <package name="pangocairo"/>
   <c:include name="pango/pangocairo.h"/>
-  <namespace name="PangoCairo" version="1.0" shared-library="libpango-1.0.so.0,libpangocairo-1.0.so.0,libpango-1.0.so.0,libpangoft2-1.0.so.0" c:identifier-prefixes="PangoCairo" c:symbol-prefixes="pango_cairo">
-    <class name="FcFontMap" c:symbol-prefix="fc_font_map" c:type="PangoCairoFcFontMap" parent="Pango.FontMap" glib:type-name="PangoCairoFcFontMap" glib:get-type="pango_cairo_fc_font_map_get_type">
-      <implements name="FontMap"/>
-      
-      
-      
-      
-    </class>
+  <namespace name="PangoCairo" version="1.0" shared-library="libpangocairo-1.0.so.0" c:identifier-prefixes="PangoCairo" c:symbol-prefixes="pango_cairo">
     <interface name="Font" c:symbol-prefix="font" c:type="PangoCairoFont" version="1.18" glib:type-name="PangoCairoFont" glib:get-type="pango_cairo_font_get_type">
       <doc xml:space="preserve">#PangoCairoFont is an interface exported by fonts for
 use with Cairo. The actual type of the font will depend

--- a/PangoFT2-1.0.gir
+++ b/PangoFT2-1.0.gir
@@ -10,7 +10,7 @@ and/or use gtk-doc annotations.  -->
   <include name="freetype2" version="2.0"/>
   <package name="pangoft2"/>
   <c:include name="pango/pangoft2.h"/>
-  <namespace name="PangoFT2" version="1.0" shared-library="libpango-1.0.so.0,libpangoft2-1.0.so.0" c:identifier-prefixes="PangoFT2" c:symbol-prefixes="pango_ft2">
+  <namespace name="PangoFT2" version="1.0" shared-library="libpangoft2-1.0.so.0" c:identifier-prefixes="PangoFT2" c:symbol-prefixes="pango_ft2">
     <class name="FontMap" c:symbol-prefix="font_map" c:type="PangoFT2FontMap" parent="Pango.FontMap" glib:type-name="PangoFT2FontMap" glib:get-type="pango_ft2_font_map_get_type">
       <constructor name="new" c:identifier="pango_ft2_font_map_new">
         <return-value transfer-ownership="full">

--- a/PangoXft-1.0.gir
+++ b/PangoXft-1.0.gir
@@ -10,7 +10,7 @@ and/or use gtk-doc annotations.  -->
   <include name="xlib" version="2.0"/>
   <package name="pangoxft"/>
   <c:include name="pango/pangoxft.h"/>
-  <namespace name="PangoXft" version="1.0" shared-library="libpango-1.0.so.0,libpangoft2-1.0.so.0,libpangoxft-1.0.so.0" c:identifier-prefixes="PangoXft" c:symbol-prefixes="pango_xft">
+  <namespace name="PangoXft" version="1.0" shared-library="libpangoxft-1.0.so.0" c:identifier-prefixes="PangoXft" c:symbol-prefixes="pango_xft">
     <class name="Font" c:symbol-prefix="font" c:type="PangoXftFont" parent="Pango.Font" glib:type-name="PangoXftFont" glib:get-type="pango_xft_font_get_type">
       <doc xml:space="preserve">#PangoXftFont is an implementation of #PangoFcFont using the Xft
 library for rendering.  It is used in conjunction with #PangoXftFontMap.</doc>

--- a/Secret-1.gir
+++ b/Secret-1.gir
@@ -1392,7 +1392,7 @@ the number of seconds since the unix epoch, January 1st 1970.</doc>
       <method name="get_schema_name" c:identifier="secret_item_get_schema_name">
         <doc xml:space="preserve">Gets the name of the schema that this item was stored with. This is also
 available at the &lt;literal&gt;xdg:schema&lt;/literal&gt; attribute.</doc>
-        <return-value transfer-ownership="full">
+        <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">the schema name</doc>
           <type name="utf8" c:type="gchar*"/>
         </return-value>
@@ -5090,7 +5090,7 @@ null-terminated unless it was created with secret_value_new() or a
 null-terminated string was passed to secret_value_new_full().</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the secret data</doc>
-          <array length="0" zero-terminated="0" c:type="gchar*">
+          <array length="0" zero-terminated="0" c:type="const gchar*">
             <type name="guint8"/>
           </array>
         </return-value>

--- a/Soup-2.4.gir
+++ b/Soup-2.4.gir
@@ -57,9 +57,6 @@ for calling soup_auth_domain_add_path().)</doc>
 (The data to pass to the #SoupAuthDomainBasicAuthCallback.)</doc>
       <type name="utf8" c:type="gchar*"/>
     </constant>
-    <constant name="AUTH_DOMAIN_BASIC_H" value="1" c:type="SOUP_AUTH_DOMAIN_BASIC_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <constant name="AUTH_DOMAIN_DIGEST_AUTH_CALLBACK" value="auth-callback" c:type="SOUP_AUTH_DOMAIN_DIGEST_AUTH_CALLBACK">
       <doc xml:space="preserve">Alias for the #SoupAuthDomainDigest:auth-callback property.
 (The #SoupAuthDomainDigestAuthCallback.)</doc>
@@ -69,9 +66,6 @@ for calling soup_auth_domain_add_path().)</doc>
       <doc xml:space="preserve">Alias for the #SoupAuthDomainDigest:auth-callback property.
 (The #SoupAuthDomainDigestAuthCallback.)</doc>
       <type name="utf8" c:type="gchar*"/>
-    </constant>
-    <constant name="AUTH_DOMAIN_DIGEST_H" value="1" c:type="SOUP_AUTH_DOMAIN_DIGEST_H">
-      <type name="gint" c:type="gint"/>
     </constant>
     <constant name="AUTH_DOMAIN_FILTER" value="filter" c:type="SOUP_AUTH_DOMAIN_FILTER">
       <doc xml:space="preserve">Alias for the #SoupAuthDomain:filter property. (The
@@ -93,9 +87,6 @@ to pass to the #SoupAuthDomainFilter.)</doc>
 (The data to pass to the #SoupAuthDomainGenericAuthCallback.)</doc>
       <type name="utf8" c:type="gchar*"/>
     </constant>
-    <constant name="AUTH_DOMAIN_H" value="1" c:type="SOUP_AUTH_DOMAIN_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <constant name="AUTH_DOMAIN_PROXY" value="proxy" c:type="SOUP_AUTH_DOMAIN_PROXY">
       <doc xml:space="preserve">Alias for the #SoupAuthDomain:proxy property. (Whether or
 not this is a proxy auth domain.)</doc>
@@ -111,9 +102,6 @@ this auth domain.)</doc>
 (Shortcut for calling soup_auth_domain_remove_path().)</doc>
       <type name="utf8" c:type="gchar*"/>
     </constant>
-    <constant name="AUTH_H" value="1" c:type="SOUP_AUTH_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <constant name="AUTH_HOST" value="host" c:type="SOUP_AUTH_HOST">
       <doc xml:space="preserve">An alias for the #SoupAuth:host property. (The
 host being authenticated to.)</doc>
@@ -128,9 +116,6 @@ host being authenticated to.)</doc>
       <doc xml:space="preserve">An alias for the #SoupAuth:is-for-proxy property. (Whether
 or not the auth is for a proxy server.)</doc>
       <type name="utf8" c:type="gchar*"/>
-    </constant>
-    <constant name="AUTH_MANAGER_H" value="1" c:type="SOUP_AUTH_MANAGER_H">
-      <type name="gint" c:type="gint"/>
     </constant>
     <constant name="AUTH_REALM" value="realm" c:type="SOUP_AUTH_REALM">
       <doc xml:space="preserve">An alias for the #SoupAuth:realm property. (The
@@ -1213,15 +1198,23 @@ response to.</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="challenge">
+      <virtual-method name="challenge" invoker="challenge">
+        <doc xml:space="preserve">Adds a "WWW-Authenticate" or "Proxy-Authenticate" header to @msg,
+requesting that the client authenticate, and sets @msg's status
+accordingly.
+
+This is used by #SoupServer internally and is probably of no use to
+anyone else.</doc>
         <return-value transfer-ownership="full">
           <type name="utf8" c:type="char*"/>
         </return-value>
         <parameters>
           <instance-parameter name="domain" transfer-ownership="none">
+            <doc xml:space="preserve">a #SoupAuthDomain</doc>
             <type name="AuthDomain" c:type="SoupAuthDomain*"/>
           </instance-parameter>
           <parameter name="msg" transfer-ownership="none">
+            <doc xml:space="preserve">a #SoupMessage</doc>
             <type name="Message" c:type="SoupMessage*"/>
           </parameter>
         </parameters>
@@ -1299,39 +1292,6 @@ construct time.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="basic_set_auth_callback" c:identifier="soup_auth_domain_basic_set_auth_callback">
-        <doc xml:space="preserve">Sets the callback that @domain will use to authenticate incoming
-requests. For each request containing authorization, @domain will
-invoke the callback, and then either accept or reject the request
-based on @callback's return value.
-
-You can also set the auth callback by setting the
-%SOUP_AUTH_DOMAIN_BASIC_AUTH_CALLBACK and
-%SOUP_AUTH_DOMAIN_BASIC_AUTH_DATA properties, which can also be
-used to set the callback at construct time.</doc>
-        <return-value transfer-ownership="none">
-          <type name="none" c:type="void"/>
-        </return-value>
-        <parameters>
-          <instance-parameter name="domain" transfer-ownership="none">
-            <doc xml:space="preserve">the domain</doc>
-            <type name="AuthDomain" c:type="SoupAuthDomain*"/>
-          </instance-parameter>
-          <parameter name="callback" transfer-ownership="none" scope="notified" closure="1" destroy="2">
-            <doc xml:space="preserve">the callback</doc>
-            <type name="AuthDomainBasicAuthCallback" c:type="SoupAuthDomainBasicAuthCallback"/>
-          </parameter>
-          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
-            <doc xml:space="preserve">data to pass to @auth_callback</doc>
-            <type name="gpointer" c:type="gpointer"/>
-          </parameter>
-          <parameter name="dnotify" transfer-ownership="none" scope="async">
-            <doc xml:space="preserve">destroy notifier to free @user_data when @domain
-is destroyed</doc>
-            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
-          </parameter>
-        </parameters>
-      </method>
       <method name="challenge" c:identifier="soup_auth_domain_challenge">
         <doc xml:space="preserve">Adds a "WWW-Authenticate" or "Proxy-Authenticate" header to @msg,
 requesting that the client authenticate, and sets @msg's status
@@ -1400,39 +1360,6 @@ anyone else.</doc>
           <parameter name="msg" transfer-ownership="none">
             <doc xml:space="preserve">a #SoupMessage</doc>
             <type name="Message" c:type="SoupMessage*"/>
-          </parameter>
-        </parameters>
-      </method>
-      <method name="digest_set_auth_callback" c:identifier="soup_auth_domain_digest_set_auth_callback">
-        <doc xml:space="preserve">Sets the callback that @domain will use to authenticate incoming
-requests. For each request containing authorization, @domain will
-invoke the callback, and then either accept or reject the request
-based on @callback's return value.
-
-You can also set the auth callback by setting the
-%SOUP_AUTH_DOMAIN_DIGEST_AUTH_CALLBACK and
-%SOUP_AUTH_DOMAIN_DIGEST_AUTH_DATA properties, which can also be
-used to set the callback at construct time.</doc>
-        <return-value transfer-ownership="none">
-          <type name="none" c:type="void"/>
-        </return-value>
-        <parameters>
-          <instance-parameter name="domain" transfer-ownership="none">
-            <doc xml:space="preserve">the domain</doc>
-            <type name="AuthDomain" c:type="SoupAuthDomain*"/>
-          </instance-parameter>
-          <parameter name="callback" transfer-ownership="none" scope="notified" closure="1" destroy="2">
-            <doc xml:space="preserve">the callback</doc>
-            <type name="AuthDomainDigestAuthCallback" c:type="SoupAuthDomainDigestAuthCallback"/>
-          </parameter>
-          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
-            <doc xml:space="preserve">data to pass to @auth_callback</doc>
-            <type name="gpointer" c:type="gpointer"/>
-          </parameter>
-          <parameter name="dnotify" transfer-ownership="none" scope="async">
-            <doc xml:space="preserve">destroy notifier to free @user_data when @domain
-is destroyed</doc>
-            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
           </parameter>
         </parameters>
       </method>
@@ -1576,13 +1503,15 @@ is destroyed</doc>
         <type name="utf8" c:type="gchar*"/>
       </property>
       <property name="filter" writable="1" transfer-ownership="none">
-        <type name="gpointer" c:type="gpointer"/>
+        <doc xml:space="preserve">The #SoupAuthDomainFilter for the domain</doc>
+        <type name="AuthDomainFilter" c:type="gpointer"/>
       </property>
       <property name="filter-data" writable="1" transfer-ownership="none">
         <type name="gpointer" c:type="gpointer"/>
       </property>
       <property name="generic-auth-callback" writable="1" transfer-ownership="none">
-        <type name="gpointer" c:type="gpointer"/>
+        <doc xml:space="preserve">The #SoupAuthDomainGenericAuthCallback for the domain</doc>
+        <type name="AuthDomainGenericAuthCallback" c:type="gpointer"/>
       </property>
       <property name="generic-auth-data" writable="1" transfer-ownership="none">
         <type name="gpointer" c:type="gpointer"/>
@@ -1621,10 +1550,45 @@ parameters are optional.</doc>
           </parameter>
         </parameters>
       </constructor>
+      <method name="set_auth_callback" c:identifier="soup_auth_domain_basic_set_auth_callback">
+        <doc xml:space="preserve">Sets the callback that @domain will use to authenticate incoming
+requests. For each request containing authorization, @domain will
+invoke the callback, and then either accept or reject the request
+based on @callback's return value.
+
+You can also set the auth callback by setting the
+%SOUP_AUTH_DOMAIN_BASIC_AUTH_CALLBACK and
+%SOUP_AUTH_DOMAIN_BASIC_AUTH_DATA properties, which can also be
+used to set the callback at construct time.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="domain" transfer-ownership="none">
+            <doc xml:space="preserve">the domain</doc>
+            <type name="AuthDomainBasic" c:type="SoupAuthDomain*"/>
+          </instance-parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="1" destroy="2">
+            <doc xml:space="preserve">the callback</doc>
+            <type name="AuthDomainBasicAuthCallback" c:type="SoupAuthDomainBasicAuthCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">data to pass to @auth_callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="dnotify" transfer-ownership="none" scope="async">
+            <doc xml:space="preserve">destroy notifier to free @user_data when @domain
+is destroyed</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+        </parameters>
+      </method>
       <property name="auth-callback" writable="1" transfer-ownership="none">
-        <type name="gpointer" c:type="gpointer"/>
+        <doc xml:space="preserve">The #SoupAuthDomainBasicAuthCallback</doc>
+        <type name="AuthDomainBasicAuthCallback" c:type="gpointer"/>
       </property>
       <property name="auth-data" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">The data to pass to the #SoupAuthDomainBasicAuthCallback</doc>
         <type name="gpointer" c:type="gpointer"/>
       </property>
       <field name="parent">
@@ -1653,7 +1617,7 @@ as well.</doc>
       <parameters>
         <parameter name="domain" transfer-ownership="none">
           <doc xml:space="preserve">the domain</doc>
-          <type name="AuthDomain" c:type="SoupAuthDomain*"/>
+          <type name="AuthDomainBasic" c:type="SoupAuthDomain*"/>
         </parameter>
         <parameter name="msg" transfer-ownership="none">
           <doc xml:space="preserve">the message being authenticated</doc>
@@ -1735,9 +1699,11 @@ as well.</doc>
           </return-value>
           <parameters>
             <parameter name="domain" transfer-ownership="none">
+              <doc xml:space="preserve">a #SoupAuthDomain</doc>
               <type name="AuthDomain" c:type="SoupAuthDomain*"/>
             </parameter>
             <parameter name="msg" transfer-ownership="none">
+              <doc xml:space="preserve">a #SoupMessage</doc>
               <type name="Message" c:type="SoupMessage*"/>
             </parameter>
           </parameters>
@@ -1845,10 +1811,45 @@ the encoded password stored in an Apache .htdigest file.)</doc>
           </parameter>
         </parameters>
       </function>
+      <method name="set_auth_callback" c:identifier="soup_auth_domain_digest_set_auth_callback">
+        <doc xml:space="preserve">Sets the callback that @domain will use to authenticate incoming
+requests. For each request containing authorization, @domain will
+invoke the callback, and then either accept or reject the request
+based on @callback's return value.
+
+You can also set the auth callback by setting the
+%SOUP_AUTH_DOMAIN_DIGEST_AUTH_CALLBACK and
+%SOUP_AUTH_DOMAIN_DIGEST_AUTH_DATA properties, which can also be
+used to set the callback at construct time.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="domain" transfer-ownership="none">
+            <doc xml:space="preserve">the domain</doc>
+            <type name="AuthDomainDigest" c:type="SoupAuthDomain*"/>
+          </instance-parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="1" destroy="2">
+            <doc xml:space="preserve">the callback</doc>
+            <type name="AuthDomainDigestAuthCallback" c:type="SoupAuthDomainDigestAuthCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">data to pass to @auth_callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="dnotify" transfer-ownership="none" scope="async">
+            <doc xml:space="preserve">destroy notifier to free @user_data when @domain
+is destroyed</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+        </parameters>
+      </method>
       <property name="auth-callback" writable="1" transfer-ownership="none">
-        <type name="gpointer" c:type="gpointer"/>
+        <doc xml:space="preserve">The #SoupAuthDomainDigestAuthCallback</doc>
+        <type name="AuthDomainDigestAuthCallback" c:type="gpointer"/>
       </property>
       <property name="auth-data" writable="1" transfer-ownership="none">
+        <doc xml:space="preserve">The data to pass to the #SoupAuthDomainDigestAuthCallback</doc>
         <type name="gpointer" c:type="gpointer"/>
       </property>
       <field name="parent">
@@ -1869,7 +1870,7 @@ it is done with it.</doc>
       <parameters>
         <parameter name="domain" transfer-ownership="none">
           <doc xml:space="preserve">the domain</doc>
-          <type name="AuthDomain" c:type="SoupAuthDomain*"/>
+          <type name="AuthDomainDigest" c:type="SoupAuthDomain*"/>
         </parameter>
         <parameter name="msg" transfer-ownership="none">
           <doc xml:space="preserve">the message being authenticated</doc>
@@ -2282,7 +2283,7 @@ of #SoupBuffer.</doc>
           <parameter name="data" direction="out" caller-allocates="0" transfer-ownership="none">
             <doc xml:space="preserve">the pointer
 to the buffer data is stored here</doc>
-            <array length="1" zero-terminated="0" c:type="guint8**">
+            <array length="1" zero-terminated="0" c:type="const guint8**">
               <type name="guint8" c:type="guint8*"/>
             </array>
           </parameter>
@@ -2333,9 +2334,6 @@ any data, but will instead simply reference the same data as
     </record>
     <glib:boxed glib:name="ByteArray" c:symbol-prefix="byte_array" glib:type-name="SoupByteArray" glib:get-type="soup_byte_array_get_type">
     </glib:boxed>
-    <constant name="CACHE_H" value="1" c:type="SOUP_CACHE_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <constant name="CHAR_HTTP_CTL" value="16" c:type="SOUP_CHAR_HTTP_CTL">
       <type name="gint" c:type="gint"/>
     </constant>
@@ -2351,15 +2349,6 @@ any data, but will instead simply reference the same data as
     <constant name="CHAR_URI_SUB_DELIMS" value="4" c:type="SOUP_CHAR_URI_SUB_DELIMS">
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="CONTENT_DECODER_H" value="1" c:type="SOUP_CONTENT_DECODER_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="CONTENT_SNIFFER_H" value="1" c:type="SOUP_CONTENT_SNIFFER_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="COOKIE_H" value="1" c:type="SOUP_COOKIE_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <constant name="COOKIE_JAR_ACCEPT_POLICY" value="accept-policy" c:type="SOUP_COOKIE_JAR_ACCEPT_POLICY" version="2.30">
       <doc xml:space="preserve">Alias for the #SoupCookieJar:accept-policy property.</doc>
       <type name="utf8" c:type="gchar*"/>
@@ -2368,12 +2357,6 @@ any data, but will instead simply reference the same data as
       <doc xml:space="preserve">Alias for the #SoupCookieJarDB:filename property. (The
 cookie-storage filename.)</doc>
       <type name="utf8" c:type="gchar*"/>
-    </constant>
-    <constant name="COOKIE_JAR_DB_H" value="1" c:type="SOUP_COOKIE_JAR_DB_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="COOKIE_JAR_H" value="1" c:type="SOUP_COOKIE_JAR_H">
-      <type name="gint" c:type="gint"/>
     </constant>
     <constant name="COOKIE_JAR_READ_ONLY" value="read-only" c:type="SOUP_COOKIE_JAR_READ_ONLY">
       <doc xml:space="preserve">Alias for the #SoupCookieJar:read-only property. (Whether
@@ -2384,9 +2367,6 @@ or not the cookie jar is read-only.)</doc>
       <doc xml:space="preserve">Alias for the #SoupCookieJarText:filename property. (The
 cookie-storage filename.)</doc>
       <type name="utf8" c:type="gchar*"/>
-    </constant>
-    <constant name="COOKIE_JAR_TEXT_H" value="1" c:type="SOUP_COOKIE_JAR_TEXT_H">
-      <type name="gint" c:type="gint"/>
     </constant>
     <constant name="COOKIE_MAX_AGE_ONE_DAY" value="0" c:type="SOUP_COOKIE_MAX_AGE_ONE_DAY" version="2.24">
       <doc xml:space="preserve">A constant corresponding to 1 day, for use with soup_cookie_new()
@@ -3290,10 +3270,11 @@ match. This may change in the future.</doc>
         </parameters>
       </method>
       <method name="get_expires" c:identifier="soup_cookie_get_expires" version="2.32">
-        <doc xml:space="preserve">Gets @cookie's expiration time</doc>
-        <return-value transfer-ownership="none">
-          <doc xml:space="preserve">@cookie's expiration time, which is
-owned by @cookie and should not be modified or freed.</doc>
+        <doc xml:space="preserve">Gets @cookie's expiration time.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">@cookie's expiration
+time, which is owned by @cookie and should not be modified or
+freed.</doc>
           <type name="Date" c:type="SoupDate*"/>
         </return-value>
         <parameters>
@@ -4133,9 +4114,6 @@ jar is destroyed.)</doc>
         </callback>
       </field>
     </record>
-    <constant name="DATE_H" value="1" c:type="SOUP_DATE_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <record name="Date" c:type="SoupDate" glib:type-name="SoupDate" glib:get-type="soup_date_get_type" c:symbol-prefix="date">
       <doc xml:space="preserve">A date and time. The date is assumed to be in the (proleptic)
 Gregorian calendar. The time is in UTC if @utc is %TRUE. Otherwise,
@@ -4522,9 +4500,6 @@ use: NOT CURRENTLY IMPLEMENTED)</doc>
         <doc xml:space="preserve">"100-continue"</doc>
       </member>
     </bitfield>
-    <constant name="FORM_H" value="1" c:type="SOUP_FORM_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <constant name="FORM_MIME_TYPE_MULTIPART" value="multipart/form-data" c:type="SOUP_FORM_MIME_TYPE_MULTIPART" version="2.26">
       <doc xml:space="preserve">A macro containing the value
 &lt;literal&gt;"multipart/form-data"&lt;/literal&gt;; the MIME type used for
@@ -4536,9 +4511,6 @@ posting form data that contains files to be uploaded.</doc>
 &lt;literal&gt;"application/x-www-form-urlencoded"&lt;/literal&gt;; the default
 MIME type for POSTing HTML form data.</doc>
       <type name="utf8" c:type="gchar*"/>
-    </constant>
-    <constant name="HEADERS_H" value="1" c:type="SOUP_HEADERS_H">
-      <type name="gint" c:type="gint"/>
     </constant>
     <enumeration name="HTTPVersion" glib:type-name="SoupHTTPVersion" glib:get-type="soup_http_version_get_type" c:type="SoupHTTPVersion">
       <doc xml:space="preserve">Indicates the HTTP protocol version being used.</doc>
@@ -4677,9 +4649,6 @@ MIME type for POSTing HTML form data.</doc>
       <member name="not_extended" value="510" c:identifier="SOUP_KNOWN_STATUS_CODE_NOT_EXTENDED" glib:nick="not-extended">
       </member>
     </enumeration>
-    <constant name="LOGGER_H" value="1" c:type="SOUP_LOGGER_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <constant name="LOGGER_LEVEL" value="level" c:type="SOUP_LOGGER_LEVEL" version="2.56">
       <doc xml:space="preserve">Alias for the #SoupLogger:level property, qv.</doc>
       <type name="utf8" c:type="gchar*"/>
@@ -4970,9 +4939,6 @@ application compile time, rather than from the library linked
 against at application run time.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="MESSAGE_BODY_H" value="1" c:type="SOUP_MESSAGE_BODY_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <constant name="MESSAGE_FIRST_PARTY" value="first-party" c:type="SOUP_MESSAGE_FIRST_PARTY" version="2.30">
       <doc xml:space="preserve">Alias for the #SoupMessage:first-party property. (The
 #SoupURI loaded in the application when the message was
@@ -4983,12 +4949,6 @@ queued.)</doc>
       <doc xml:space="preserve">Alias for the #SoupMessage:flags property. (The message's
 #SoupMessageFlags.)</doc>
       <type name="utf8" c:type="gchar*"/>
-    </constant>
-    <constant name="MESSAGE_H" value="1" c:type="SOUP_MESSAGE_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="MESSAGE_HEADERS_H" value="1" c:type="SOUP_MESSAGE_HEADERS_H">
-      <type name="gint" c:type="gint"/>
     </constant>
     <constant name="MESSAGE_HTTP_VERSION" value="http-version" c:type="SOUP_MESSAGE_HTTP_VERSION">
       <doc xml:space="preserve">Alias for the #SoupMessage:http-version property. (The
@@ -5065,28 +5025,16 @@ verification errors on #SoupMessage:tls-certificate.)</doc>
 #SoupURI.)</doc>
       <type name="utf8" c:type="gchar*"/>
     </constant>
-    <constant name="METHOD_H" value="1" c:type="SOUP_METHOD_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="MICRO_VERSION" value="1" c:type="SOUP_MICRO_VERSION" version="2.42">
+    <constant name="MICRO_VERSION" value="2" c:type="SOUP_MICRO_VERSION" version="2.42">
       <doc xml:space="preserve">Like soup_get_micro_version(), but from the headers used at
 application compile time, rather than from the library linked
 against at application run time.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="MINOR_VERSION" value="62" c:type="SOUP_MINOR_VERSION" version="2.42">
+    <constant name="MINOR_VERSION" value="64" c:type="SOUP_MINOR_VERSION" version="2.42">
       <doc xml:space="preserve">Like soup_get_minor_version(), but from the headers used at
 application compile time, rather than from the library linked
 against at application run time.</doc>
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="MISC_H" value="1" c:type="SOUP_MISC_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="MULTIPART_H" value="1" c:type="SOUP_MULTIPART_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="MULTIPART_INPUT_STREAM_H" value="1" c:type="SOUP_MULTIPART_INPUT_STREAM_H">
       <type name="gint" c:type="gint"/>
     </constant>
     <enumeration name="MemoryUse" glib:type-name="SoupMemoryUse" glib:get-type="soup_memory_use_get_type" c:type="SoupMemoryUse">
@@ -5806,7 +5754,7 @@ interpreted relative to @msg's current URI. In particular, if
           <parameter name="req_body" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">
   a data buffer containing the body of the message request.</doc>
-            <array length="3" zero-terminated="0" c:type="char*">
+            <array length="3" zero-terminated="0" c:type="const char*">
               <type name="guint8"/>
             </array>
           </parameter>
@@ -5838,7 +5786,7 @@ interpreted relative to @msg's current URI. In particular, if
           <parameter name="resp_body" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">
   a data buffer containing the body of the message response.</doc>
-            <array length="3" zero-terminated="0" c:type="char*">
+            <array length="3" zero-terminated="0" c:type="const char*">
               <type name="guint8"/>
             </array>
           </parameter>
@@ -7950,15 +7898,6 @@ more parts.</doc>
     </record>
     <record name="MultipartInputStreamPrivate" c:type="SoupMultipartInputStreamPrivate" disguised="1">
     </record>
-    <constant name="PASSWORD_MANAGER_H" value="1" c:type="SOUP_PASSWORD_MANAGER_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="PROXY_RESOLVER_DEFAULT_H" value="1" c:type="SOUP_PROXY_RESOLVER_DEFAULT_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="PROXY_URI_RESOLVER_H" value="1" c:type="SOUP_PROXY_URI_RESOLVER_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <interface name="PasswordManager" c:symbol-prefix="password_manager" c:type="SoupPasswordManager" glib:type-name="SoupPasswordManager" glib:get-type="soup_password_manager_get_type" glib:type-struct="PasswordManagerInterface">
       <prerequisite name="SessionFeature"/>
       <virtual-method name="get_passwords_async" invoker="get_passwords_async">
@@ -8143,6 +8082,124 @@ more parts.</doc>
         </callback>
       </field>
     </record>
+    <interface name="ProxyResolver" c:symbol-prefix="proxy_resolver" c:type="SoupProxyResolver" glib:type-name="SoupProxyResolver" glib:get-type="soup_proxy_resolver_get_type" glib:type-struct="ProxyResolverInterface">
+      <prerequisite name="SessionFeature"/>
+      <virtual-method name="get_proxy_async" invoker="get_proxy_async" deprecated="1" deprecated-version="2.28">
+        <doc-deprecated xml:space="preserve">Use SoupProxyURIResolver.get_proxy_uri_async instead</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proxy_resolver" transfer-ownership="none">
+            <type name="ProxyResolver" c:type="SoupProxyResolver*"/>
+          </instance-parameter>
+          <parameter name="msg" transfer-ownership="none">
+            <type name="Message" c:type="SoupMessage*"/>
+          </parameter>
+          <parameter name="async_context" transfer-ownership="none">
+            <type name="GLib.MainContext" c:type="GMainContext*"/>
+          </parameter>
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
+            <type name="Gio.Cancellable" c:type="GCancellable*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="async" closure="4">
+            <type name="ProxyResolverCallback" c:type="SoupProxyResolverCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="4">
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_proxy_sync" invoker="get_proxy_sync" deprecated="1" deprecated-version="2.28">
+        <doc-deprecated xml:space="preserve">Use SoupProxyURIResolver.get_proxy_uri_sync() instead</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proxy_resolver" transfer-ownership="none">
+            <type name="ProxyResolver" c:type="SoupProxyResolver*"/>
+          </instance-parameter>
+          <parameter name="msg" transfer-ownership="none">
+            <type name="Message" c:type="SoupMessage*"/>
+          </parameter>
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
+            <type name="Gio.Cancellable" c:type="GCancellable*"/>
+          </parameter>
+          <parameter name="addr" direction="out" caller-allocates="0" transfer-ownership="none">
+            <type name="Address" c:type="SoupAddress**"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <method name="get_proxy_async" c:identifier="soup_proxy_resolver_get_proxy_async" deprecated="1" deprecated-version="2.28">
+        <doc-deprecated xml:space="preserve">Use SoupProxyURIResolver.get_proxy_uri_async instead</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proxy_resolver" transfer-ownership="none">
+            <type name="ProxyResolver" c:type="SoupProxyResolver*"/>
+          </instance-parameter>
+          <parameter name="msg" transfer-ownership="none">
+            <type name="Message" c:type="SoupMessage*"/>
+          </parameter>
+          <parameter name="async_context" transfer-ownership="none">
+            <type name="GLib.MainContext" c:type="GMainContext*"/>
+          </parameter>
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
+            <type name="Gio.Cancellable" c:type="GCancellable*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="async" closure="4">
+            <type name="ProxyResolverCallback" c:type="SoupProxyResolverCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_proxy_sync" c:identifier="soup_proxy_resolver_get_proxy_sync" deprecated="1" deprecated-version="2.28">
+        <doc-deprecated xml:space="preserve">Use SoupProxyURIResolver.get_proxy_uri_sync() instead</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="proxy_resolver" transfer-ownership="none">
+            <type name="ProxyResolver" c:type="SoupProxyResolver*"/>
+          </instance-parameter>
+          <parameter name="msg" transfer-ownership="none">
+            <type name="Message" c:type="SoupMessage*"/>
+          </parameter>
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
+            <type name="Gio.Cancellable" c:type="GCancellable*"/>
+          </parameter>
+          <parameter name="addr" direction="out" caller-allocates="0" transfer-ownership="none">
+            <type name="Address" c:type="SoupAddress**"/>
+          </parameter>
+        </parameters>
+      </method>
+    </interface>
+    <callback name="ProxyResolverCallback" c:type="SoupProxyResolverCallback" deprecated="1" deprecated-version="2.28">
+      <doc-deprecated xml:space="preserve">Use SoupProxyURIResolver instead</doc-deprecated>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="proxy_resolver" transfer-ownership="none">
+          <type name="ProxyResolver" c:type="SoupProxyResolver*"/>
+        </parameter>
+        <parameter name="msg" transfer-ownership="none">
+          <type name="Message" c:type="SoupMessage*"/>
+        </parameter>
+        <parameter name="arg" transfer-ownership="none">
+          <type name="guint" c:type="guint"/>
+        </parameter>
+        <parameter name="addr" transfer-ownership="none">
+          <type name="Address" c:type="SoupAddress*"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="4">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
     <class name="ProxyResolverDefault" c:symbol-prefix="proxy_resolver_default" c:type="SoupProxyResolverDefault" parent="GObject.Object" glib:type-name="SoupProxyResolverDefault" glib:get-type="soup_proxy_resolver_default_get_type" glib:type-struct="ProxyResolverDefaultClass">
       <implements name="ProxyURIResolver"/>
       <implements name="SessionFeature"/>
@@ -8156,6 +8213,59 @@ more parts.</doc>
     <record name="ProxyResolverDefaultClass" c:type="SoupProxyResolverDefaultClass" glib:is-gtype-struct-for="ProxyResolverDefault">
       <field name="parent_class">
         <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+    </record>
+    <record name="ProxyResolverInterface" c:type="SoupProxyResolverInterface" glib:is-gtype-struct-for="ProxyResolver">
+      <field name="base">
+        <type name="GObject.TypeInterface" c:type="GTypeInterface"/>
+      </field>
+      <field name="get_proxy_async">
+        <callback name="get_proxy_async">
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="proxy_resolver" transfer-ownership="none">
+              <type name="ProxyResolver" c:type="SoupProxyResolver*"/>
+            </parameter>
+            <parameter name="msg" transfer-ownership="none">
+              <type name="Message" c:type="SoupMessage*"/>
+            </parameter>
+            <parameter name="async_context" transfer-ownership="none">
+              <type name="GLib.MainContext" c:type="GMainContext*"/>
+            </parameter>
+            <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
+              <type name="Gio.Cancellable" c:type="GCancellable*"/>
+            </parameter>
+            <parameter name="callback" transfer-ownership="none" scope="async" closure="5">
+              <type name="ProxyResolverCallback" c:type="SoupProxyResolverCallback"/>
+            </parameter>
+            <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="5">
+              <type name="gpointer" c:type="gpointer"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_proxy_sync">
+        <callback name="get_proxy_sync">
+          <return-value transfer-ownership="none">
+            <type name="guint" c:type="guint"/>
+          </return-value>
+          <parameters>
+            <parameter name="proxy_resolver" transfer-ownership="none">
+              <type name="ProxyResolver" c:type="SoupProxyResolver*"/>
+            </parameter>
+            <parameter name="msg" transfer-ownership="none">
+              <type name="Message" c:type="SoupMessage*"/>
+            </parameter>
+            <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
+              <type name="Gio.Cancellable" c:type="GCancellable*"/>
+            </parameter>
+            <parameter name="addr" direction="out" caller-allocates="0" transfer-ownership="none">
+              <type name="Address" c:type="SoupAddress**"/>
+            </parameter>
+          </parameters>
+        </callback>
       </field>
     </record>
     <interface name="ProxyURIResolver" c:symbol-prefix="proxy_uri_resolver" c:type="SoupProxyURIResolver" glib:type-name="SoupProxyURIResolver" glib:get-type="soup_proxy_uri_resolver_get_type" glib:type-struct="ProxyURIResolverInterface">
@@ -8408,21 +8518,6 @@ error.</doc>
         </callback>
       </field>
     </record>
-    <constant name="REQUESTER_H" value="1" c:type="SOUP_REQUESTER_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="REQUEST_DATA_H" value="1" c:type="SOUP_REQUEST_DATA_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="REQUEST_FILE_H" value="1" c:type="SOUP_REQUEST_FILE_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="REQUEST_H" value="1" c:type="SOUP_REQUEST_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="REQUEST_HTTP_H" value="1" c:type="SOUP_REQUEST_HTTP_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <constant name="REQUEST_SESSION" value="session" c:type="SOUP_REQUEST_SESSION" version="2.42">
       <doc xml:space="preserve">Alias for the #SoupRequest:session property, qv.</doc>
       <type name="utf8" c:type="gchar*"/>
@@ -8998,9 +9093,6 @@ property, qv.</doc>
 rather than having an explicitly-specified one.</doc-deprecated>
       <type name="utf8" c:type="gchar*"/>
     </constant>
-    <constant name="SERVER_H" value="1" c:type="SOUP_SERVER_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <constant name="SERVER_HTTPS_ALIASES" value="https-aliases" c:type="SOUP_SERVER_HTTPS_ALIASES" version="2.44">
       <doc xml:space="preserve">Alias for the #SoupServer:https-aliases property, qv.</doc>
       <type name="utf8" c:type="gchar*"/>
@@ -9071,15 +9163,6 @@ soup_server_set_ssl_certificate().</doc-deprecated>
       <doc xml:space="preserve">Alias for the #SoupSession:async-context property, qv.</doc>
       <type name="utf8" c:type="gchar*"/>
     </constant>
-    <constant name="SESSION_ASYNC_H" value="1" c:type="SOUP_SESSION_ASYNC_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="SESSION_FEATURE_H" value="1" c:type="SOUP_SESSION_FEATURE_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="SESSION_H" value="1" c:type="SOUP_SESSION_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <constant name="SESSION_HTTPS_ALIASES" value="https-aliases" c:type="SOUP_SESSION_HTTPS_ALIASES" version="2.38">
       <doc xml:space="preserve">Alias for the #SoupSession:https-aliases property, qv.</doc>
       <type name="utf8" c:type="gchar*"/>
@@ -9130,9 +9213,6 @@ qv.</doc>
 qv.</doc>
       <type name="utf8" c:type="gchar*"/>
     </constant>
-    <constant name="SESSION_SYNC_H" value="1" c:type="SOUP_SESSION_SYNC_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <constant name="SESSION_TIMEOUT" value="timeout" c:type="SOUP_SESSION_TIMEOUT">
       <doc xml:space="preserve">Alias for the #SoupSession:timeout property, qv.</doc>
       <type name="utf8" c:type="gchar*"/>
@@ -9166,9 +9246,6 @@ socket's #GMainContext.)</doc>
       <doc xml:space="preserve">Alias for the #SoupSocket:non-blocking property. (Whether
 or not the socket uses non-blocking I/O.)</doc>
       <type name="utf8" c:type="gchar*"/>
-    </constant>
-    <constant name="SOCKET_H" value="1" c:type="SOUP_SOCKET_H">
-      <type name="gint" c:type="gint"/>
     </constant>
     <constant name="SOCKET_IS_SERVER" value="is-server" c:type="SOUP_SOCKET_IS_SERVER">
       <doc xml:space="preserve">Alias for the #SoupSocket:is-server property, qv.</doc>
@@ -9225,9 +9302,6 @@ property.</doc>
       <doc xml:space="preserve">Alias for the #SoupSocket:use-thread-context property. (Use
 g_main_context_get_thread_default())</doc>
       <type name="utf8" c:type="gchar*"/>
-    </constant>
-    <constant name="STATUS_H" value="1" c:type="SOUP_STATUS_H">
-      <type name="gint" c:type="gint"/>
     </constant>
     <class name="Server" c:symbol-prefix="server" c:type="SoupServer" parent="GObject.Object" glib:type-name="SoupServer" glib:get-type="soup_server_get_type" glib:type-struct="ServerClass">
       <constructor name="new" c:identifier="soup_server_new" introspectable="0">
@@ -13624,15 +13698,14 @@ through unchanged.</doc>
         <doc xml:space="preserve">The passed-in hostname has
   no recognized public suffix.</doc>
       </member>
+      <member name="no_psl_data" value="4" c:identifier="SOUP_TLD_ERROR_NO_PSL_DATA" glib:nick="no-psl-data">
+      </member>
       <function name="quark" c:identifier="soup_tld_error_quark">
         <return-value transfer-ownership="none">
           <type name="GLib.Quark" c:type="GQuark"/>
         </return-value>
       </function>
     </enumeration>
-    <constant name="TYPES_H" value="1" c:type="SOUP_TYPES_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <record name="URI" c:type="SoupURI" glib:type-name="SoupURI" glib:get-type="soup_uri_get_type" c:symbol-prefix="uri">
       <doc xml:space="preserve">A #SoupURI represents a (parsed) URI. #SoupURI supports RFC 3986
 (URI Generic Syntax), and can parse any valid URI. However, libsoup
@@ -13722,6 +13795,23 @@ those fields are required.)</doc>
         <parameters>
           <parameter name="uri_string" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a URI</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_with_base" c:identifier="soup_uri_new_with_base">
+        <doc xml:space="preserve">Parses @uri_string relative to @base.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a parsed #SoupURI.</doc>
+          <type name="URI" c:type="SoupURI*"/>
+        </return-value>
+        <parameters>
+          <parameter name="base" transfer-ownership="none">
+            <doc xml:space="preserve">a base URI</doc>
+            <type name="URI" c:type="SoupURI*"/>
+          </parameter>
+          <parameter name="uri_string" transfer-ownership="none">
+            <doc xml:space="preserve">the URI</doc>
             <type name="utf8" c:type="const char*"/>
           </parameter>
         </parameters>
@@ -13914,23 +14004,6 @@ and port.</doc>
             <doc xml:space="preserve">a #SoupURI with a non-%NULL @host member</doc>
             <type name="URI" c:type="gconstpointer"/>
           </instance-parameter>
-        </parameters>
-      </method>
-      <method name="new_with_base" c:identifier="soup_uri_new_with_base">
-        <doc xml:space="preserve">Parses @uri_string relative to @base.</doc>
-        <return-value transfer-ownership="full">
-          <doc xml:space="preserve">a parsed #SoupURI.</doc>
-          <type name="URI" c:type="SoupURI*"/>
-        </return-value>
-        <parameters>
-          <instance-parameter name="base" transfer-ownership="none">
-            <doc xml:space="preserve">a base URI</doc>
-            <type name="URI" c:type="SoupURI*"/>
-          </instance-parameter>
-          <parameter name="uri_string" transfer-ownership="none">
-            <doc xml:space="preserve">the URI</doc>
-            <type name="utf8" c:type="const char*"/>
-          </parameter>
         </parameters>
       </method>
       <method name="set_fragment" c:identifier="soup_uri_set_fragment">
@@ -14223,12 +14296,6 @@ soup_uri_new() already did).</doc>
         </parameters>
       </function>
     </record>
-    <constant name="URI_H" value="1" c:type="SOUP_URI_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="VALUE_UTILS_H" value="1" c:type="SOUP_VALUE_UTILS_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <constant name="VERSION_MIN_REQUIRED" value="2" c:type="SOUP_VERSION_MIN_REQUIRED" version="2.42">
       <doc xml:space="preserve">A macro that should be defined by the user prior to including
 libsoup.h. The definition should be one of the predefined libsoup
@@ -15006,12 +15073,6 @@ Deserialization details:
         </parameters>
       </method>
     </record>
-    <constant name="XMLRPC_H" value="1" c:type="SOUP_XMLRPC_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
-    <constant name="XMLRPC_OLD_H" value="1" c:type="SOUP_XMLRPC_OLD_H">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <function name="add_completion" c:identifier="soup_add_completion" version="2.24" introspectable="0">
       <doc xml:space="preserve">Adds @function to be executed from inside @async_context with the
 default priority. Use this when you want to complete an action in

--- a/Vte-2.91.gir
+++ b/Vte-2.91.gir
@@ -91,12 +91,12 @@ should be copied to the clipboard in.</doc>
 (e.g. in version 3.1.4 this is 3).</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="MICRO_VERSION" value="1" c:type="VTE_MICRO_VERSION">
+    <constant name="MICRO_VERSION" value="2" c:type="VTE_MICRO_VERSION">
       <doc xml:space="preserve">The micro version number of the VTE library
 (e.g. in version 3.1.4 this is 4).</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="MINOR_VERSION" value="52" c:type="VTE_MINOR_VERSION">
+    <constant name="MINOR_VERSION" value="54" c:type="VTE_MINOR_VERSION">
       <doc xml:space="preserve">The minor version number of the VTE library
 (e.g. in version 3.1.4 this is 1).</doc>
       <type name="gint" c:type="gint"/>
@@ -516,6 +516,12 @@ a cell has to be selected or not.</doc>
         </parameter>
       </parameters>
     </callback>
+    <constant name="TEST_FLAGS_ALL" value="18446744073709551615" c:type="VTE_TEST_FLAGS_ALL">
+      <type name="guint64" c:type="guint64"/>
+    </constant>
+    <constant name="TEST_FLAGS_NONE" value="0" c:type="VTE_TEST_FLAGS_NONE">
+      <type name="guint64" c:type="guint64"/>
+    </constant>
     <class name="Terminal" c:symbol-prefix="terminal" c:type="VteTerminal" parent="Gtk.Widget" glib:type-name="VteTerminal" glib:get-type="vte_terminal_get_type" glib:type-struct="TerminalClass">
       <implements name="Atk.ImplementorIface"/>
       <implements name="Gtk.Buildable"/>
@@ -725,8 +731,7 @@ selection.</doc>
       </virtual-method>
       <virtual-method name="paste_clipboard" invoker="paste_clipboard">
         <doc xml:space="preserve">Sends the contents of the #GDK_SELECTION_CLIPBOARD selection to the
-terminal's child.  If necessary, the data is converted from UTF-8 to the
-terminal's current encoding. It's called on paste menu item, or when
+terminal's child. It's called on paste menu item, or when
 user presses Shift+Insert.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -992,9 +997,9 @@ to mess with your users.</doc>
             <doc xml:space="preserve">a #VteTerminal</doc>
             <type name="Terminal" c:type="VteTerminal*"/>
           </instance-parameter>
-          <parameter name="data" transfer-ownership="none">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a string in the terminal's current encoding</doc>
-            <array length="1" zero-terminated="0" c:type="char*">
+            <array length="1" zero-terminated="0" c:type="const char*">
               <type name="guint8"/>
             </array>
           </parameter>
@@ -1015,9 +1020,11 @@ at the keyboard.</doc>
             <doc xml:space="preserve">a #VteTerminal</doc>
             <type name="Terminal" c:type="VteTerminal*"/>
           </instance-parameter>
-          <parameter name="text" transfer-ownership="none">
+          <parameter name="text" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">data to send to the child</doc>
-            <type name="utf8" c:type="const char*"/>
+            <array length="1" zero-terminated="0" c:type="const char*">
+              <type name="gchar"/>
+            </array>
           </parameter>
           <parameter name="length" transfer-ownership="none">
             <doc xml:space="preserve">length of @text in bytes, or -1 if @text is NUL-terminated</doc>
@@ -1035,9 +1042,11 @@ at the keyboard.</doc>
             <doc xml:space="preserve">a #VteTerminal</doc>
             <type name="Terminal" c:type="VteTerminal*"/>
           </instance-parameter>
-          <parameter name="data" transfer-ownership="none">
+          <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">data to send to the child</doc>
-            <type name="guint8" c:type="const guint8*"/>
+            <array length="1" zero-terminated="0" c:type="const guint8*">
+              <type name="guint8"/>
+            </array>
           </parameter>
           <parameter name="length" transfer-ownership="none">
             <doc xml:space="preserve">length of @data</doc>
@@ -1157,8 +1166,10 @@ because the return value takes cell-width-scale into account.</doc>
         </parameters>
       </method>
       <method name="get_cjk_ambiguous_width" c:identifier="vte_terminal_get_cjk_ambiguous_width">
-        <doc xml:space="preserve">Returns whether ambiguous-width characters are narrow or wide when using
-the UTF-8 encoding (vte_terminal_set_encoding()).</doc>
+        <doc xml:space="preserve">Returns whether ambiguous-width characters are narrow or wide.
+(Note that when using a non-UTF-8 encoding set via vte_terminal_set_encoding(),
+the width of ambiguous-width characters is fixed and determined by the encoding
+itself.)</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">1 if ambiguous-width characters are narrow, or 2 if they are wide</doc>
           <type name="gint" c:type="int"/>
@@ -1168,6 +1179,31 @@ the UTF-8 encoding (vte_terminal_set_encoding()).</doc>
             <doc xml:space="preserve">a #VteTerminal</doc>
             <type name="Terminal" c:type="VteTerminal*"/>
           </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_color_background_for_draw" c:identifier="vte_terminal_get_color_background_for_draw" version="0.54">
+        <doc xml:space="preserve">Returns the background colour, as used by @terminal when
+drawing the background, which may be different from
+the color set by vte_terminal_set_color_background().
+
+Note: you must only call this function while handling the
+GtkWidget::draw signal.
+
+This function is rarely useful. One use for it is if you disable
+drawing the background (see vte_terminal_set_clear_background())
+and then need to draw the background yourself.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="terminal" transfer-ownership="none">
+            <doc xml:space="preserve">a #VteTerminal</doc>
+            <type name="Terminal" c:type="VteTerminal*"/>
+          </instance-parameter>
+          <parameter name="color" direction="out" caller-allocates="1" transfer-ownership="none">
+            <doc xml:space="preserve">a location to store a #GdbRGBA color</doc>
+            <type name="Gdk.RGBA" c:type="GdkRGBA*"/>
+          </parameter>
         </parameters>
       </method>
       <method name="get_column_count" c:identifier="vte_terminal_get_column_count">
@@ -1183,7 +1219,7 @@ the UTF-8 encoding (vte_terminal_set_encoding()).</doc>
         </parameters>
       </method>
       <method name="get_current_directory_uri" c:identifier="vte_terminal_get_current_directory_uri">
-        <return-value transfer-ownership="none">
+        <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">the URI of the current directory of the
   process running in the terminal, or %NULL</doc>
           <type name="utf8" c:type="const char*"/>
@@ -1196,7 +1232,7 @@ the UTF-8 encoding (vte_terminal_set_encoding()).</doc>
         </parameters>
       </method>
       <method name="get_current_file_uri" c:identifier="vte_terminal_get_current_file_uri">
-        <return-value transfer-ownership="none">
+        <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">the URI of the current file the
   process running in the terminal is operating on, or %NULL if
   not set</doc>
@@ -1256,10 +1292,11 @@ coordinate is absolute.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_encoding" c:identifier="vte_terminal_get_encoding">
+      <method name="get_encoding" c:identifier="vte_terminal_get_encoding" deprecated="1" deprecated-version="0.54">
         <doc xml:space="preserve">Determines the name of the encoding in which the terminal expects data to be
-encoded.</doc>
-        <return-value transfer-ownership="none">
+encoded, or %NULL if UTF-8 is in use.</doc>
+        <doc-deprecated xml:space="preserve">Support for non-UTF-8 is deprecated.</doc-deprecated>
+        <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">the current encoding for the terminal</doc>
           <type name="utf8" c:type="const char*"/>
         </return-value>
@@ -1344,9 +1381,9 @@ is different from determining if the terminal is the owner of any
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_icon_title" c:identifier="vte_terminal_get_icon_title">
-        <return-value transfer-ownership="none">
-          <doc xml:space="preserve">the icon title</doc>
+      <method name="get_icon_title" c:identifier="vte_terminal_get_icon_title" deprecated="1" deprecated-version="0.54">
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">%NULL</doc>
           <type name="utf8" c:type="const char*"/>
         </return-value>
         <parameters>
@@ -1589,8 +1626,8 @@ contents of the buffer using this function.</doc>
         </parameters>
       </method>
       <method name="get_window_title" c:identifier="vte_terminal_get_window_title">
-        <return-value transfer-ownership="none">
-          <doc xml:space="preserve">the window title</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve">the window title, or %NULL</doc>
           <type name="utf8" c:type="const char*"/>
         </return-value>
         <parameters>
@@ -1606,7 +1643,7 @@ when doing word-wise selection, in addition to the default which only
 considers alphanumeric characters part of a word.
 
 If %NULL, a built-in set is used.</doc>
-        <return-value transfer-ownership="none">
+        <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">a string, or %NULL</doc>
           <type name="utf8" c:type="const char*"/>
         </return-value>
@@ -1784,7 +1821,7 @@ when the user moves the mouse cursor.</doc>
       <method name="match_set_cursor" c:identifier="vte_terminal_match_set_cursor" deprecated="1" deprecated-version="0.40">
         <doc xml:space="preserve">Sets which cursor the terminal will use if the pointer is over the pattern
 specified by @tag.  The terminal keeps a reference to @cursor.</doc>
-        <doc-deprecated xml:space="preserve">Use vte_terminal_match_set_cursor_type() or vte_terminal_match_set_cursor_named() instead.</doc-deprecated>
+        <doc-deprecated xml:space="preserve">Use vte_terminal_match_set_cursor_name() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1825,9 +1862,10 @@ specified by @tag.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="match_set_cursor_type" c:identifier="vte_terminal_match_set_cursor_type">
+      <method name="match_set_cursor_type" c:identifier="vte_terminal_match_set_cursor_type" deprecated="1" deprecated-version="0.54">
         <doc xml:space="preserve">Sets which cursor the terminal will use if the pointer is over the pattern
 specified by @tag.</doc>
+        <doc-deprecated xml:space="preserve">Use vte_terminal_match_set_cursor_name() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1848,8 +1886,7 @@ specified by @tag.</doc>
       </method>
       <method name="paste_clipboard" c:identifier="vte_terminal_paste_clipboard">
         <doc xml:space="preserve">Sends the contents of the #GDK_SELECTION_CLIPBOARD selection to the
-terminal's child.  If necessary, the data is converted from UTF-8 to the
-terminal's current encoding. It's called on paste menu item, or when
+terminal's child. It's called on paste menu item, or when
 user presses Shift+Insert.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -1863,8 +1900,7 @@ user presses Shift+Insert.</doc>
       </method>
       <method name="paste_primary" c:identifier="vte_terminal_paste_primary">
         <doc xml:space="preserve">Sends the contents of the #GDK_SELECTION_PRIMARY selection to the terminal's
-child.  If necessary, the data is converted from UTF-8 to the terminal's
-current encoding.  The terminal will call also paste the
+child. The terminal will call also paste the
 #GDK_SELECTION_PRIMARY selection when the user clicks with the the second
 mouse button.</doc>
         <return-value transfer-ownership="none">
@@ -2185,9 +2221,10 @@ Valid values go from 1.0 (default) to 2.0.</doc>
         </parameters>
       </method>
       <method name="set_cjk_ambiguous_width" c:identifier="vte_terminal_set_cjk_ambiguous_width">
-        <doc xml:space="preserve">This setting controls whether ambiguous-width characters are narrow or wide
-when using the UTF-8 encoding (vte_terminal_set_encoding()). In all other encodings,
-the width of ambiguous-width characters is fixed.</doc>
+        <doc xml:space="preserve">This setting controls whether ambiguous-width characters are narrow or wide.
+(Note that when using a non-UTF-8 encoding set via vte_terminal_set_encoding(),
+the width of ambiguous-width characters is fixed and determined by the encoding
+itself.)</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2374,7 +2411,7 @@ greater than 0, the new background color is taken from @palette[0].</doc>
           </parameter>
           <parameter name="palette" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">the color palette</doc>
-            <array length="3" zero-terminated="0" c:type="GdkRGBA*">
+            <array length="3" zero-terminated="0" c:type="const GdkRGBA*">
               <type name="Gdk.RGBA"/>
             </array>
           </parameter>
@@ -2447,10 +2484,15 @@ presses the delete key.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_encoding" c:identifier="vte_terminal_set_encoding" throws="1">
+      <method name="set_encoding" c:identifier="vte_terminal_set_encoding" deprecated="1" deprecated-version="0.54" throws="1">
         <doc xml:space="preserve">Changes the encoding the terminal will expect data from the child to
 be encoded with.  For certain terminal types, applications executing in the
-terminal can change the encoding. If @codeset is %NULL, it uses "UTF-8".</doc>
+terminal can change the encoding. If @codeset is %NULL, it uses "UTF-8".
+
+Note: Support for non-UTF-8 is deprecated and may get removed altogether.
+Instead of this function, you should use a wrapper like luit(1) when
+spawning the child process.</doc>
+        <doc-deprecated xml:space="preserve">Support for non-UTF-8 is deprecated.</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE if the encoding could be changed to the specified one,
  or %FALSE with @error set to %G_CONVERT_ERROR_NO_CONVERSION.</doc>
@@ -2982,9 +3024,10 @@ or if SGR 1 only enables bold and leaves the color intact.</doc>
         <type name="gdouble" c:type="gdouble"/>
       </property>
       <property name="cjk-ambiguous-width" writable="1" transfer-ownership="none">
-        <doc xml:space="preserve">This setting controls whether ambiguous-width characters are narrow or wide
-when using the UTF-8 encoding (vte_terminal_set_encoding()). In all other encodings,
-the width of ambiguous-width characters is fixed.
+        <doc xml:space="preserve">This setting controls whether ambiguous-width characters are narrow or wide.
+(Note that when using a non-UTF-8 encoding set via vte_terminal_set_encoding(),
+the width of ambiguous-width characters is fixed and determined by the encoding
+itself.)
 
 This setting only takes effect the next time the terminal is reset, either
 via escape sequence or with vte_terminal_reset().</doc>
@@ -3012,11 +3055,13 @@ will use the #GtkSettings::gtk-cursor-blink setting.</doc>
 when the user presses the delete key.</doc>
         <type name="EraseBinding"/>
       </property>
-      <property name="encoding" writable="1" transfer-ownership="none">
+      <property name="encoding" deprecated="1" deprecated-version="0.54" writable="1" transfer-ownership="none">
         <doc xml:space="preserve">Controls the encoding the terminal will expect data from the child to
 be encoded with.  For certain terminal types, applications executing in the
 terminal can change the encoding.  The default is defined by the
 application's locale settings.</doc>
+        <doc-deprecated xml:space="preserve">Instead of using this, you should use a tool like
+  luit(1) when support for non-UTF-8 is required</doc-deprecated>
         <type name="utf8" c:type="gchar*"/>
       </property>
       <property name="font-desc" writable="1" transfer-ownership="none">
@@ -3035,8 +3080,8 @@ and columns.</doc>
         <doc xml:space="preserve">The currently hovered hyperlink URI, or %NULL if unset.</doc>
         <type name="utf8" c:type="gchar*"/>
       </property>
-      <property name="icon-title" transfer-ownership="none">
-        <doc xml:space="preserve">The terminal's so-called icon title, or %NULL if no icon title has been set.</doc>
+      <property name="icon-title" deprecated="1" deprecated-version="0.54" transfer-ownership="none">
+        <doc-deprecated xml:space="preserve">This property is always %NULL.</doc-deprecated>
         <type name="utf8" c:type="gchar*"/>
       </property>
       <property name="input-enabled" writable="1" transfer-ownership="none">
@@ -3206,9 +3251,9 @@ primarily by #VteTerminalAccessible.</doc>
         </return-value>
       </glib:signal>
       <glib:signal name="encoding-changed" when="last">
-        <doc xml:space="preserve">Emitted whenever the terminal's current encoding has changed, either
-as a result of receiving a control sequence which toggled between the
-local and UTF-8 encodings, or at the parent application's request.</doc>
+        <doc xml:space="preserve">Emitted whenever the terminal's current encoding has changed.
+
+Note: support for non-UTF-8 is deprecated.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -3243,8 +3288,8 @@ same hyperlink. This might change in a future VTE version without notice.</doc>
           </parameter>
         </parameters>
       </glib:signal>
-      <glib:signal name="icon-title-changed" when="last">
-        <doc xml:space="preserve">Emitted when the terminal's %icon_title field is modified.</doc>
+      <glib:signal name="icon-title-changed" when="last" deprecated="1" deprecated-version="0.54">
+        <doc-deprecated xml:space="preserve">This signal is never emitted.</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -3873,6 +3918,19 @@ enumeration. See #GError for more information on error domains.</doc>
       <return-value transfer-ownership="none">
         <type name="GLib.Quark" c:type="GQuark"/>
       </return-value>
+    </function>
+    <function name="set_test_flags" c:identifier="vte_set_test_flags" version="0.54" introspectable="0">
+      <doc xml:space="preserve">Sets test flags. This function is only useful for implementing
+unit tests for vte itself; it is a no-op in non-debug builds.</doc>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="flags" transfer-ownership="none">
+          <doc xml:space="preserve">flags</doc>
+          <type name="guint64" c:type="guint64"/>
+        </parameter>
+      </parameters>
     </function>
   </namespace>
 </repository>

--- a/WebKit2-4.0.gir
+++ b/WebKit2-4.0.gir
@@ -2804,7 +2804,7 @@ user to select multiple files at once or only one.</doc>
 is defined or %NULL otherwise, meaning that any MIME type should be
 accepted. This array and its contents are owned by WebKit and
 should not be modified or freed.</doc>
-          <array c:type="gchar**">
+          <array c:type="const gchar* const*">
             <type name="utf8"/>
           </array>
         </return-value>
@@ -2869,7 +2869,7 @@ extra action, like pre-selecting the files from a previous request.</doc>
 associated with the request or %NULL otherwise. This array and its
 contents are owned by WebKit and should not be modified or
 freed.</doc>
-          <array c:type="gchar**">
+          <array c:type="const gchar* const*">
             <type name="utf8"/>
           </array>
         </return-value>
@@ -2894,7 +2894,7 @@ request.</doc>
           <parameter name="files" transfer-ownership="none">
             <doc xml:space="preserve">a
 %NULL-terminated array of strings, containing paths to local files.</doc>
-            <array c:type="gchar**">
+            <array c:type="const gchar* const*">
               <type name="utf8" c:type="gchar*"/>
             </array>
           </parameter>
@@ -3792,12 +3792,13 @@ from an untrusted source.</doc>
       </function>
     </enumeration>
     <record name="JavascriptResult" c:type="WebKitJavascriptResult" glib:type-name="WebKitJavascriptResult" glib:get-type="webkit_javascript_result_get_type" c:symbol-prefix="javascript_result">
-      <method name="get_global_context" c:identifier="webkit_javascript_result_get_global_context">
+      <method name="get_global_context" c:identifier="webkit_javascript_result_get_global_context" introspectable="0" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Get the global Javascript context that should be used with the
 &lt;function&gt;JSValueRef&lt;/function&gt; returned by webkit_javascript_result_get_value().</doc>
-        <return-value transfer-ownership="full">
+        <doc-deprecated xml:space="preserve">Use jsc_value_get_context() instead.</doc-deprecated>
+        <return-value>
           <doc xml:space="preserve">the &lt;function&gt;JSGlobalContextRef&lt;/function&gt; for the #WebKitJavascriptResult</doc>
-          <type name="JavaScriptCore.GlobalContext" c:type="JSGlobalContextRef"/>
+          <type c:type="JSGlobalContextRef"/>
         </return-value>
         <parameters>
           <instance-parameter name="js_result" transfer-ownership="none">
@@ -3806,12 +3807,26 @@ from an untrusted source.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_value" c:identifier="webkit_javascript_result_get_value">
+      <method name="get_js_value" c:identifier="webkit_javascript_result_get_js_value" version="2.22">
+        <doc xml:space="preserve">Get the #JSCValue of @js_result.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the #JSCValue of the #WebKitJavascriptResult</doc>
+          <type name="JavaScriptCore.Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="js_result" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitJavascriptResult</doc>
+            <type name="JavascriptResult" c:type="WebKitJavascriptResult*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_value" c:identifier="webkit_javascript_result_get_value" introspectable="0" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Get the value of @js_result. You should use the &lt;function&gt;JSGlobalContextRef&lt;/function&gt;
 returned by webkit_javascript_result_get_global_context() to use the &lt;function&gt;JSValueRef&lt;/function&gt;.</doc>
-        <return-value transfer-ownership="full">
+        <doc-deprecated xml:space="preserve">Use webkit_javascript_result_get_js_value() instead.</doc-deprecated>
+        <return-value>
           <doc xml:space="preserve">the &lt;function&gt;JSValueRef&lt;/function&gt; of the #WebKitJavascriptResult</doc>
-          <type name="JavaScriptCore.Value" c:type="JSValueRef"/>
+          <type c:type="JSValueRef"/>
         </return-value>
         <parameters>
           <instance-parameter name="js_result" transfer-ownership="none">
@@ -3880,13 +3895,13 @@ application compile time, rather than from the library linked
 against at application run time.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="MICRO_VERSION" value="2" c:type="WEBKIT_MICRO_VERSION">
+    <constant name="MICRO_VERSION" value="5" c:type="WEBKIT_MICRO_VERSION">
       <doc xml:space="preserve">Like webkit_get_micro_version(), but from the headers used at
 application compile time, rather than from the library linked
 against at application run time.</doc>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="MINOR_VERSION" value="20" c:type="WEBKIT_MINOR_VERSION">
+    <constant name="MINOR_VERSION" value="22" c:type="WEBKIT_MINOR_VERSION">
       <doc xml:space="preserve">Like webkit_get_minor_version(), but from the headers used at
 application compile time, rather than from the library linked
 against at application run time.</doc>
@@ -3911,7 +3926,7 @@ MIME type of @info</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a
     %NULL-terminated array of strings</doc>
-          <array c:type="gchar**">
+          <array c:type="const gchar* const*">
             <type name="utf8"/>
           </array>
         </return-value>
@@ -4338,7 +4353,7 @@ contains only "192.168.1.1", then a connection to "example.com" will use the pro
           </parameter>
           <parameter name="ignore_hosts" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">an optional list of hosts/IP addresses to not use a proxy for.</doc>
-            <array c:type="gchar**">
+            <array c:type="const gchar* const*">
               <type name="utf8" c:type="gchar*"/>
             </array>
           </parameter>
@@ -6550,6 +6565,19 @@ of #WebKitSettings.</doc>
           </instance-parameter>
         </parameters>
       </method>
+      <method name="get_enable_media_capabilities" c:identifier="webkit_settings_get_enable_media_capabilities" version="2.22">
+        <doc xml:space="preserve">Get the #WebKitSettings:enable-media-capabilities property.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if MediaCapabilities support is enabled or %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="settings" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitSettings</doc>
+            <type name="Settings" c:type="WebKitSettings*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
       <method name="get_enable_media_stream" c:identifier="webkit_settings_get_enable_media_stream" version="2.4">
         <doc xml:space="preserve">Get the #WebKitSettings:enable-media-stream property.</doc>
         <return-value transfer-ownership="none">
@@ -7297,6 +7325,22 @@ otherwise.</doc>
           </parameter>
         </parameters>
       </method>
+      <method name="set_enable_media_capabilities" c:identifier="webkit_settings_set_enable_media_capabilities" version="2.22">
+        <doc xml:space="preserve">Set the #WebKitSettings:enable-media-capabilities property.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="settings" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitSettings</doc>
+            <type name="Settings" c:type="WebKitSettings*"/>
+          </instance-parameter>
+          <parameter name="enabled" transfer-ownership="none">
+            <doc xml:space="preserve">Value to be set</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
       <method name="set_enable_media_stream" c:identifier="webkit_settings_set_enable_media_stream" version="2.4">
         <doc xml:space="preserve">Set the #WebKitSettings:enable-media-stream property.</doc>
         <return-value transfer-ownership="none">
@@ -7932,6 +7976,17 @@ http://www.whatwg.org/specs/web-apps/current-work/multipage/links.html#hyperlink
       </property>
       <property name="enable-javascript" writable="1" construct="1" transfer-ownership="none">
         <doc xml:space="preserve">Determines whether or not JavaScript executes within a page.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="enable-media-capabilities" version="2.22" writable="1" construct="1" transfer-ownership="none">
+        <doc xml:space="preserve">Enable or disable support for MediaCapabilities on pages. This
+specification intends to provide APIs to allow websites to make an optimal
+decision when picking media content for the user. The APIs will expose
+information about the decoding and encoding capabilities for a given format
+but also output capabilities to find the best match based on the device&#x2019;s
+display.
+
+See also https://wicg.github.io/media-capabilities/</doc>
         <type name="gboolean" c:type="gboolean"/>
       </property>
       <property name="enable-media-stream" version="2.4" writable="1" construct="1" transfer-ownership="none">
@@ -8733,6 +8788,31 @@ name has been already registered before.</doc>
           </parameter>
         </parameters>
       </method>
+      <method name="register_script_message_handler_in_world" c:identifier="webkit_user_content_manager_register_script_message_handler_in_world" version="2.22">
+        <doc xml:space="preserve">Registers a new user script message handler in script world with name @world_name.
+See webkit_user_content_manager_register_script_message_handler() for full description.
+
+Registering a script message handler will fail if the requested
+name has been already registered before.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">%TRUE if message handler was registered successfully, or %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitUserContentManager</doc>
+            <type name="UserContentManager" c:type="WebKitUserContentManager*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">Name of the script message channel</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="world_name" transfer-ownership="none">
+            <doc xml:space="preserve">the name of a #WebKitScriptWorld</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
       <method name="remove_all_scripts" c:identifier="webkit_user_content_manager_remove_all_scripts" version="2.6">
         <doc xml:space="preserve">Removes all user scripts from the given #WebKitUserContentManager</doc>
         <return-value transfer-ownership="none">
@@ -8761,11 +8841,11 @@ name has been already registered before.</doc>
         <doc xml:space="preserve">Unregisters a previously registered message handler.
 
 Note that this does *not* disconnect handlers for the
-#WebKitUserContentManager::script-message-received signal,
+#WebKitUserContentManager::script-message-received signal;
 they will be kept connected, but the signal will not be emitted
 unless the handler name is registered again.
 
-See also webkit_user_content_manager_register_script_message_handler()</doc>
+See also webkit_user_content_manager_register_script_message_handler().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8776,6 +8856,33 @@ See also webkit_user_content_manager_register_script_message_handler()</doc>
           </instance-parameter>
           <parameter name="name" transfer-ownership="none">
             <doc xml:space="preserve">Name of the script message channel</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="unregister_script_message_handler_in_world" c:identifier="webkit_user_content_manager_unregister_script_message_handler_in_world" version="2.22">
+        <doc xml:space="preserve">Unregisters a previously registered message handler in script world with name @world_name.
+
+Note that this does *not* disconnect handlers for the
+#WebKitUserContentManager::script-message-received signal;
+they will be kept connected, but the signal will not be emitted
+unless the handler name is registered again.
+
+See also webkit_user_content_manager_register_script_message_handler_in_world().</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="manager" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitUserContentManager</doc>
+            <type name="UserContentManager" c:type="WebKitUserContentManager*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">Name of the script message channel</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="world_name" transfer-ownership="none">
+            <doc xml:space="preserve">the name of a #WebKitScriptWorld</doc>
             <type name="utf8" c:type="const gchar*"/>
           </parameter>
         </parameters>
@@ -8915,13 +9022,51 @@ represent zero or more other characters.</doc>
           </parameter>
           <parameter name="whitelist" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">A whitelist of URI patterns or %NULL</doc>
-            <array c:type="gchar**">
+            <array c:type="const gchar* const*">
               <type name="utf8" c:type="gchar*"/>
             </array>
           </parameter>
           <parameter name="blacklist" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">A blacklist of URI patterns or %NULL</doc>
-            <array c:type="gchar**">
+            <array c:type="const gchar* const*">
+              <type name="utf8" c:type="gchar*"/>
+            </array>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_for_world" c:identifier="webkit_user_script_new_for_world" version="2.22">
+        <doc xml:space="preserve">Creates a new user script for script world with name @world_name.
+See webkit_user_script_new() for a full description.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">A new #WebKitUserScript</doc>
+          <type name="UserScript" c:type="WebKitUserScript*"/>
+        </return-value>
+        <parameters>
+          <parameter name="source" transfer-ownership="none">
+            <doc xml:space="preserve">Source code of the user script.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="injected_frames" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitUserContentInjectedFrames value</doc>
+            <type name="UserContentInjectedFrames" c:type="WebKitUserContentInjectedFrames"/>
+          </parameter>
+          <parameter name="injection_time" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitUserScriptInjectionTime value</doc>
+            <type name="UserScriptInjectionTime" c:type="WebKitUserScriptInjectionTime"/>
+          </parameter>
+          <parameter name="world_name" transfer-ownership="none">
+            <doc xml:space="preserve">the name of a #WebKitScriptWorld</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="whitelist" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">A whitelist of URI patterns or %NULL</doc>
+            <array c:type="const gchar* const*">
+              <type name="utf8" c:type="gchar*"/>
+            </array>
+          </parameter>
+          <parameter name="blacklist" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">A blacklist of URI patterns or %NULL</doc>
+            <array c:type="const gchar* const*">
               <type name="utf8" c:type="gchar*"/>
             </array>
           </parameter>
@@ -9008,13 +9153,51 @@ represent zero or more other characters.</doc>
           </parameter>
           <parameter name="whitelist" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">A whitelist of URI patterns or %NULL</doc>
-            <array c:type="gchar**">
+            <array c:type="const gchar* const*">
               <type name="utf8" c:type="gchar*"/>
             </array>
           </parameter>
           <parameter name="blacklist" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">A blacklist of URI patterns or %NULL</doc>
-            <array c:type="gchar**">
+            <array c:type="const gchar* const*">
+              <type name="utf8" c:type="gchar*"/>
+            </array>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_for_world" c:identifier="webkit_user_style_sheet_new_for_world" version="2.22">
+        <doc xml:space="preserve">Creates a new user style sheet for script world with name @world_name.
+See webkit_user_style_sheet_new() for a full description.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">A new #WebKitUserStyleSheet</doc>
+          <type name="UserStyleSheet" c:type="WebKitUserStyleSheet*"/>
+        </return-value>
+        <parameters>
+          <parameter name="source" transfer-ownership="none">
+            <doc xml:space="preserve">Source code of the user style sheet.</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="injected_frames" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitUserContentInjectedFrames value</doc>
+            <type name="UserContentInjectedFrames" c:type="WebKitUserContentInjectedFrames"/>
+          </parameter>
+          <parameter name="level" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitUserStyleLevel</doc>
+            <type name="UserStyleLevel" c:type="WebKitUserStyleLevel"/>
+          </parameter>
+          <parameter name="world_name" transfer-ownership="none">
+            <doc xml:space="preserve">the name of a #WebKitScriptWorld</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="whitelist" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">A whitelist of URI patterns or %NULL</doc>
+            <array c:type="const gchar* const*">
+              <type name="utf8" c:type="gchar*"/>
+            </array>
+          </parameter>
+          <parameter name="blacklist" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">A blacklist of URI patterns or %NULL</doc>
+            <array c:type="const gchar* const*">
               <type name="utf8" c:type="gchar*"/>
             </array>
           </parameter>
@@ -9351,7 +9534,7 @@ details on the format of the languages in the list.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A %NULL-terminated
    array of languages if available, or %NULL otherwise.</doc>
-          <array c:type="gchar**">
+          <array c:type="const gchar* const*">
             <type name="utf8"/>
           </array>
         </return-value>
@@ -9713,7 +9896,7 @@ the #WebKitWebContext.</doc>
           </instance-parameter>
           <parameter name="languages" transfer-ownership="none" nullable="1" allow-none="1">
             <doc xml:space="preserve">a %NULL-terminated list of language identifiers</doc>
-            <array c:type="gchar**">
+            <array c:type="const gchar* const*">
               <type name="utf8"/>
             </array>
           </parameter>
@@ -9791,7 +9974,7 @@ in WebKit.</doc>
           </instance-parameter>
           <parameter name="languages" transfer-ownership="none">
             <doc xml:space="preserve">a %NULL-terminated list of spell checking languages</doc>
-            <array c:type="gchar**">
+            <array c:type="const gchar* const*">
               <type name="utf8" c:type="gchar*"/>
             </array>
           </parameter>
@@ -11233,13 +11416,14 @@ this particular #WebKitWebView.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_javascript_global_context" c:identifier="webkit_web_view_get_javascript_global_context">
+      <method name="get_javascript_global_context" c:identifier="webkit_web_view_get_javascript_global_context" introspectable="0" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Get the global JavaScript context used by @web_view to deserialize the
 result values of scripts executed with webkit_web_view_run_javascript().</doc>
-        <return-value transfer-ownership="full">
+        <doc-deprecated xml:space="preserve">Use jsc_value_get_context() instead.</doc-deprecated>
+        <return-value>
           <doc xml:space="preserve">the &lt;function&gt;JSGlobalContextRef&lt;/function&gt; used by @web_view to deserialize
    the result values of scripts.</doc>
-          <type name="JavaScriptCore.GlobalContext" c:type="JSGlobalContextRef"/>
+          <type c:type="JSGlobalContextRef"/>
         </return-value>
         <parameters>
           <instance-parameter name="web_view" transfer-ownership="none">
@@ -11889,8 +12073,7 @@ web_view_javascript_finished (GObject      *object,
                               gpointer      user_data)
 {
     WebKitJavascriptResult *js_result;
-    JSValueRef              value;
-    JSGlobalContextRef      context;
+    JSCValue               *value;
     GError                 *error = NULL;
 
     js_result = webkit_web_view_run_javascript_finish (WEBKIT_WEB_VIEW (object), result, &amp;error);
@@ -11900,19 +12083,17 @@ web_view_javascript_finished (GObject      *object,
         return;
     }
 
-    context = webkit_javascript_result_get_global_context (js_result);
-    value = webkit_javascript_result_get_value (js_result);
-    if (JSValueIsString (context, value)) {
-        JSStringRef js_str_value;
-        gchar      *str_value;
-        gsize       str_length;
+    value = webkit_javascript_result_get_js_value (js_result);
+    if (jsc_value_is_string (value)) {
+        JSCException *exception;
+        gchar        *str_value;
 
-        js_str_value = JSValueToStringCopy (context, value, NULL);
-        str_length = JSStringGetMaximumUTF8CStringSize (js_str_value);
-        str_value = (gchar *)g_malloc (str_length);
-        JSStringGetUTF8CString (js_str_value, str_value, str_length);
-        JSStringRelease (js_str_value);
-        g_print ("Script result: %s\n", str_value);
+        str_value = jsc_value_to_string (value);
+        exception = jsc_context_get_exception (jsc_value_get_context (value));
+        if (exception)
+            g_warning ("Error running javascript: %s", jsc_exception_get_message (exception));
+        else
+            g_print ("Script result: %s\n", str_value);
         g_free (str_value);
     } else {
         g_warning ("Error running javascript: unexpected return value");
@@ -11984,6 +12165,60 @@ of the operation.</doc>
         <doc xml:space="preserve">Finish an asynchronous operation started with webkit_web_view_run_javascript_from_gresource().
 
 Check webkit_web_view_run_javascript_finish() for a usage example.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a #WebKitJavascriptResult with the result of the last executed statement in @script
+   or %NULL in case of error</doc>
+          <type name="JavascriptResult" c:type="WebKitJavascriptResult*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="web_view" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitWebView</doc>
+            <type name="WebView" c:type="WebKitWebView*"/>
+          </instance-parameter>
+          <parameter name="result" transfer-ownership="none">
+            <doc xml:space="preserve">a #GAsyncResult</doc>
+            <type name="Gio.AsyncResult" c:type="GAsyncResult*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="run_javascript_in_world" c:identifier="webkit_web_view_run_javascript_in_world" version="2.22">
+        <doc xml:space="preserve">Asynchronously run @script in the script world with name @world_name of the current page context in @web_view.
+If WebKitSettings:enable-javascript is FALSE, this method will do nothing.
+
+When the operation is finished, @callback will be called. You can then call
+webkit_web_view_run_javascript_in_world_finish() to get the result of the operation.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="web_view" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitWebView</doc>
+            <type name="WebView" c:type="WebKitWebView*"/>
+          </instance-parameter>
+          <parameter name="script" transfer-ownership="none">
+            <doc xml:space="preserve">the script to run</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="world_name" transfer-ownership="none">
+            <doc xml:space="preserve">the name of a #WebKitScriptWorld</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+          <parameter name="cancellable" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">a #GCancellable or %NULL to ignore</doc>
+            <type name="Gio.Cancellable" c:type="GCancellable*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" nullable="1" allow-none="1" scope="async" closure="4">
+            <doc xml:space="preserve">a #GAsyncReadyCallback to call when the script finished</doc>
+            <type name="Gio.AsyncReadyCallback" c:type="GAsyncReadyCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve">the data to pass to callback function</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="run_javascript_in_world_finish" c:identifier="webkit_web_view_run_javascript_in_world_finish" version="2.22" throws="1">
+        <doc xml:space="preserve">Finish an asynchronous operation started with webkit_web_view_run_javascript_in_world().</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a #WebKitJavascriptResult with the result of the last executed statement in @script
    or %NULL in case of error</doc>

--- a/WebKit2WebExtension-4.0.gir
+++ b/WebKit2WebExtension-4.0.gir
@@ -789,7 +789,8 @@ submenu of @item is removed.</doc>
     </record>
     <class name="DOMAttr" c:symbol-prefix="dom_attr" c:type="WebKitDOMAttr" parent="DOMNode" glib:type-name="WebKitDOMAttr" glib:get-type="webkit_dom_attr_get_type" glib:type-struct="DOMAttrClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_local_name" c:identifier="webkit_dom_attr_get_local_name" version="2.14">
+      <method name="get_local_name" c:identifier="webkit_dom_attr_get_local_name" version="2.14" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -801,7 +802,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_attr_get_name">
+      <method name="get_name" c:identifier="webkit_dom_attr_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -813,7 +815,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_namespace_uri" c:identifier="webkit_dom_attr_get_namespace_uri" version="2.14">
+      <method name="get_namespace_uri" c:identifier="webkit_dom_attr_get_namespace_uri" version="2.14" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -825,7 +828,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_owner_element" c:identifier="webkit_dom_attr_get_owner_element">
+      <method name="get_owner_element" c:identifier="webkit_dom_attr_get_owner_element" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -837,7 +841,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_prefix" c:identifier="webkit_dom_attr_get_prefix" version="2.14">
+      <method name="get_prefix" c:identifier="webkit_dom_attr_get_prefix" version="2.14" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -849,7 +854,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_specified" c:identifier="webkit_dom_attr_get_specified">
+      <method name="get_specified" c:identifier="webkit_dom_attr_get_specified" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -861,7 +867,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_value" c:identifier="webkit_dom_attr_get_value">
+      <method name="get_value" c:identifier="webkit_dom_attr_get_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -873,7 +880,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_value" c:identifier="webkit_dom_attr_set_value" throws="1">
+      <method name="set_value" c:identifier="webkit_dom_attr_set_value" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -919,7 +927,8 @@ submenu of @item is removed.</doc>
       </field>
     </record>
     <class name="DOMBlob" c:symbol-prefix="dom_blob" c:type="WebKitDOMBlob" parent="DOMObject" glib:type-name="WebKitDOMBlob" glib:get-type="webkit_dom_blob_get_type" glib:type-struct="DOMBlobClass">
-      <method name="get_size" c:identifier="webkit_dom_blob_get_size">
+      <method name="get_size" c:identifier="webkit_dom_blob_get_size" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #guint64</doc>
           <type name="guint64" c:type="guint64"/>
@@ -955,7 +964,8 @@ submenu of @item is removed.</doc>
       </field>
     </record>
     <class name="DOMCSSRule" c:symbol-prefix="dom_css_rule" c:type="WebKitDOMCSSRule" parent="DOMObject" glib:type-name="WebKitDOMCSSRule" glib:get-type="webkit_dom_css_rule_get_type" glib:type-struct="DOMCSSRuleClass">
-      <method name="get_css_text" c:identifier="webkit_dom_css_rule_get_css_text">
+      <method name="get_css_text" c:identifier="webkit_dom_css_rule_get_css_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -967,7 +977,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_parent_rule" c:identifier="webkit_dom_css_rule_get_parent_rule">
+      <method name="get_parent_rule" c:identifier="webkit_dom_css_rule_get_parent_rule" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMCSSRule</doc>
           <type name="DOMCSSRule" c:type="WebKitDOMCSSRule*"/>
@@ -979,7 +990,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_parent_style_sheet" c:identifier="webkit_dom_css_rule_get_parent_style_sheet">
+      <method name="get_parent_style_sheet" c:identifier="webkit_dom_css_rule_get_parent_style_sheet" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMCSSStyleSheet</doc>
           <type name="DOMCSSStyleSheet" c:type="WebKitDOMCSSStyleSheet*"/>
@@ -991,7 +1003,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_rule_type" c:identifier="webkit_dom_css_rule_get_rule_type">
+      <method name="get_rule_type" c:identifier="webkit_dom_css_rule_get_rule_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gushort</doc>
           <type name="gushort" c:type="gushort"/>
@@ -1003,7 +1016,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_css_text" c:identifier="webkit_dom_css_rule_set_css_text" throws="1">
+      <method name="set_css_text" c:identifier="webkit_dom_css_rule_set_css_text" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1040,7 +1054,8 @@ submenu of @item is removed.</doc>
       </field>
     </record>
     <class name="DOMCSSRuleList" c:symbol-prefix="dom_css_rule_list" c:type="WebKitDOMCSSRuleList" parent="DOMObject" glib:type-name="WebKitDOMCSSRuleList" glib:get-type="webkit_dom_css_rule_list_get_type" glib:type-struct="DOMCSSRuleListClass">
-      <method name="get_length" c:identifier="webkit_dom_css_rule_list_get_length">
+      <method name="get_length" c:identifier="webkit_dom_css_rule_list_get_length" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -1052,7 +1067,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="item" c:identifier="webkit_dom_css_rule_list_item">
+      <method name="item" c:identifier="webkit_dom_css_rule_list_item" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMCSSRule</doc>
           <type name="DOMCSSRule" c:type="WebKitDOMCSSRule*"/>
@@ -1081,7 +1097,8 @@ submenu of @item is removed.</doc>
       </field>
     </record>
     <class name="DOMCSSStyleDeclaration" c:symbol-prefix="dom_css_style_declaration" c:type="WebKitDOMCSSStyleDeclaration" parent="DOMObject" glib:type-name="WebKitDOMCSSStyleDeclaration" glib:get-type="webkit_dom_css_style_declaration_get_type" glib:type-struct="DOMCSSStyleDeclarationClass">
-      <method name="get_css_text" c:identifier="webkit_dom_css_style_declaration_get_css_text">
+      <method name="get_css_text" c:identifier="webkit_dom_css_style_declaration_get_css_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -1093,7 +1110,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_length" c:identifier="webkit_dom_css_style_declaration_get_length">
+      <method name="get_length" c:identifier="webkit_dom_css_style_declaration_get_length" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -1105,7 +1123,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_parent_rule" c:identifier="webkit_dom_css_style_declaration_get_parent_rule">
+      <method name="get_parent_rule" c:identifier="webkit_dom_css_style_declaration_get_parent_rule" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMCSSRule</doc>
           <type name="DOMCSSRule" c:type="WebKitDOMCSSRule*"/>
@@ -1117,7 +1136,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_property_priority" c:identifier="webkit_dom_css_style_declaration_get_property_priority">
+      <method name="get_property_priority" c:identifier="webkit_dom_css_style_declaration_get_property_priority" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -1133,7 +1153,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_property_shorthand" c:identifier="webkit_dom_css_style_declaration_get_property_shorthand">
+      <method name="get_property_shorthand" c:identifier="webkit_dom_css_style_declaration_get_property_shorthand" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -1149,7 +1170,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_property_value" c:identifier="webkit_dom_css_style_declaration_get_property_value">
+      <method name="get_property_value" c:identifier="webkit_dom_css_style_declaration_get_property_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -1165,7 +1187,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="is_property_implicit" c:identifier="webkit_dom_css_style_declaration_is_property_implicit">
+      <method name="is_property_implicit" c:identifier="webkit_dom_css_style_declaration_is_property_implicit" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -1181,7 +1204,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="item" c:identifier="webkit_dom_css_style_declaration_item">
+      <method name="item" c:identifier="webkit_dom_css_style_declaration_item" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -1197,7 +1221,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="remove_property" c:identifier="webkit_dom_css_style_declaration_remove_property" throws="1">
+      <method name="remove_property" c:identifier="webkit_dom_css_style_declaration_remove_property" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -1213,7 +1238,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_css_text" c:identifier="webkit_dom_css_style_declaration_set_css_text" throws="1">
+      <method name="set_css_text" c:identifier="webkit_dom_css_style_declaration_set_css_text" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1228,7 +1254,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_property" c:identifier="webkit_dom_css_style_declaration_set_property" throws="1">
+      <method name="set_property" c:identifier="webkit_dom_css_style_declaration_set_property" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1270,7 +1297,8 @@ submenu of @item is removed.</doc>
       </field>
     </record>
     <class name="DOMCSSStyleSheet" c:symbol-prefix="dom_css_style_sheet" c:type="WebKitDOMCSSStyleSheet" parent="DOMStyleSheet" glib:type-name="WebKitDOMCSSStyleSheet" glib:get-type="webkit_dom_css_style_sheet_get_type" glib:type-struct="DOMCSSStyleSheetClass">
-      <method name="add_rule" c:identifier="webkit_dom_css_style_sheet_add_rule" throws="1">
+      <method name="add_rule" c:identifier="webkit_dom_css_style_sheet_add_rule" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -1294,7 +1322,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="delete_rule" c:identifier="webkit_dom_css_style_sheet_delete_rule" throws="1">
+      <method name="delete_rule" c:identifier="webkit_dom_css_style_sheet_delete_rule" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1309,7 +1338,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_css_rules" c:identifier="webkit_dom_css_style_sheet_get_css_rules">
+      <method name="get_css_rules" c:identifier="webkit_dom_css_style_sheet_get_css_rules" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMCSSRuleList</doc>
           <type name="DOMCSSRuleList" c:type="WebKitDOMCSSRuleList*"/>
@@ -1321,7 +1351,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_owner_rule" c:identifier="webkit_dom_css_style_sheet_get_owner_rule">
+      <method name="get_owner_rule" c:identifier="webkit_dom_css_style_sheet_get_owner_rule" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMCSSRule</doc>
           <type name="DOMCSSRule" c:type="WebKitDOMCSSRule*"/>
@@ -1333,7 +1364,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_rules" c:identifier="webkit_dom_css_style_sheet_get_rules">
+      <method name="get_rules" c:identifier="webkit_dom_css_style_sheet_get_rules" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMCSSRuleList</doc>
           <type name="DOMCSSRuleList" c:type="WebKitDOMCSSRuleList*"/>
@@ -1345,7 +1377,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="insert_rule" c:identifier="webkit_dom_css_style_sheet_insert_rule" throws="1">
+      <method name="insert_rule" c:identifier="webkit_dom_css_style_sheet_insert_rule" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -1365,7 +1398,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="remove_rule" c:identifier="webkit_dom_css_style_sheet_remove_rule" throws="1">
+      <method name="remove_rule" c:identifier="webkit_dom_css_style_sheet_remove_rule" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1399,7 +1433,8 @@ submenu of @item is removed.</doc>
       </field>
     </record>
     <class name="DOMCSSValue" c:symbol-prefix="dom_css_value" c:type="WebKitDOMCSSValue" parent="DOMObject" glib:type-name="WebKitDOMCSSValue" glib:get-type="webkit_dom_css_value_get_type" glib:type-struct="DOMCSSValueClass">
-      <method name="get_css_text" c:identifier="webkit_dom_css_value_get_css_text">
+      <method name="get_css_text" c:identifier="webkit_dom_css_value_get_css_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -1411,7 +1446,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_css_value_type" c:identifier="webkit_dom_css_value_get_css_value_type">
+      <method name="get_css_value_type" c:identifier="webkit_dom_css_value_get_css_value_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gushort</doc>
           <type name="gushort" c:type="gushort"/>
@@ -1423,7 +1459,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_css_text" c:identifier="webkit_dom_css_value_set_css_text" throws="1">
+      <method name="set_css_text" c:identifier="webkit_dom_css_value_set_css_text" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1455,7 +1492,8 @@ submenu of @item is removed.</doc>
     </record>
     <class name="DOMCharacterData" c:symbol-prefix="dom_character_data" c:type="WebKitDOMCharacterData" parent="DOMNode" glib:type-name="WebKitDOMCharacterData" glib:get-type="webkit_dom_character_data_get_type" glib:type-struct="DOMCharacterDataClass">
       <implements name="DOMEventTarget"/>
-      <method name="append_data" c:identifier="webkit_dom_character_data_append_data" throws="1">
+      <method name="append_data" c:identifier="webkit_dom_character_data_append_data" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1470,7 +1508,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="delete_data" c:identifier="webkit_dom_character_data_delete_data" throws="1">
+      <method name="delete_data" c:identifier="webkit_dom_character_data_delete_data" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1489,7 +1528,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_data" c:identifier="webkit_dom_character_data_get_data">
+      <method name="get_data" c:identifier="webkit_dom_character_data_get_data" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -1501,7 +1541,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_length" c:identifier="webkit_dom_character_data_get_length">
+      <method name="get_length" c:identifier="webkit_dom_character_data_get_length" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -1513,7 +1554,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="insert_data" c:identifier="webkit_dom_character_data_insert_data" throws="1">
+      <method name="insert_data" c:identifier="webkit_dom_character_data_insert_data" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1532,7 +1574,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="replace_data" c:identifier="webkit_dom_character_data_replace_data" throws="1">
+      <method name="replace_data" c:identifier="webkit_dom_character_data_replace_data" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1555,7 +1598,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_data" c:identifier="webkit_dom_character_data_set_data" throws="1">
+      <method name="set_data" c:identifier="webkit_dom_character_data_set_data" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1570,7 +1614,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="substring_data" c:identifier="webkit_dom_character_data_substring_data" throws="1">
+      <method name="substring_data" c:identifier="webkit_dom_character_data_substring_data" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -1606,8 +1651,9 @@ submenu of @item is removed.</doc>
       </field>
     </record>
     <class name="DOMClientRect" c:symbol-prefix="dom_client_rect" c:type="WebKitDOMClientRect" parent="DOMObject" glib:type-name="WebKitDOMClientRect" glib:get-type="webkit_dom_client_rect_get_type" glib:type-struct="DOMClientRectClass">
-      <method name="get_bottom" c:identifier="webkit_dom_client_rect_get_bottom" version="2.18">
+      <method name="get_bottom" c:identifier="webkit_dom_client_rect_get_bottom" version="2.18" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Returns the bottom coordinate of @self, relative to the viewport.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gfloat</doc>
           <type name="gfloat" c:type="gfloat"/>
@@ -1619,8 +1665,9 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_height" c:identifier="webkit_dom_client_rect_get_height" version="2.18">
+      <method name="get_height" c:identifier="webkit_dom_client_rect_get_height" version="2.18" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Returns the height of @self.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gfloat</doc>
           <type name="gfloat" c:type="gfloat"/>
@@ -1632,8 +1679,9 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_left" c:identifier="webkit_dom_client_rect_get_left" version="2.18">
+      <method name="get_left" c:identifier="webkit_dom_client_rect_get_left" version="2.18" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Returns the left coordinate of @self, relative to the viewport.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gfloat</doc>
           <type name="gfloat" c:type="gfloat"/>
@@ -1645,8 +1693,9 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_right" c:identifier="webkit_dom_client_rect_get_right" version="2.18">
+      <method name="get_right" c:identifier="webkit_dom_client_rect_get_right" version="2.18" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Returns the right coordinate of @self, relative to the viewport.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gfloat</doc>
           <type name="gfloat" c:type="gfloat"/>
@@ -1658,8 +1707,9 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_top" c:identifier="webkit_dom_client_rect_get_top" version="2.18">
+      <method name="get_top" c:identifier="webkit_dom_client_rect_get_top" version="2.18" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Returns the top coordinate of @self, relative to the viewport.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gfloat</doc>
           <type name="gfloat" c:type="gfloat"/>
@@ -1671,8 +1721,9 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_width" c:identifier="webkit_dom_client_rect_get_width" version="2.18">
+      <method name="get_width" c:identifier="webkit_dom_client_rect_get_width" version="2.18" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Returns the width of @self.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gfloat</doc>
           <type name="gfloat" c:type="gfloat"/>
@@ -1712,8 +1763,9 @@ submenu of @item is removed.</doc>
       </field>
     </record>
     <class name="DOMClientRectList" c:symbol-prefix="dom_client_rect_list" c:type="WebKitDOMClientRectList" parent="DOMObject" glib:type-name="WebKitDOMClientRectList" glib:get-type="webkit_dom_client_rect_list_get_type" glib:type-struct="DOMClientRectListClass">
-      <method name="get_length" c:identifier="webkit_dom_client_rect_list_get_length" version="2.18">
+      <method name="get_length" c:identifier="webkit_dom_client_rect_list_get_length" version="2.18" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Returns the number of #WebKitDOMClientRect objects that @self contains.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -1725,8 +1777,9 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="item" c:identifier="webkit_dom_client_rect_list_item" version="2.18">
+      <method name="item" c:identifier="webkit_dom_client_rect_list_item" version="2.18" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Returns the #WebKitDOMClientRect object that @self contains at @index.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMClientRect</doc>
           <type name="DOMClientRect" c:type="WebKitDOMClientRect*"/>
@@ -1766,7 +1819,8 @@ submenu of @item is removed.</doc>
       </field>
     </record>
     <class name="DOMDOMImplementation" c:symbol-prefix="dom_dom_implementation" c:type="WebKitDOMDOMImplementation" parent="DOMObject" glib:type-name="WebKitDOMDOMImplementation" glib:get-type="webkit_dom_dom_implementation_get_type" glib:type-struct="DOMDOMImplementationClass">
-      <method name="create_css_style_sheet" c:identifier="webkit_dom_dom_implementation_create_css_style_sheet" throws="1">
+      <method name="create_css_style_sheet" c:identifier="webkit_dom_dom_implementation_create_css_style_sheet" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMCSSStyleSheet</doc>
           <type name="DOMCSSStyleSheet" c:type="WebKitDOMCSSStyleSheet*"/>
@@ -1786,7 +1840,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_document" c:identifier="webkit_dom_dom_implementation_create_document" throws="1">
+      <method name="create_document" c:identifier="webkit_dom_dom_implementation_create_document" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMDocument</doc>
           <type name="DOMDocument" c:type="WebKitDOMDocument*"/>
@@ -1810,7 +1865,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_document_type" c:identifier="webkit_dom_dom_implementation_create_document_type" throws="1">
+      <method name="create_document_type" c:identifier="webkit_dom_dom_implementation_create_document_type" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMDocumentType</doc>
           <type name="DOMDocumentType" c:type="WebKitDOMDocumentType*"/>
@@ -1834,7 +1890,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_html_document" c:identifier="webkit_dom_dom_implementation_create_html_document">
+      <method name="create_html_document" c:identifier="webkit_dom_dom_implementation_create_html_document" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLDocument</doc>
           <type name="DOMHTMLDocument" c:type="WebKitDOMHTMLDocument*"/>
@@ -1850,7 +1907,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="has_feature" c:identifier="webkit_dom_dom_implementation_has_feature">
+      <method name="has_feature" c:identifier="webkit_dom_dom_implementation_has_feature" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -1880,7 +1938,8 @@ submenu of @item is removed.</doc>
       </field>
     </record>
     <class name="DOMDOMSelection" c:symbol-prefix="dom_dom_selection" c:type="WebKitDOMDOMSelection" parent="DOMObject" glib:type-name="WebKitDOMDOMSelection" glib:get-type="webkit_dom_dom_selection_get_type" glib:type-struct="DOMDOMSelectionClass">
-      <method name="add_range" c:identifier="webkit_dom_dom_selection_add_range" version="2.16">
+      <method name="add_range" c:identifier="webkit_dom_dom_selection_add_range" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1895,7 +1954,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="collapse" c:identifier="webkit_dom_dom_selection_collapse" version="2.16">
+      <method name="collapse" c:identifier="webkit_dom_dom_selection_collapse" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1914,7 +1974,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="collapse_to_end" c:identifier="webkit_dom_dom_selection_collapse_to_end" version="2.16" throws="1">
+      <method name="collapse_to_end" c:identifier="webkit_dom_dom_selection_collapse_to_end" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1925,7 +1986,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="collapse_to_start" c:identifier="webkit_dom_dom_selection_collapse_to_start" version="2.16" throws="1">
+      <method name="collapse_to_start" c:identifier="webkit_dom_dom_selection_collapse_to_start" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1936,7 +1998,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="contains_node" c:identifier="webkit_dom_dom_selection_contains_node" version="2.16">
+      <method name="contains_node" c:identifier="webkit_dom_dom_selection_contains_node" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -1956,7 +2019,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="delete_from_document" c:identifier="webkit_dom_dom_selection_delete_from_document" version="2.16">
+      <method name="delete_from_document" c:identifier="webkit_dom_dom_selection_delete_from_document" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1967,7 +2031,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="empty" c:identifier="webkit_dom_dom_selection_empty" version="2.16">
+      <method name="empty" c:identifier="webkit_dom_dom_selection_empty" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1978,7 +2043,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="extend" c:identifier="webkit_dom_dom_selection_extend" version="2.16" throws="1">
+      <method name="extend" c:identifier="webkit_dom_dom_selection_extend" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1997,7 +2063,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_anchor_node" c:identifier="webkit_dom_dom_selection_get_anchor_node" version="2.16">
+      <method name="get_anchor_node" c:identifier="webkit_dom_dom_selection_get_anchor_node" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -2009,7 +2076,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_anchor_offset" c:identifier="webkit_dom_dom_selection_get_anchor_offset" version="2.16">
+      <method name="get_anchor_offset" c:identifier="webkit_dom_dom_selection_get_anchor_offset" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -2021,7 +2089,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_base_node" c:identifier="webkit_dom_dom_selection_get_base_node" version="2.16">
+      <method name="get_base_node" c:identifier="webkit_dom_dom_selection_get_base_node" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -2033,7 +2102,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_base_offset" c:identifier="webkit_dom_dom_selection_get_base_offset" version="2.16">
+      <method name="get_base_offset" c:identifier="webkit_dom_dom_selection_get_base_offset" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -2045,7 +2115,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_extent_node" c:identifier="webkit_dom_dom_selection_get_extent_node" version="2.16">
+      <method name="get_extent_node" c:identifier="webkit_dom_dom_selection_get_extent_node" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -2057,7 +2128,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_extent_offset" c:identifier="webkit_dom_dom_selection_get_extent_offset" version="2.16">
+      <method name="get_extent_offset" c:identifier="webkit_dom_dom_selection_get_extent_offset" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -2069,7 +2141,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_focus_node" c:identifier="webkit_dom_dom_selection_get_focus_node" version="2.16">
+      <method name="get_focus_node" c:identifier="webkit_dom_dom_selection_get_focus_node" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -2081,7 +2154,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_focus_offset" c:identifier="webkit_dom_dom_selection_get_focus_offset" version="2.16">
+      <method name="get_focus_offset" c:identifier="webkit_dom_dom_selection_get_focus_offset" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -2093,7 +2167,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_is_collapsed" c:identifier="webkit_dom_dom_selection_get_is_collapsed" version="2.16">
+      <method name="get_is_collapsed" c:identifier="webkit_dom_dom_selection_get_is_collapsed" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -2105,7 +2180,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_range_at" c:identifier="webkit_dom_dom_selection_get_range_at" version="2.16" throws="1">
+      <method name="get_range_at" c:identifier="webkit_dom_dom_selection_get_range_at" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMRange</doc>
           <type name="DOMRange" c:type="WebKitDOMRange*"/>
@@ -2121,7 +2197,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_range_count" c:identifier="webkit_dom_dom_selection_get_range_count" version="2.16">
+      <method name="get_range_count" c:identifier="webkit_dom_dom_selection_get_range_count" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -2133,7 +2210,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_selection_type" c:identifier="webkit_dom_dom_selection_get_selection_type" version="2.16">
+      <method name="get_selection_type" c:identifier="webkit_dom_dom_selection_get_selection_type" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -2145,7 +2223,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="modify" c:identifier="webkit_dom_dom_selection_modify" version="2.16">
+      <method name="modify" c:identifier="webkit_dom_dom_selection_modify" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2168,7 +2247,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="remove_all_ranges" c:identifier="webkit_dom_dom_selection_remove_all_ranges" version="2.16">
+      <method name="remove_all_ranges" c:identifier="webkit_dom_dom_selection_remove_all_ranges" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2179,7 +2259,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="select_all_children" c:identifier="webkit_dom_dom_selection_select_all_children" version="2.16">
+      <method name="select_all_children" c:identifier="webkit_dom_dom_selection_select_all_children" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2194,7 +2275,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_base_and_extent" c:identifier="webkit_dom_dom_selection_set_base_and_extent" version="2.16">
+      <method name="set_base_and_extent" c:identifier="webkit_dom_dom_selection_set_base_and_extent" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2221,7 +2303,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_position" c:identifier="webkit_dom_dom_selection_set_position" version="2.16">
+      <method name="set_position" c:identifier="webkit_dom_dom_selection_set_position" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2283,7 +2366,8 @@ submenu of @item is removed.</doc>
       </field>
     </record>
     <class name="DOMDOMTokenList" c:symbol-prefix="dom_dom_token_list" c:type="WebKitDOMDOMTokenList" parent="DOMObject" glib:type-name="WebKitDOMDOMTokenList" glib:get-type="webkit_dom_dom_token_list_get_type" glib:type-struct="DOMDOMTokenListClass">
-      <method name="add" c:identifier="webkit_dom_dom_token_list_add" version="2.16" introspectable="0">
+      <method name="add" c:identifier="webkit_dom_dom_token_list_add" version="2.16" introspectable="0" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2302,7 +2386,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="contains" c:identifier="webkit_dom_dom_token_list_contains" version="2.16">
+      <method name="contains" c:identifier="webkit_dom_dom_token_list_contains" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -2318,7 +2403,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_length" c:identifier="webkit_dom_dom_token_list_get_length" version="2.16">
+      <method name="get_length" c:identifier="webkit_dom_dom_token_list_get_length" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -2330,7 +2416,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_value" c:identifier="webkit_dom_dom_token_list_get_value" version="2.16">
+      <method name="get_value" c:identifier="webkit_dom_dom_token_list_get_value" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -2342,7 +2429,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="item" c:identifier="webkit_dom_dom_token_list_item" version="2.16">
+      <method name="item" c:identifier="webkit_dom_dom_token_list_item" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -2358,7 +2446,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="remove" c:identifier="webkit_dom_dom_token_list_remove" version="2.16" introspectable="0">
+      <method name="remove" c:identifier="webkit_dom_dom_token_list_remove" version="2.16" introspectable="0" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2377,7 +2466,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="replace" c:identifier="webkit_dom_dom_token_list_replace" version="2.16" throws="1">
+      <method name="replace" c:identifier="webkit_dom_dom_token_list_replace" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2396,7 +2486,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_value" c:identifier="webkit_dom_dom_token_list_set_value" version="2.16">
+      <method name="set_value" c:identifier="webkit_dom_dom_token_list_set_value" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2411,7 +2502,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="toggle" c:identifier="webkit_dom_dom_token_list_toggle" version="2.16" throws="1">
+      <method name="toggle" c:identifier="webkit_dom_dom_token_list_toggle" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -2448,7 +2540,8 @@ submenu of @item is removed.</doc>
     </record>
     <class name="DOMDOMWindow" c:symbol-prefix="dom_dom_window" c:type="WebKitDOMDOMWindow" parent="DOMObject" glib:type-name="WebKitDOMDOMWindow" glib:get-type="webkit_dom_dom_window_get_type" glib:type-struct="DOMDOMWindowClass">
       <implements name="DOMEventTarget"/>
-      <method name="alert" c:identifier="webkit_dom_dom_window_alert" version="2.16">
+      <method name="alert" c:identifier="webkit_dom_dom_window_alert" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2463,7 +2556,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="blur" c:identifier="webkit_dom_dom_window_blur" version="2.16">
+      <method name="blur" c:identifier="webkit_dom_dom_window_blur" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2474,7 +2568,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="capture_events" c:identifier="webkit_dom_dom_window_capture_events" version="2.16">
+      <method name="capture_events" c:identifier="webkit_dom_dom_window_capture_events" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2485,7 +2580,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="close" c:identifier="webkit_dom_dom_window_close" version="2.16">
+      <method name="close" c:identifier="webkit_dom_dom_window_close" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2496,7 +2592,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="confirm" c:identifier="webkit_dom_dom_window_confirm" version="2.16">
+      <method name="confirm" c:identifier="webkit_dom_dom_window_confirm" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -2512,7 +2609,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="find" c:identifier="webkit_dom_dom_window_find" version="2.16">
+      <method name="find" c:identifier="webkit_dom_dom_window_find" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -2552,7 +2650,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="focus" c:identifier="webkit_dom_dom_window_focus" version="2.16">
+      <method name="focus" c:identifier="webkit_dom_dom_window_focus" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2563,7 +2662,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_closed" c:identifier="webkit_dom_dom_window_get_closed" version="2.16">
+      <method name="get_closed" c:identifier="webkit_dom_dom_window_get_closed" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -2575,7 +2675,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_computed_style" c:identifier="webkit_dom_dom_window_get_computed_style" version="2.16">
+      <method name="get_computed_style" c:identifier="webkit_dom_dom_window_get_computed_style" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMCSSStyleDeclaration</doc>
           <type name="DOMCSSStyleDeclaration" c:type="WebKitDOMCSSStyleDeclaration*"/>
@@ -2595,7 +2696,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_default_status" c:identifier="webkit_dom_dom_window_get_default_status" version="2.16">
+      <method name="get_default_status" c:identifier="webkit_dom_dom_window_get_default_status" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -2607,7 +2709,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_device_pixel_ratio" c:identifier="webkit_dom_dom_window_get_device_pixel_ratio" version="2.16">
+      <method name="get_device_pixel_ratio" c:identifier="webkit_dom_dom_window_get_device_pixel_ratio" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gdouble</doc>
           <type name="gdouble" c:type="gdouble"/>
@@ -2619,7 +2722,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_document" c:identifier="webkit_dom_dom_window_get_document" version="2.16">
+      <method name="get_document" c:identifier="webkit_dom_dom_window_get_document" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMDocument</doc>
           <type name="DOMDocument" c:type="WebKitDOMDocument*"/>
@@ -2631,7 +2735,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_frame_element" c:identifier="webkit_dom_dom_window_get_frame_element" version="2.16">
+      <method name="get_frame_element" c:identifier="webkit_dom_dom_window_get_frame_element" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -2643,7 +2748,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_frames" c:identifier="webkit_dom_dom_window_get_frames" version="2.16">
+      <method name="get_frames" c:identifier="webkit_dom_dom_window_get_frames" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMDOMWindow</doc>
           <type name="DOMDOMWindow" c:type="WebKitDOMDOMWindow*"/>
@@ -2655,7 +2761,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_inner_height" c:identifier="webkit_dom_dom_window_get_inner_height" version="2.16">
+      <method name="get_inner_height" c:identifier="webkit_dom_dom_window_get_inner_height" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -2667,7 +2774,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_inner_width" c:identifier="webkit_dom_dom_window_get_inner_width" version="2.16">
+      <method name="get_inner_width" c:identifier="webkit_dom_dom_window_get_inner_width" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -2679,7 +2787,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_length" c:identifier="webkit_dom_dom_window_get_length" version="2.16">
+      <method name="get_length" c:identifier="webkit_dom_dom_window_get_length" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -2691,7 +2800,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_dom_window_get_name" version="2.16">
+      <method name="get_name" c:identifier="webkit_dom_dom_window_get_name" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -2703,7 +2813,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_offscreen_buffering" c:identifier="webkit_dom_dom_window_get_offscreen_buffering" version="2.16">
+      <method name="get_offscreen_buffering" c:identifier="webkit_dom_dom_window_get_offscreen_buffering" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -2715,7 +2826,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_opener" c:identifier="webkit_dom_dom_window_get_opener" version="2.16">
+      <method name="get_opener" c:identifier="webkit_dom_dom_window_get_opener" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMDOMWindow</doc>
           <type name="DOMDOMWindow" c:type="WebKitDOMDOMWindow*"/>
@@ -2727,7 +2839,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_orientation" c:identifier="webkit_dom_dom_window_get_orientation" version="2.16">
+      <method name="get_orientation" c:identifier="webkit_dom_dom_window_get_orientation" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -2739,7 +2852,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_outer_height" c:identifier="webkit_dom_dom_window_get_outer_height" version="2.16">
+      <method name="get_outer_height" c:identifier="webkit_dom_dom_window_get_outer_height" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -2751,7 +2865,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_outer_width" c:identifier="webkit_dom_dom_window_get_outer_width" version="2.16">
+      <method name="get_outer_width" c:identifier="webkit_dom_dom_window_get_outer_width" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -2763,7 +2878,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_page_x_offset" c:identifier="webkit_dom_dom_window_get_page_x_offset" version="2.16">
+      <method name="get_page_x_offset" c:identifier="webkit_dom_dom_window_get_page_x_offset" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -2775,7 +2891,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_page_y_offset" c:identifier="webkit_dom_dom_window_get_page_y_offset" version="2.16">
+      <method name="get_page_y_offset" c:identifier="webkit_dom_dom_window_get_page_y_offset" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -2787,7 +2904,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_parent" c:identifier="webkit_dom_dom_window_get_parent" version="2.16">
+      <method name="get_parent" c:identifier="webkit_dom_dom_window_get_parent" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMDOMWindow</doc>
           <type name="DOMDOMWindow" c:type="WebKitDOMDOMWindow*"/>
@@ -2799,7 +2917,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_screen_left" c:identifier="webkit_dom_dom_window_get_screen_left" version="2.16">
+      <method name="get_screen_left" c:identifier="webkit_dom_dom_window_get_screen_left" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -2811,7 +2930,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_screen_top" c:identifier="webkit_dom_dom_window_get_screen_top" version="2.16">
+      <method name="get_screen_top" c:identifier="webkit_dom_dom_window_get_screen_top" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -2823,7 +2943,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_screen_x" c:identifier="webkit_dom_dom_window_get_screen_x" version="2.16">
+      <method name="get_screen_x" c:identifier="webkit_dom_dom_window_get_screen_x" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -2835,7 +2956,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_screen_y" c:identifier="webkit_dom_dom_window_get_screen_y" version="2.16">
+      <method name="get_screen_y" c:identifier="webkit_dom_dom_window_get_screen_y" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -2847,7 +2969,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_scroll_x" c:identifier="webkit_dom_dom_window_get_scroll_x" version="2.16">
+      <method name="get_scroll_x" c:identifier="webkit_dom_dom_window_get_scroll_x" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -2859,7 +2982,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_scroll_y" c:identifier="webkit_dom_dom_window_get_scroll_y" version="2.16">
+      <method name="get_scroll_y" c:identifier="webkit_dom_dom_window_get_scroll_y" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -2871,7 +2995,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_selection" c:identifier="webkit_dom_dom_window_get_selection" version="2.16">
+      <method name="get_selection" c:identifier="webkit_dom_dom_window_get_selection" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMDOMSelection</doc>
           <type name="DOMDOMSelection" c:type="WebKitDOMDOMSelection*"/>
@@ -2883,7 +3008,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_self" c:identifier="webkit_dom_dom_window_get_self" version="2.16">
+      <method name="get_self" c:identifier="webkit_dom_dom_window_get_self" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMDOMWindow</doc>
           <type name="DOMDOMWindow" c:type="WebKitDOMDOMWindow*"/>
@@ -2895,7 +3021,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_status" c:identifier="webkit_dom_dom_window_get_status" version="2.16">
+      <method name="get_status" c:identifier="webkit_dom_dom_window_get_status" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -2907,7 +3034,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_top" c:identifier="webkit_dom_dom_window_get_top" version="2.16">
+      <method name="get_top" c:identifier="webkit_dom_dom_window_get_top" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMDOMWindow</doc>
           <type name="DOMDOMWindow" c:type="WebKitDOMDOMWindow*"/>
@@ -2919,7 +3047,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_window" c:identifier="webkit_dom_dom_window_get_window" version="2.16">
+      <method name="get_window" c:identifier="webkit_dom_dom_window_get_window" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMDOMWindow</doc>
           <type name="DOMDOMWindow" c:type="WebKitDOMDOMWindow*"/>
@@ -2931,7 +3060,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="move_by" c:identifier="webkit_dom_dom_window_move_by" version="2.16">
+      <method name="move_by" c:identifier="webkit_dom_dom_window_move_by" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2950,7 +3080,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="move_to" c:identifier="webkit_dom_dom_window_move_to" version="2.16">
+      <method name="move_to" c:identifier="webkit_dom_dom_window_move_to" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2969,7 +3100,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="print" c:identifier="webkit_dom_dom_window_print" version="2.16">
+      <method name="print" c:identifier="webkit_dom_dom_window_print" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -2980,7 +3112,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="prompt" c:identifier="webkit_dom_dom_window_prompt" version="2.16">
+      <method name="prompt" c:identifier="webkit_dom_dom_window_prompt" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -3000,7 +3133,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="release_events" c:identifier="webkit_dom_dom_window_release_events" version="2.16">
+      <method name="release_events" c:identifier="webkit_dom_dom_window_release_events" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -3011,7 +3145,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="resize_by" c:identifier="webkit_dom_dom_window_resize_by" version="2.16">
+      <method name="resize_by" c:identifier="webkit_dom_dom_window_resize_by" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -3030,7 +3165,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="resize_to" c:identifier="webkit_dom_dom_window_resize_to" version="2.16">
+      <method name="resize_to" c:identifier="webkit_dom_dom_window_resize_to" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -3049,7 +3185,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="scroll_by" c:identifier="webkit_dom_dom_window_scroll_by" version="2.16">
+      <method name="scroll_by" c:identifier="webkit_dom_dom_window_scroll_by" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -3068,7 +3205,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="scroll_to" c:identifier="webkit_dom_dom_window_scroll_to" version="2.16">
+      <method name="scroll_to" c:identifier="webkit_dom_dom_window_scroll_to" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -3087,7 +3225,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_default_status" c:identifier="webkit_dom_dom_window_set_default_status" version="2.16">
+      <method name="set_default_status" c:identifier="webkit_dom_dom_window_set_default_status" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -3102,7 +3241,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_dom_window_set_name" version="2.16">
+      <method name="set_name" c:identifier="webkit_dom_dom_window_set_name" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -3117,7 +3257,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_status" c:identifier="webkit_dom_dom_window_set_status" version="2.16">
+      <method name="set_status" c:identifier="webkit_dom_dom_window_set_status" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -3132,7 +3273,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="stop" c:identifier="webkit_dom_dom_window_stop" version="2.16">
+      <method name="stop" c:identifier="webkit_dom_dom_window_stop" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -3254,7 +3396,8 @@ submenu of @item is removed.</doc>
     </record>
     <class name="DOMDocument" c:symbol-prefix="dom_document" c:type="WebKitDOMDocument" parent="DOMNode" glib:type-name="WebKitDOMDocument" glib:get-type="webkit_dom_document_get_type" glib:type-struct="DOMDocumentClass">
       <implements name="DOMEventTarget"/>
-      <method name="adopt_node" c:identifier="webkit_dom_document_adopt_node" throws="1">
+      <method name="adopt_node" c:identifier="webkit_dom_document_adopt_node" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -3270,7 +3413,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="caret_range_from_point" c:identifier="webkit_dom_document_caret_range_from_point" version="2.16">
+      <method name="caret_range_from_point" c:identifier="webkit_dom_document_caret_range_from_point" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMRange</doc>
           <type name="DOMRange" c:type="WebKitDOMRange*"/>
@@ -3290,7 +3434,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_attribute" c:identifier="webkit_dom_document_create_attribute" throws="1">
+      <method name="create_attribute" c:identifier="webkit_dom_document_create_attribute" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMAttr</doc>
           <type name="DOMAttr" c:type="WebKitDOMAttr*"/>
@@ -3306,7 +3451,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_attribute_ns" c:identifier="webkit_dom_document_create_attribute_ns" throws="1">
+      <method name="create_attribute_ns" c:identifier="webkit_dom_document_create_attribute_ns" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMAttr</doc>
           <type name="DOMAttr" c:type="WebKitDOMAttr*"/>
@@ -3326,7 +3472,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_cdata_section" c:identifier="webkit_dom_document_create_cdata_section" throws="1">
+      <method name="create_cdata_section" c:identifier="webkit_dom_document_create_cdata_section" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMCDATASection</doc>
           <type name="DOMCDATASection" c:type="WebKitDOMCDATASection*"/>
@@ -3342,7 +3489,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_comment" c:identifier="webkit_dom_document_create_comment">
+      <method name="create_comment" c:identifier="webkit_dom_document_create_comment" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMComment</doc>
           <type name="DOMComment" c:type="WebKitDOMComment*"/>
@@ -3358,7 +3506,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_css_style_declaration" c:identifier="webkit_dom_document_create_css_style_declaration">
+      <method name="create_css_style_declaration" c:identifier="webkit_dom_document_create_css_style_declaration" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMCSSStyleDeclaration</doc>
           <type name="DOMCSSStyleDeclaration" c:type="WebKitDOMCSSStyleDeclaration*"/>
@@ -3370,7 +3519,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="create_document_fragment" c:identifier="webkit_dom_document_create_document_fragment">
+      <method name="create_document_fragment" c:identifier="webkit_dom_document_create_document_fragment" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMDocumentFragment</doc>
           <type name="DOMDocumentFragment" c:type="WebKitDOMDocumentFragment*"/>
@@ -3382,7 +3532,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="create_element" c:identifier="webkit_dom_document_create_element" throws="1">
+      <method name="create_element" c:identifier="webkit_dom_document_create_element" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -3398,7 +3549,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_element_ns" c:identifier="webkit_dom_document_create_element_ns" throws="1">
+      <method name="create_element_ns" c:identifier="webkit_dom_document_create_element_ns" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -3435,7 +3587,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_event" c:identifier="webkit_dom_document_create_event" throws="1">
+      <method name="create_event" c:identifier="webkit_dom_document_create_event" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMEvent</doc>
           <type name="DOMEvent" c:type="WebKitDOMEvent*"/>
@@ -3451,7 +3604,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_expression" c:identifier="webkit_dom_document_create_expression" throws="1">
+      <method name="create_expression" c:identifier="webkit_dom_document_create_expression" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMXPathExpression</doc>
           <type name="DOMXPathExpression" c:type="WebKitDOMXPathExpression*"/>
@@ -3471,7 +3625,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_node_iterator" c:identifier="webkit_dom_document_create_node_iterator" throws="1">
+      <method name="create_node_iterator" c:identifier="webkit_dom_document_create_node_iterator" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMNodeIterator</doc>
           <type name="DOMNodeIterator" c:type="WebKitDOMNodeIterator*"/>
@@ -3499,7 +3654,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_ns_resolver" c:identifier="webkit_dom_document_create_ns_resolver">
+      <method name="create_ns_resolver" c:identifier="webkit_dom_document_create_ns_resolver" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMXPathNSResolver</doc>
           <type name="DOMXPathNSResolver" c:type="WebKitDOMXPathNSResolver*"/>
@@ -3515,7 +3671,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_processing_instruction" c:identifier="webkit_dom_document_create_processing_instruction" throws="1">
+      <method name="create_processing_instruction" c:identifier="webkit_dom_document_create_processing_instruction" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMProcessingInstruction</doc>
           <type name="DOMProcessingInstruction" c:type="WebKitDOMProcessingInstruction*"/>
@@ -3535,7 +3692,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_range" c:identifier="webkit_dom_document_create_range">
+      <method name="create_range" c:identifier="webkit_dom_document_create_range" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMRange</doc>
           <type name="DOMRange" c:type="WebKitDOMRange*"/>
@@ -3547,7 +3705,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="create_text_node" c:identifier="webkit_dom_document_create_text_node">
+      <method name="create_text_node" c:identifier="webkit_dom_document_create_text_node" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMText</doc>
           <type name="DOMText" c:type="WebKitDOMText*"/>
@@ -3563,7 +3722,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_tree_walker" c:identifier="webkit_dom_document_create_tree_walker" throws="1">
+      <method name="create_tree_walker" c:identifier="webkit_dom_document_create_tree_walker" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMTreeWalker</doc>
           <type name="DOMTreeWalker" c:type="WebKitDOMTreeWalker*"/>
@@ -3591,7 +3751,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="element_from_point" c:identifier="webkit_dom_document_element_from_point">
+      <method name="element_from_point" c:identifier="webkit_dom_document_element_from_point" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -3611,7 +3772,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="evaluate" c:identifier="webkit_dom_document_evaluate" throws="1">
+      <method name="evaluate" c:identifier="webkit_dom_document_evaluate" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMXPathResult</doc>
           <type name="DOMXPathResult" c:type="WebKitDOMXPathResult*"/>
@@ -3643,7 +3805,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="exec_command" c:identifier="webkit_dom_document_exec_command">
+      <method name="exec_command" c:identifier="webkit_dom_document_exec_command" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -3667,7 +3830,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="exit_pointer_lock" c:identifier="webkit_dom_document_exit_pointer_lock" version="2.16">
+      <method name="exit_pointer_lock" c:identifier="webkit_dom_document_exit_pointer_lock" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -3678,7 +3842,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_active_element" c:identifier="webkit_dom_document_get_active_element">
+      <method name="get_active_element" c:identifier="webkit_dom_document_get_active_element" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -3690,7 +3855,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_anchors" c:identifier="webkit_dom_document_get_anchors">
+      <method name="get_anchors" c:identifier="webkit_dom_document_get_anchors" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -3702,7 +3868,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_applets" c:identifier="webkit_dom_document_get_applets">
+      <method name="get_applets" c:identifier="webkit_dom_document_get_applets" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -3714,7 +3881,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_body" c:identifier="webkit_dom_document_get_body">
+      <method name="get_body" c:identifier="webkit_dom_document_get_body" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLElement</doc>
           <type name="DOMHTMLElement" c:type="WebKitDOMHTMLElement*"/>
@@ -3726,7 +3894,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_character_set" c:identifier="webkit_dom_document_get_character_set">
+      <method name="get_character_set" c:identifier="webkit_dom_document_get_character_set" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -3738,7 +3907,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_charset" c:identifier="webkit_dom_document_get_charset">
+      <method name="get_charset" c:identifier="webkit_dom_document_get_charset" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -3750,7 +3920,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_child_element_count" c:identifier="webkit_dom_document_get_child_element_count" version="2.16">
+      <method name="get_child_element_count" c:identifier="webkit_dom_document_get_child_element_count" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -3762,7 +3933,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_children" c:identifier="webkit_dom_document_get_children" version="2.16">
+      <method name="get_children" c:identifier="webkit_dom_document_get_children" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -3774,7 +3946,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_compat_mode" c:identifier="webkit_dom_document_get_compat_mode" version="2.14">
+      <method name="get_compat_mode" c:identifier="webkit_dom_document_get_compat_mode" version="2.14" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -3786,7 +3959,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_content_type" c:identifier="webkit_dom_document_get_content_type" version="2.16">
+      <method name="get_content_type" c:identifier="webkit_dom_document_get_content_type" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -3798,7 +3972,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_cookie" c:identifier="webkit_dom_document_get_cookie" throws="1">
+      <method name="get_cookie" c:identifier="webkit_dom_document_get_cookie" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -3810,7 +3985,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_current_script" c:identifier="webkit_dom_document_get_current_script" version="2.16">
+      <method name="get_current_script" c:identifier="webkit_dom_document_get_current_script" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLScriptElement</doc>
           <type name="DOMHTMLScriptElement" c:type="WebKitDOMHTMLScriptElement*"/>
@@ -3834,7 +4010,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_default_view" c:identifier="webkit_dom_document_get_default_view">
+      <method name="get_default_view" c:identifier="webkit_dom_document_get_default_view" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMDOMWindow</doc>
           <type name="DOMDOMWindow" c:type="WebKitDOMDOMWindow*"/>
@@ -3846,7 +4023,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_design_mode" c:identifier="webkit_dom_document_get_design_mode" version="2.14">
+      <method name="get_design_mode" c:identifier="webkit_dom_document_get_design_mode" version="2.14" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -3858,7 +4036,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_dir" c:identifier="webkit_dom_document_get_dir" version="2.16">
+      <method name="get_dir" c:identifier="webkit_dom_document_get_dir" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -3870,7 +4049,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_doctype" c:identifier="webkit_dom_document_get_doctype">
+      <method name="get_doctype" c:identifier="webkit_dom_document_get_doctype" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMDocumentType</doc>
           <type name="DOMDocumentType" c:type="WebKitDOMDocumentType*"/>
@@ -3882,7 +4062,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_document_element" c:identifier="webkit_dom_document_get_document_element">
+      <method name="get_document_element" c:identifier="webkit_dom_document_get_document_element" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -3894,7 +4075,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_document_uri" c:identifier="webkit_dom_document_get_document_uri">
+      <method name="get_document_uri" c:identifier="webkit_dom_document_get_document_uri" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -3906,7 +4088,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_domain" c:identifier="webkit_dom_document_get_domain">
+      <method name="get_domain" c:identifier="webkit_dom_document_get_domain" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -3918,7 +4101,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_element_by_id" c:identifier="webkit_dom_document_get_element_by_id">
+      <method name="get_element_by_id" c:identifier="webkit_dom_document_get_element_by_id" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -3951,7 +4135,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_elements_by_class_name_as_html_collection" c:identifier="webkit_dom_document_get_elements_by_class_name_as_html_collection" version="2.12">
+      <method name="get_elements_by_class_name_as_html_collection" c:identifier="webkit_dom_document_get_elements_by_class_name_as_html_collection" version="2.12" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -3967,7 +4152,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_elements_by_name" c:identifier="webkit_dom_document_get_elements_by_name">
+      <method name="get_elements_by_name" c:identifier="webkit_dom_document_get_elements_by_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMNodeList</doc>
           <type name="DOMNodeList" c:type="WebKitDOMNodeList*"/>
@@ -4000,7 +4186,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_elements_by_tag_name_as_html_collection" c:identifier="webkit_dom_document_get_elements_by_tag_name_as_html_collection" version="2.12">
+      <method name="get_elements_by_tag_name_as_html_collection" c:identifier="webkit_dom_document_get_elements_by_tag_name_as_html_collection" version="2.12" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -4037,7 +4224,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_elements_by_tag_name_ns_as_html_collection" c:identifier="webkit_dom_document_get_elements_by_tag_name_ns_as_html_collection" version="2.12">
+      <method name="get_elements_by_tag_name_ns_as_html_collection" c:identifier="webkit_dom_document_get_elements_by_tag_name_ns_as_html_collection" version="2.12" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -4057,7 +4245,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_embeds" c:identifier="webkit_dom_document_get_embeds" version="2.14">
+      <method name="get_embeds" c:identifier="webkit_dom_document_get_embeds" version="2.14" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -4069,7 +4258,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_first_element_child" c:identifier="webkit_dom_document_get_first_element_child" version="2.16">
+      <method name="get_first_element_child" c:identifier="webkit_dom_document_get_first_element_child" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -4081,7 +4271,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_forms" c:identifier="webkit_dom_document_get_forms">
+      <method name="get_forms" c:identifier="webkit_dom_document_get_forms" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -4093,7 +4284,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_head" c:identifier="webkit_dom_document_get_head">
+      <method name="get_head" c:identifier="webkit_dom_document_get_head" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLHeadElement</doc>
           <type name="DOMHTMLHeadElement" c:type="WebKitDOMHTMLHeadElement*"/>
@@ -4105,7 +4297,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_hidden" c:identifier="webkit_dom_document_get_hidden" version="2.16">
+      <method name="get_hidden" c:identifier="webkit_dom_document_get_hidden" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -4117,7 +4310,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_images" c:identifier="webkit_dom_document_get_images">
+      <method name="get_images" c:identifier="webkit_dom_document_get_images" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -4129,7 +4323,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_implementation" c:identifier="webkit_dom_document_get_implementation">
+      <method name="get_implementation" c:identifier="webkit_dom_document_get_implementation" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMDOMImplementation</doc>
           <type name="DOMDOMImplementation" c:type="WebKitDOMDOMImplementation*"/>
@@ -4141,7 +4336,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_input_encoding" c:identifier="webkit_dom_document_get_input_encoding">
+      <method name="get_input_encoding" c:identifier="webkit_dom_document_get_input_encoding" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -4153,7 +4349,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_last_element_child" c:identifier="webkit_dom_document_get_last_element_child" version="2.16">
+      <method name="get_last_element_child" c:identifier="webkit_dom_document_get_last_element_child" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -4165,7 +4362,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_last_modified" c:identifier="webkit_dom_document_get_last_modified">
+      <method name="get_last_modified" c:identifier="webkit_dom_document_get_last_modified" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -4177,7 +4375,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_links" c:identifier="webkit_dom_document_get_links">
+      <method name="get_links" c:identifier="webkit_dom_document_get_links" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -4189,7 +4388,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_origin" c:identifier="webkit_dom_document_get_origin" version="2.16">
+      <method name="get_origin" c:identifier="webkit_dom_document_get_origin" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -4201,7 +4401,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_override_style" c:identifier="webkit_dom_document_get_override_style">
+      <method name="get_override_style" c:identifier="webkit_dom_document_get_override_style" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMCSSStyleDeclaration</doc>
           <type name="DOMCSSStyleDeclaration" c:type="WebKitDOMCSSStyleDeclaration*"/>
@@ -4221,7 +4422,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_plugins" c:identifier="webkit_dom_document_get_plugins" version="2.14">
+      <method name="get_plugins" c:identifier="webkit_dom_document_get_plugins" version="2.14" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -4233,7 +4435,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_pointer_lock_element" c:identifier="webkit_dom_document_get_pointer_lock_element" version="2.16">
+      <method name="get_pointer_lock_element" c:identifier="webkit_dom_document_get_pointer_lock_element" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -4245,7 +4448,9 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_preferred_stylesheet_set" c:identifier="webkit_dom_document_get_preferred_stylesheet_set">
+      <method name="get_preferred_stylesheet_set" c:identifier="webkit_dom_document_get_preferred_stylesheet_set" deprecated="1" deprecated-version="2.22">
+        <doc xml:space="preserve">This function has been removed and does nothing.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -4257,7 +4462,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_ready_state" c:identifier="webkit_dom_document_get_ready_state">
+      <method name="get_ready_state" c:identifier="webkit_dom_document_get_ready_state" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -4269,7 +4475,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_referrer" c:identifier="webkit_dom_document_get_referrer">
+      <method name="get_referrer" c:identifier="webkit_dom_document_get_referrer" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -4281,7 +4488,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_scripts" c:identifier="webkit_dom_document_get_scripts" version="2.14">
+      <method name="get_scripts" c:identifier="webkit_dom_document_get_scripts" version="2.14" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -4293,7 +4501,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_scrolling_element" c:identifier="webkit_dom_document_get_scrolling_element" version="2.16">
+      <method name="get_scrolling_element" c:identifier="webkit_dom_document_get_scrolling_element" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -4305,7 +4514,9 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_selected_stylesheet_set" c:identifier="webkit_dom_document_get_selected_stylesheet_set">
+      <method name="get_selected_stylesheet_set" c:identifier="webkit_dom_document_get_selected_stylesheet_set" deprecated="1" deprecated-version="2.22">
+        <doc xml:space="preserve">This function has been removed and does nothing.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -4317,7 +4528,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_style_sheets" c:identifier="webkit_dom_document_get_style_sheets">
+      <method name="get_style_sheets" c:identifier="webkit_dom_document_get_style_sheets" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMStyleSheetList</doc>
           <type name="DOMStyleSheetList" c:type="WebKitDOMStyleSheetList*"/>
@@ -4329,7 +4541,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_title" c:identifier="webkit_dom_document_get_title">
+      <method name="get_title" c:identifier="webkit_dom_document_get_title" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -4341,7 +4554,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_url" c:identifier="webkit_dom_document_get_url">
+      <method name="get_url" c:identifier="webkit_dom_document_get_url" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -4353,7 +4567,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_visibility_state" c:identifier="webkit_dom_document_get_visibility_state" version="2.16">
+      <method name="get_visibility_state" c:identifier="webkit_dom_document_get_visibility_state" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -4365,7 +4580,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_webkit_current_fullscreen_element" c:identifier="webkit_dom_document_get_webkit_current_fullscreen_element" version="2.16">
+      <method name="get_webkit_current_fullscreen_element" c:identifier="webkit_dom_document_get_webkit_current_fullscreen_element" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -4377,7 +4593,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_webkit_fullscreen_element" c:identifier="webkit_dom_document_get_webkit_fullscreen_element" version="2.16">
+      <method name="get_webkit_fullscreen_element" c:identifier="webkit_dom_document_get_webkit_fullscreen_element" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -4389,7 +4606,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_webkit_fullscreen_enabled" c:identifier="webkit_dom_document_get_webkit_fullscreen_enabled" version="2.16">
+      <method name="get_webkit_fullscreen_enabled" c:identifier="webkit_dom_document_get_webkit_fullscreen_enabled" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -4401,7 +4619,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_webkit_fullscreen_keyboard_input_allowed" c:identifier="webkit_dom_document_get_webkit_fullscreen_keyboard_input_allowed" version="2.16">
+      <method name="get_webkit_fullscreen_keyboard_input_allowed" c:identifier="webkit_dom_document_get_webkit_fullscreen_keyboard_input_allowed" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -4413,7 +4632,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_webkit_is_fullscreen" c:identifier="webkit_dom_document_get_webkit_is_fullscreen" version="2.16">
+      <method name="get_webkit_is_fullscreen" c:identifier="webkit_dom_document_get_webkit_is_fullscreen" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -4425,7 +4645,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_xml_encoding" c:identifier="webkit_dom_document_get_xml_encoding">
+      <method name="get_xml_encoding" c:identifier="webkit_dom_document_get_xml_encoding" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -4437,7 +4658,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_xml_standalone" c:identifier="webkit_dom_document_get_xml_standalone">
+      <method name="get_xml_standalone" c:identifier="webkit_dom_document_get_xml_standalone" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -4449,7 +4671,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_xml_version" c:identifier="webkit_dom_document_get_xml_version">
+      <method name="get_xml_version" c:identifier="webkit_dom_document_get_xml_version" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -4461,7 +4684,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="has_focus" c:identifier="webkit_dom_document_has_focus">
+      <method name="has_focus" c:identifier="webkit_dom_document_has_focus" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -4473,7 +4697,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="import_node" c:identifier="webkit_dom_document_import_node" throws="1">
+      <method name="import_node" c:identifier="webkit_dom_document_import_node" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -4493,7 +4718,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="query_command_enabled" c:identifier="webkit_dom_document_query_command_enabled">
+      <method name="query_command_enabled" c:identifier="webkit_dom_document_query_command_enabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -4509,7 +4735,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="query_command_indeterm" c:identifier="webkit_dom_document_query_command_indeterm">
+      <method name="query_command_indeterm" c:identifier="webkit_dom_document_query_command_indeterm" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -4525,7 +4752,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="query_command_state" c:identifier="webkit_dom_document_query_command_state">
+      <method name="query_command_state" c:identifier="webkit_dom_document_query_command_state" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -4541,7 +4769,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="query_command_supported" c:identifier="webkit_dom_document_query_command_supported">
+      <method name="query_command_supported" c:identifier="webkit_dom_document_query_command_supported" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -4557,7 +4786,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="query_command_value" c:identifier="webkit_dom_document_query_command_value">
+      <method name="query_command_value" c:identifier="webkit_dom_document_query_command_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -4573,7 +4803,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="query_selector" c:identifier="webkit_dom_document_query_selector" throws="1">
+      <method name="query_selector" c:identifier="webkit_dom_document_query_selector" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -4589,7 +4820,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="query_selector_all" c:identifier="webkit_dom_document_query_selector_all" throws="1">
+      <method name="query_selector_all" c:identifier="webkit_dom_document_query_selector_all" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMNodeList</doc>
           <type name="DOMNodeList" c:type="WebKitDOMNodeList*"/>
@@ -4605,7 +4837,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_body" c:identifier="webkit_dom_document_set_body" throws="1">
+      <method name="set_body" c:identifier="webkit_dom_document_set_body" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -4620,7 +4853,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_charset" c:identifier="webkit_dom_document_set_charset">
+      <method name="set_charset" c:identifier="webkit_dom_document_set_charset" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -4635,7 +4869,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_cookie" c:identifier="webkit_dom_document_set_cookie" throws="1">
+      <method name="set_cookie" c:identifier="webkit_dom_document_set_cookie" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -4650,7 +4885,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_design_mode" c:identifier="webkit_dom_document_set_design_mode" version="2.14">
+      <method name="set_design_mode" c:identifier="webkit_dom_document_set_design_mode" version="2.14" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -4665,7 +4901,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_dir" c:identifier="webkit_dom_document_set_dir" version="2.16">
+      <method name="set_dir" c:identifier="webkit_dom_document_set_dir" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -4680,7 +4917,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_document_uri" c:identifier="webkit_dom_document_set_document_uri">
+      <method name="set_document_uri" c:identifier="webkit_dom_document_set_document_uri" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -4695,7 +4933,9 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_selected_stylesheet_set" c:identifier="webkit_dom_document_set_selected_stylesheet_set">
+      <method name="set_selected_stylesheet_set" c:identifier="webkit_dom_document_set_selected_stylesheet_set" deprecated="1" deprecated-version="2.22">
+        <doc xml:space="preserve">This function has been removed and does nothing.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -4710,7 +4950,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_title" c:identifier="webkit_dom_document_set_title">
+      <method name="set_title" c:identifier="webkit_dom_document_set_title" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -4725,7 +4966,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_xml_standalone" c:identifier="webkit_dom_document_set_xml_standalone" throws="1">
+      <method name="set_xml_standalone" c:identifier="webkit_dom_document_set_xml_standalone" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -4740,7 +4982,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_xml_version" c:identifier="webkit_dom_document_set_xml_version" throws="1">
+      <method name="set_xml_version" c:identifier="webkit_dom_document_set_xml_version" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -4755,7 +4998,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="webkit_cancel_fullscreen" c:identifier="webkit_dom_document_webkit_cancel_fullscreen" version="2.16">
+      <method name="webkit_cancel_fullscreen" c:identifier="webkit_dom_document_webkit_cancel_fullscreen" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -4766,7 +5010,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="webkit_exit_fullscreen" c:identifier="webkit_dom_document_webkit_exit_fullscreen" version="2.16">
+      <method name="webkit_exit_fullscreen" c:identifier="webkit_dom_document_webkit_exit_fullscreen" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -4941,7 +5186,8 @@ submenu of @item is removed.</doc>
     </record>
     <class name="DOMDocumentFragment" c:symbol-prefix="dom_document_fragment" c:type="WebKitDOMDocumentFragment" parent="DOMNode" glib:type-name="WebKitDOMDocumentFragment" glib:get-type="webkit_dom_document_fragment_get_type" glib:type-struct="DOMDocumentFragmentClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_child_element_count" c:identifier="webkit_dom_document_fragment_get_child_element_count" version="2.16">
+      <method name="get_child_element_count" c:identifier="webkit_dom_document_fragment_get_child_element_count" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -4953,7 +5199,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_children" c:identifier="webkit_dom_document_fragment_get_children" version="2.16">
+      <method name="get_children" c:identifier="webkit_dom_document_fragment_get_children" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -4965,7 +5212,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_element_by_id" c:identifier="webkit_dom_document_fragment_get_element_by_id" version="2.16">
+      <method name="get_element_by_id" c:identifier="webkit_dom_document_fragment_get_element_by_id" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -4981,7 +5229,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_first_element_child" c:identifier="webkit_dom_document_fragment_get_first_element_child" version="2.16">
+      <method name="get_first_element_child" c:identifier="webkit_dom_document_fragment_get_first_element_child" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -4993,7 +5242,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_last_element_child" c:identifier="webkit_dom_document_fragment_get_last_element_child" version="2.16">
+      <method name="get_last_element_child" c:identifier="webkit_dom_document_fragment_get_last_element_child" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -5005,7 +5255,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="query_selector" c:identifier="webkit_dom_document_fragment_query_selector" version="2.16" throws="1">
+      <method name="query_selector" c:identifier="webkit_dom_document_fragment_query_selector" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -5021,7 +5272,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="query_selector_all" c:identifier="webkit_dom_document_fragment_query_selector_all" version="2.16" throws="1">
+      <method name="query_selector_all" c:identifier="webkit_dom_document_fragment_query_selector_all" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMNodeList</doc>
           <type name="DOMNodeList" c:type="WebKitDOMNodeList*"/>
@@ -5060,7 +5312,8 @@ submenu of @item is removed.</doc>
     </record>
     <class name="DOMDocumentType" c:symbol-prefix="dom_document_type" c:type="WebKitDOMDocumentType" parent="DOMNode" glib:type-name="WebKitDOMDocumentType" glib:get-type="webkit_dom_document_type_get_type" glib:type-struct="DOMDocumentTypeClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_entities" c:identifier="webkit_dom_document_type_get_entities">
+      <method name="get_entities" c:identifier="webkit_dom_document_type_get_entities" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMNamedNodeMap</doc>
           <type name="DOMNamedNodeMap" c:type="WebKitDOMNamedNodeMap*"/>
@@ -5072,7 +5325,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_internal_subset" c:identifier="webkit_dom_document_type_get_internal_subset">
+      <method name="get_internal_subset" c:identifier="webkit_dom_document_type_get_internal_subset" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -5084,7 +5338,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_document_type_get_name">
+      <method name="get_name" c:identifier="webkit_dom_document_type_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -5096,7 +5351,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_notations" c:identifier="webkit_dom_document_type_get_notations">
+      <method name="get_notations" c:identifier="webkit_dom_document_type_get_notations" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMNamedNodeMap</doc>
           <type name="DOMNamedNodeMap" c:type="WebKitDOMNamedNodeMap*"/>
@@ -5108,7 +5364,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_public_id" c:identifier="webkit_dom_document_type_get_public_id">
+      <method name="get_public_id" c:identifier="webkit_dom_document_type_get_public_id" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -5120,7 +5377,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_system_id" c:identifier="webkit_dom_document_type_get_system_id">
+      <method name="get_system_id" c:identifier="webkit_dom_document_type_get_system_id" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -5161,7 +5419,8 @@ submenu of @item is removed.</doc>
     </record>
     <class name="DOMElement" c:symbol-prefix="dom_element" c:type="WebKitDOMElement" parent="DOMNode" glib:type-name="WebKitDOMElement" glib:get-type="webkit_dom_element_get_type" glib:type-struct="DOMElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="blur" c:identifier="webkit_dom_element_blur">
+      <method name="blur" c:identifier="webkit_dom_element_blur" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -5172,7 +5431,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="closest" c:identifier="webkit_dom_element_closest" version="2.16" throws="1">
+      <method name="closest" c:identifier="webkit_dom_element_closest" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -5188,7 +5448,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="focus" c:identifier="webkit_dom_element_focus">
+      <method name="focus" c:identifier="webkit_dom_element_focus" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -5199,7 +5460,8 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_attribute" c:identifier="webkit_dom_element_get_attribute">
+      <method name="get_attribute" c:identifier="webkit_dom_element_get_attribute" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -5215,7 +5477,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_attribute_node" c:identifier="webkit_dom_element_get_attribute_node">
+      <method name="get_attribute_node" c:identifier="webkit_dom_element_get_attribute_node" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMAttr</doc>
           <type name="DOMAttr" c:type="WebKitDOMAttr*"/>
@@ -5231,7 +5494,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_attribute_node_ns" c:identifier="webkit_dom_element_get_attribute_node_ns">
+      <method name="get_attribute_node_ns" c:identifier="webkit_dom_element_get_attribute_node_ns" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMAttr</doc>
           <type name="DOMAttr" c:type="WebKitDOMAttr*"/>
@@ -5251,7 +5515,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_attribute_ns" c:identifier="webkit_dom_element_get_attribute_ns">
+      <method name="get_attribute_ns" c:identifier="webkit_dom_element_get_attribute_ns" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -5271,7 +5536,8 @@ submenu of @item is removed.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_attributes" c:identifier="webkit_dom_element_get_attributes">
+      <method name="get_attributes" c:identifier="webkit_dom_element_get_attributes" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMNamedNodeMap</doc>
           <type name="DOMNamedNodeMap" c:type="WebKitDOMNamedNodeMap*"/>
@@ -5283,9 +5549,10 @@ submenu of @item is removed.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_bounding_client_rect" c:identifier="webkit_dom_element_get_bounding_client_rect" version="2.18">
+      <method name="get_bounding_client_rect" c:identifier="webkit_dom_element_get_bounding_client_rect" version="2.18" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Returns a #WebKitDOMClientRect representing the size and position of @self
 relative to the viewport.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMClientRect</doc>
           <type name="DOMClientRect" c:type="WebKitDOMClientRect*"/>
@@ -5297,7 +5564,8 @@ relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_child_element_count" c:identifier="webkit_dom_element_get_child_element_count">
+      <method name="get_child_element_count" c:identifier="webkit_dom_element_get_child_element_count" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -5309,7 +5577,8 @@ relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_children" c:identifier="webkit_dom_element_get_children" version="2.10">
+      <method name="get_children" c:identifier="webkit_dom_element_get_children" version="2.10" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -5321,7 +5590,8 @@ relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_class_list" c:identifier="webkit_dom_element_get_class_list" version="2.16">
+      <method name="get_class_list" c:identifier="webkit_dom_element_get_class_list" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMDOMTokenList</doc>
           <type name="DOMDOMTokenList" c:type="WebKitDOMDOMTokenList*"/>
@@ -5333,7 +5603,8 @@ relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_class_name" c:identifier="webkit_dom_element_get_class_name">
+      <method name="get_class_name" c:identifier="webkit_dom_element_get_class_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -5345,7 +5616,8 @@ relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_client_height" c:identifier="webkit_dom_element_get_client_height">
+      <method name="get_client_height" c:identifier="webkit_dom_element_get_client_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gdouble</doc>
           <type name="gdouble" c:type="gdouble"/>
@@ -5357,7 +5629,8 @@ relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_client_left" c:identifier="webkit_dom_element_get_client_left">
+      <method name="get_client_left" c:identifier="webkit_dom_element_get_client_left" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gdouble</doc>
           <type name="gdouble" c:type="gdouble"/>
@@ -5369,9 +5642,10 @@ relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_client_rects" c:identifier="webkit_dom_element_get_client_rects" version="2.18">
+      <method name="get_client_rects" c:identifier="webkit_dom_element_get_client_rects" version="2.18" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Returns a collection of #WebKitDOMClientRect objects, each of which describe
 the size and position of a CSS border box relative to the viewport.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMClientRectList</doc>
           <type name="DOMClientRectList" c:type="WebKitDOMClientRectList*"/>
@@ -5383,7 +5657,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_client_top" c:identifier="webkit_dom_element_get_client_top">
+      <method name="get_client_top" c:identifier="webkit_dom_element_get_client_top" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gdouble</doc>
           <type name="gdouble" c:type="gdouble"/>
@@ -5395,7 +5670,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_client_width" c:identifier="webkit_dom_element_get_client_width">
+      <method name="get_client_width" c:identifier="webkit_dom_element_get_client_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gdouble</doc>
           <type name="gdouble" c:type="gdouble"/>
@@ -5424,7 +5700,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_elements_by_class_name_as_html_collection" c:identifier="webkit_dom_element_get_elements_by_class_name_as_html_collection" version="2.12">
+      <method name="get_elements_by_class_name_as_html_collection" c:identifier="webkit_dom_element_get_elements_by_class_name_as_html_collection" version="2.12" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -5457,7 +5734,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_elements_by_tag_name_as_html_collection" c:identifier="webkit_dom_element_get_elements_by_tag_name_as_html_collection" version="2.12">
+      <method name="get_elements_by_tag_name_as_html_collection" c:identifier="webkit_dom_element_get_elements_by_tag_name_as_html_collection" version="2.12" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -5494,7 +5772,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_elements_by_tag_name_ns_as_html_collection" c:identifier="webkit_dom_element_get_elements_by_tag_name_ns_as_html_collection" version="2.12">
+      <method name="get_elements_by_tag_name_ns_as_html_collection" c:identifier="webkit_dom_element_get_elements_by_tag_name_ns_as_html_collection" version="2.12" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -5514,7 +5793,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_first_element_child" c:identifier="webkit_dom_element_get_first_element_child">
+      <method name="get_first_element_child" c:identifier="webkit_dom_element_get_first_element_child" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -5526,7 +5806,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_id" c:identifier="webkit_dom_element_get_id">
+      <method name="get_id" c:identifier="webkit_dom_element_get_id" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -5538,7 +5819,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_inner_html" c:identifier="webkit_dom_element_get_inner_html" version="2.8">
+      <method name="get_inner_html" c:identifier="webkit_dom_element_get_inner_html" version="2.8" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -5550,7 +5832,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_last_element_child" c:identifier="webkit_dom_element_get_last_element_child">
+      <method name="get_last_element_child" c:identifier="webkit_dom_element_get_last_element_child" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -5562,7 +5845,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_local_name" c:identifier="webkit_dom_element_get_local_name" version="2.14">
+      <method name="get_local_name" c:identifier="webkit_dom_element_get_local_name" version="2.14" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -5574,7 +5858,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_namespace_uri" c:identifier="webkit_dom_element_get_namespace_uri" version="2.14">
+      <method name="get_namespace_uri" c:identifier="webkit_dom_element_get_namespace_uri" version="2.14" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -5586,7 +5871,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_next_element_sibling" c:identifier="webkit_dom_element_get_next_element_sibling">
+      <method name="get_next_element_sibling" c:identifier="webkit_dom_element_get_next_element_sibling" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -5598,7 +5884,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_offset_height" c:identifier="webkit_dom_element_get_offset_height">
+      <method name="get_offset_height" c:identifier="webkit_dom_element_get_offset_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gdouble</doc>
           <type name="gdouble" c:type="gdouble"/>
@@ -5610,7 +5897,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_offset_left" c:identifier="webkit_dom_element_get_offset_left">
+      <method name="get_offset_left" c:identifier="webkit_dom_element_get_offset_left" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gdouble</doc>
           <type name="gdouble" c:type="gdouble"/>
@@ -5622,7 +5910,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_offset_parent" c:identifier="webkit_dom_element_get_offset_parent">
+      <method name="get_offset_parent" c:identifier="webkit_dom_element_get_offset_parent" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -5634,7 +5923,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_offset_top" c:identifier="webkit_dom_element_get_offset_top">
+      <method name="get_offset_top" c:identifier="webkit_dom_element_get_offset_top" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gdouble</doc>
           <type name="gdouble" c:type="gdouble"/>
@@ -5646,7 +5936,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_offset_width" c:identifier="webkit_dom_element_get_offset_width">
+      <method name="get_offset_width" c:identifier="webkit_dom_element_get_offset_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gdouble</doc>
           <type name="gdouble" c:type="gdouble"/>
@@ -5658,7 +5949,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_outer_html" c:identifier="webkit_dom_element_get_outer_html" version="2.8">
+      <method name="get_outer_html" c:identifier="webkit_dom_element_get_outer_html" version="2.8" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -5670,7 +5962,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_prefix" c:identifier="webkit_dom_element_get_prefix" version="2.14">
+      <method name="get_prefix" c:identifier="webkit_dom_element_get_prefix" version="2.14" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -5682,7 +5975,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_previous_element_sibling" c:identifier="webkit_dom_element_get_previous_element_sibling">
+      <method name="get_previous_element_sibling" c:identifier="webkit_dom_element_get_previous_element_sibling" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -5694,7 +5988,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_scroll_height" c:identifier="webkit_dom_element_get_scroll_height">
+      <method name="get_scroll_height" c:identifier="webkit_dom_element_get_scroll_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -5706,7 +6001,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_scroll_left" c:identifier="webkit_dom_element_get_scroll_left">
+      <method name="get_scroll_left" c:identifier="webkit_dom_element_get_scroll_left" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -5718,7 +6014,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_scroll_top" c:identifier="webkit_dom_element_get_scroll_top">
+      <method name="get_scroll_top" c:identifier="webkit_dom_element_get_scroll_top" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -5730,7 +6027,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_scroll_width" c:identifier="webkit_dom_element_get_scroll_width">
+      <method name="get_scroll_width" c:identifier="webkit_dom_element_get_scroll_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -5742,7 +6040,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_style" c:identifier="webkit_dom_element_get_style">
+      <method name="get_style" c:identifier="webkit_dom_element_get_style" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMCSSStyleDeclaration</doc>
           <type name="DOMCSSStyleDeclaration" c:type="WebKitDOMCSSStyleDeclaration*"/>
@@ -5754,7 +6053,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_tag_name" c:identifier="webkit_dom_element_get_tag_name">
+      <method name="get_tag_name" c:identifier="webkit_dom_element_get_tag_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -5779,7 +6079,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="has_attribute" c:identifier="webkit_dom_element_has_attribute">
+      <method name="has_attribute" c:identifier="webkit_dom_element_has_attribute" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -5795,7 +6096,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="has_attribute_ns" c:identifier="webkit_dom_element_has_attribute_ns">
+      <method name="has_attribute_ns" c:identifier="webkit_dom_element_has_attribute_ns" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -5815,7 +6117,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="has_attributes" c:identifier="webkit_dom_element_has_attributes">
+      <method name="has_attributes" c:identifier="webkit_dom_element_has_attributes" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -5827,7 +6130,64 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="insert_adjacent_element" c:identifier="webkit_dom_element_insert_adjacent_element" version="2.16" throws="1">
+      <method name="html_input_element_get_auto_filled" c:identifier="webkit_dom_element_html_input_element_get_auto_filled">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="element" transfer-ownership="none">
+            <type name="DOMElement" c:type="WebKitDOMElement*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="html_input_element_is_user_edited" c:identifier="webkit_dom_element_html_input_element_is_user_edited" version="2.22">
+        <doc xml:space="preserve">Get whether @element is an HTML text input element that has been edited by a user action.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">whether @element has been edited by a user action.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="element" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitDOMElement</doc>
+            <type name="DOMElement" c:type="WebKitDOMElement*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="html_input_element_set_auto_filled" c:identifier="webkit_dom_element_html_input_element_set_auto_filled" version="2.22">
+        <doc xml:space="preserve">Set whether the element is an HTML input element that has been filled automatically.
+If @element is not an HTML input element this function does nothing.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="element" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitDOMElement</doc>
+            <type name="DOMElement" c:type="WebKitDOMElement*"/>
+          </instance-parameter>
+          <parameter name="auto_filled" transfer-ownership="none">
+            <doc xml:space="preserve">value to set</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="html_input_element_set_editing_value" c:identifier="webkit_dom_element_html_input_element_set_editing_value" version="2.22">
+        <doc xml:space="preserve">Set editing value of an HTML input element. If @element is not an HTML input element this function does nothing.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="element" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitDOMElement</doc>
+            <type name="DOMElement" c:type="WebKitDOMElement*"/>
+          </instance-parameter>
+          <parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">the text to set</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="insert_adjacent_element" c:identifier="webkit_dom_element_insert_adjacent_element" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -5847,7 +6207,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="insert_adjacent_html" c:identifier="webkit_dom_element_insert_adjacent_html" version="2.16" throws="1">
+      <method name="insert_adjacent_html" c:identifier="webkit_dom_element_insert_adjacent_html" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -5866,7 +6227,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="insert_adjacent_text" c:identifier="webkit_dom_element_insert_adjacent_text" version="2.16" throws="1">
+      <method name="insert_adjacent_text" c:identifier="webkit_dom_element_insert_adjacent_text" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -5885,7 +6247,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="matches" c:identifier="webkit_dom_element_matches" version="2.16" throws="1">
+      <method name="matches" c:identifier="webkit_dom_element_matches" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -5901,7 +6264,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="query_selector" c:identifier="webkit_dom_element_query_selector" throws="1">
+      <method name="query_selector" c:identifier="webkit_dom_element_query_selector" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -5917,7 +6281,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="query_selector_all" c:identifier="webkit_dom_element_query_selector_all" throws="1">
+      <method name="query_selector_all" c:identifier="webkit_dom_element_query_selector_all" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMNodeList</doc>
           <type name="DOMNodeList" c:type="WebKitDOMNodeList*"/>
@@ -5933,7 +6298,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="remove" c:identifier="webkit_dom_element_remove" version="2.16" throws="1">
+      <method name="remove" c:identifier="webkit_dom_element_remove" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -5944,7 +6310,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="remove_attribute" c:identifier="webkit_dom_element_remove_attribute">
+      <method name="remove_attribute" c:identifier="webkit_dom_element_remove_attribute" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -5959,7 +6326,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="remove_attribute_node" c:identifier="webkit_dom_element_remove_attribute_node" throws="1">
+      <method name="remove_attribute_node" c:identifier="webkit_dom_element_remove_attribute_node" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMAttr</doc>
           <type name="DOMAttr" c:type="WebKitDOMAttr*"/>
@@ -5975,7 +6343,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="remove_attribute_ns" c:identifier="webkit_dom_element_remove_attribute_ns">
+      <method name="remove_attribute_ns" c:identifier="webkit_dom_element_remove_attribute_ns" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -5994,7 +6363,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="request_pointer_lock" c:identifier="webkit_dom_element_request_pointer_lock" version="2.16">
+      <method name="request_pointer_lock" c:identifier="webkit_dom_element_request_pointer_lock" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6005,7 +6375,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="scroll_by_lines" c:identifier="webkit_dom_element_scroll_by_lines">
+      <method name="scroll_by_lines" c:identifier="webkit_dom_element_scroll_by_lines" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6020,7 +6391,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="scroll_by_pages" c:identifier="webkit_dom_element_scroll_by_pages">
+      <method name="scroll_by_pages" c:identifier="webkit_dom_element_scroll_by_pages" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6035,7 +6407,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="scroll_into_view" c:identifier="webkit_dom_element_scroll_into_view">
+      <method name="scroll_into_view" c:identifier="webkit_dom_element_scroll_into_view" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6050,7 +6423,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="scroll_into_view_if_needed" c:identifier="webkit_dom_element_scroll_into_view_if_needed">
+      <method name="scroll_into_view_if_needed" c:identifier="webkit_dom_element_scroll_into_view_if_needed" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6065,7 +6439,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_attribute" c:identifier="webkit_dom_element_set_attribute" throws="1">
+      <method name="set_attribute" c:identifier="webkit_dom_element_set_attribute" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6084,7 +6459,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_attribute_node" c:identifier="webkit_dom_element_set_attribute_node" throws="1">
+      <method name="set_attribute_node" c:identifier="webkit_dom_element_set_attribute_node" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMAttr</doc>
           <type name="DOMAttr" c:type="WebKitDOMAttr*"/>
@@ -6100,7 +6476,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_attribute_node_ns" c:identifier="webkit_dom_element_set_attribute_node_ns" throws="1">
+      <method name="set_attribute_node_ns" c:identifier="webkit_dom_element_set_attribute_node_ns" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMAttr</doc>
           <type name="DOMAttr" c:type="WebKitDOMAttr*"/>
@@ -6116,7 +6493,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_attribute_ns" c:identifier="webkit_dom_element_set_attribute_ns" throws="1">
+      <method name="set_attribute_ns" c:identifier="webkit_dom_element_set_attribute_ns" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6139,7 +6517,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_class_name" c:identifier="webkit_dom_element_set_class_name">
+      <method name="set_class_name" c:identifier="webkit_dom_element_set_class_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6154,7 +6533,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_id" c:identifier="webkit_dom_element_set_id">
+      <method name="set_id" c:identifier="webkit_dom_element_set_id" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6169,7 +6549,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_inner_html" c:identifier="webkit_dom_element_set_inner_html" version="2.8" throws="1">
+      <method name="set_inner_html" c:identifier="webkit_dom_element_set_inner_html" version="2.8" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6184,7 +6565,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_outer_html" c:identifier="webkit_dom_element_set_outer_html" version="2.8" throws="1">
+      <method name="set_outer_html" c:identifier="webkit_dom_element_set_outer_html" version="2.8" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6199,7 +6581,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_scroll_left" c:identifier="webkit_dom_element_set_scroll_left">
+      <method name="set_scroll_left" c:identifier="webkit_dom_element_set_scroll_left" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6214,7 +6597,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_scroll_top" c:identifier="webkit_dom_element_set_scroll_top">
+      <method name="set_scroll_top" c:identifier="webkit_dom_element_set_scroll_top" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6229,7 +6613,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="webkit_matches_selector" c:identifier="webkit_dom_element_webkit_matches_selector" version="2.16" throws="1">
+      <method name="webkit_matches_selector" c:identifier="webkit_dom_element_webkit_matches_selector" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -6245,7 +6630,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="webkit_request_fullscreen" c:identifier="webkit_dom_element_webkit_request_fullscreen" version="2.16">
+      <method name="webkit_request_fullscreen" c:identifier="webkit_dom_element_webkit_request_fullscreen" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6370,7 +6756,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
       </field>
     </record>
     <class name="DOMEvent" c:symbol-prefix="dom_event" c:type="WebKitDOMEvent" parent="DOMObject" glib:type-name="WebKitDOMEvent" glib:get-type="webkit_dom_event_get_type" glib:type-struct="DOMEventClass">
-      <method name="get_bubbles" c:identifier="webkit_dom_event_get_bubbles">
+      <method name="get_bubbles" c:identifier="webkit_dom_event_get_bubbles" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -6382,7 +6769,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_cancel_bubble" c:identifier="webkit_dom_event_get_cancel_bubble">
+      <method name="get_cancel_bubble" c:identifier="webkit_dom_event_get_cancel_bubble" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -6394,7 +6782,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_cancelable" c:identifier="webkit_dom_event_get_cancelable">
+      <method name="get_cancelable" c:identifier="webkit_dom_event_get_cancelable" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -6406,7 +6795,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_current_target" c:identifier="webkit_dom_event_get_current_target">
+      <method name="get_current_target" c:identifier="webkit_dom_event_get_current_target" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMEventTarget</doc>
           <type name="DOMEventTarget" c:type="WebKitDOMEventTarget*"/>
@@ -6418,7 +6808,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_event_phase" c:identifier="webkit_dom_event_get_event_phase">
+      <method name="get_event_phase" c:identifier="webkit_dom_event_get_event_phase" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gushort</doc>
           <type name="gushort" c:type="gushort"/>
@@ -6430,7 +6821,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_event_type" c:identifier="webkit_dom_event_get_event_type">
+      <method name="get_event_type" c:identifier="webkit_dom_event_get_event_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -6442,7 +6834,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_return_value" c:identifier="webkit_dom_event_get_return_value">
+      <method name="get_return_value" c:identifier="webkit_dom_event_get_return_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -6454,7 +6847,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_src_element" c:identifier="webkit_dom_event_get_src_element">
+      <method name="get_src_element" c:identifier="webkit_dom_event_get_src_element" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMEventTarget</doc>
           <type name="DOMEventTarget" c:type="WebKitDOMEventTarget*"/>
@@ -6466,7 +6860,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_target" c:identifier="webkit_dom_event_get_target">
+      <method name="get_target" c:identifier="webkit_dom_event_get_target" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMEventTarget</doc>
           <type name="DOMEventTarget" c:type="WebKitDOMEventTarget*"/>
@@ -6478,7 +6873,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_time_stamp" c:identifier="webkit_dom_event_get_time_stamp">
+      <method name="get_time_stamp" c:identifier="webkit_dom_event_get_time_stamp" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #guint32</doc>
           <type name="guint32" c:type="guint32"/>
@@ -6490,7 +6886,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="init_event" c:identifier="webkit_dom_event_init_event">
+      <method name="init_event" c:identifier="webkit_dom_event_init_event" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6513,7 +6910,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="prevent_default" c:identifier="webkit_dom_event_prevent_default">
+      <method name="prevent_default" c:identifier="webkit_dom_event_prevent_default" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6524,22 +6922,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_cancel_bubble" c:identifier="webkit_dom_event_set_cancel_bubble">
-        <return-value transfer-ownership="none">
-          <type name="none" c:type="void"/>
-        </return-value>
-        <parameters>
-          <instance-parameter name="self" transfer-ownership="none">
-            <doc xml:space="preserve">A #WebKitDOMEvent</doc>
-            <type name="DOMEvent" c:type="WebKitDOMEvent*"/>
-          </instance-parameter>
-          <parameter name="value" transfer-ownership="none">
-            <doc xml:space="preserve">A #gboolean</doc>
-            <type name="gboolean" c:type="gboolean"/>
-          </parameter>
-        </parameters>
-      </method>
-      <method name="set_return_value" c:identifier="webkit_dom_event_set_return_value">
+      <method name="set_cancel_bubble" c:identifier="webkit_dom_event_set_cancel_bubble" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6554,7 +6938,24 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="stop_propagation" c:identifier="webkit_dom_event_stop_propagation">
+      <method name="set_return_value" c:identifier="webkit_dom_event_set_return_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitDOMEvent</doc>
+            <type name="DOMEvent" c:type="WebKitDOMEvent*"/>
+          </instance-parameter>
+          <parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">A #gboolean</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="stop_propagation" c:identifier="webkit_dom_event_stop_propagation" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -6624,7 +7025,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="dispatch_event" invoker="dispatch_event" throws="1">
+      <virtual-method name="dispatch_event" invoker="dispatch_event" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -6640,7 +7042,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <virtual-method name="remove_event_listener" invoker="remove_event_listener">
+      <virtual-method name="remove_event_listener" invoker="remove_event_listener" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -6664,7 +7067,8 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <method name="add_event_listener" c:identifier="webkit_dom_event_target_add_event_listener" shadowed-by="add_event_listener_with_closure">
+      <method name="add_event_listener" c:identifier="webkit_dom_event_target_add_event_listener" shadowed-by="add_event_listener_with_closure" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -6692,9 +7096,10 @@ the size and position of a CSS border box relative to the viewport.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="add_event_listener_with_closure" c:identifier="webkit_dom_event_target_add_event_listener_with_closure" shadows="add_event_listener">
+      <method name="add_event_listener_with_closure" c:identifier="webkit_dom_event_target_add_event_listener_with_closure" shadows="add_event_listener" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Version of webkit_dom_event_target_add_event_listener() using a closure
 instead of a callbacks for easier binding in other languages.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -6718,7 +7123,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="dispatch_event" c:identifier="webkit_dom_event_target_dispatch_event" throws="1">
+      <method name="dispatch_event" c:identifier="webkit_dom_event_target_dispatch_event" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -6734,7 +7140,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="remove_event_listener" c:identifier="webkit_dom_event_target_remove_event_listener" shadowed-by="remove_event_listener_with_closure">
+      <method name="remove_event_listener" c:identifier="webkit_dom_event_target_remove_event_listener" shadowed-by="remove_event_listener_with_closure" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -6758,9 +7165,10 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="remove_event_listener_with_closure" c:identifier="webkit_dom_event_target_remove_event_listener_with_closure" shadows="remove_event_listener">
+      <method name="remove_event_listener_with_closure" c:identifier="webkit_dom_event_target_remove_event_listener_with_closure" shadows="remove_event_listener" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Version of webkit_dom_event_target_remove_event_listener() using a closure
 instead of a callbacks for easier binding in other languages.</doc>
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -6884,7 +7292,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMFile" c:symbol-prefix="dom_file" c:type="WebKitDOMFile" parent="DOMBlob" glib:type-name="WebKitDOMFile" glib:get-type="webkit_dom_file_get_type" glib:type-struct="DOMFileClass">
-      <method name="get_name" c:identifier="webkit_dom_file_get_name">
+      <method name="get_name" c:identifier="webkit_dom_file_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -6909,7 +7318,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMFileList" c:symbol-prefix="dom_file_list" c:type="WebKitDOMFileList" parent="DOMObject" glib:type-name="WebKitDOMFileList" glib:get-type="webkit_dom_file_list_get_type" glib:type-struct="DOMFileListClass">
-      <method name="get_length" c:identifier="webkit_dom_file_list_get_length">
+      <method name="get_length" c:identifier="webkit_dom_file_list_get_length" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -6921,7 +7331,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="item" c:identifier="webkit_dom_file_list_item">
+      <method name="item" c:identifier="webkit_dom_file_list_item" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMFile</doc>
           <type name="DOMFile" c:type="WebKitDOMFile*"/>
@@ -6951,7 +7362,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLAnchorElement" c:symbol-prefix="dom_html_anchor_element" c:type="WebKitDOMHTMLAnchorElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLAnchorElement" glib:get-type="webkit_dom_html_anchor_element_get_type" glib:type-struct="DOMHTMLAnchorElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_charset" c:identifier="webkit_dom_html_anchor_element_get_charset">
+      <method name="get_charset" c:identifier="webkit_dom_html_anchor_element_get_charset" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -6963,7 +7375,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_coords" c:identifier="webkit_dom_html_anchor_element_get_coords">
+      <method name="get_coords" c:identifier="webkit_dom_html_anchor_element_get_coords" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -6975,7 +7388,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_hash" c:identifier="webkit_dom_html_anchor_element_get_hash">
+      <method name="get_hash" c:identifier="webkit_dom_html_anchor_element_get_hash" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -6987,7 +7401,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_host" c:identifier="webkit_dom_html_anchor_element_get_host">
+      <method name="get_host" c:identifier="webkit_dom_html_anchor_element_get_host" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -6999,7 +7414,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_hostname" c:identifier="webkit_dom_html_anchor_element_get_hostname">
+      <method name="get_hostname" c:identifier="webkit_dom_html_anchor_element_get_hostname" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7011,7 +7427,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_href" c:identifier="webkit_dom_html_anchor_element_get_href">
+      <method name="get_href" c:identifier="webkit_dom_html_anchor_element_get_href" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7023,7 +7440,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_hreflang" c:identifier="webkit_dom_html_anchor_element_get_hreflang">
+      <method name="get_hreflang" c:identifier="webkit_dom_html_anchor_element_get_hreflang" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7035,7 +7453,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_html_anchor_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_anchor_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7047,7 +7466,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_pathname" c:identifier="webkit_dom_html_anchor_element_get_pathname">
+      <method name="get_pathname" c:identifier="webkit_dom_html_anchor_element_get_pathname" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7059,7 +7479,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_port" c:identifier="webkit_dom_html_anchor_element_get_port">
+      <method name="get_port" c:identifier="webkit_dom_html_anchor_element_get_port" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7071,7 +7492,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_protocol" c:identifier="webkit_dom_html_anchor_element_get_protocol">
+      <method name="get_protocol" c:identifier="webkit_dom_html_anchor_element_get_protocol" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7083,7 +7505,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_rel" c:identifier="webkit_dom_html_anchor_element_get_rel">
+      <method name="get_rel" c:identifier="webkit_dom_html_anchor_element_get_rel" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7095,7 +7518,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_rev" c:identifier="webkit_dom_html_anchor_element_get_rev">
+      <method name="get_rev" c:identifier="webkit_dom_html_anchor_element_get_rev" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7107,7 +7531,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_search" c:identifier="webkit_dom_html_anchor_element_get_search">
+      <method name="get_search" c:identifier="webkit_dom_html_anchor_element_get_search" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7119,7 +7544,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_shape" c:identifier="webkit_dom_html_anchor_element_get_shape">
+      <method name="get_shape" c:identifier="webkit_dom_html_anchor_element_get_shape" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7131,7 +7557,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_target" c:identifier="webkit_dom_html_anchor_element_get_target">
+      <method name="get_target" c:identifier="webkit_dom_html_anchor_element_get_target" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7143,7 +7570,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_text" c:identifier="webkit_dom_html_anchor_element_get_text">
+      <method name="get_text" c:identifier="webkit_dom_html_anchor_element_get_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7155,7 +7583,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_type_attr" c:identifier="webkit_dom_html_anchor_element_get_type_attr">
+      <method name="get_type_attr" c:identifier="webkit_dom_html_anchor_element_get_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7167,7 +7596,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_charset" c:identifier="webkit_dom_html_anchor_element_set_charset">
+      <method name="set_charset" c:identifier="webkit_dom_html_anchor_element_set_charset" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7182,7 +7612,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_coords" c:identifier="webkit_dom_html_anchor_element_set_coords">
+      <method name="set_coords" c:identifier="webkit_dom_html_anchor_element_set_coords" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7197,7 +7628,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_hash" c:identifier="webkit_dom_html_anchor_element_set_hash">
+      <method name="set_hash" c:identifier="webkit_dom_html_anchor_element_set_hash" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7212,7 +7644,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_host" c:identifier="webkit_dom_html_anchor_element_set_host">
+      <method name="set_host" c:identifier="webkit_dom_html_anchor_element_set_host" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7227,7 +7660,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_hostname" c:identifier="webkit_dom_html_anchor_element_set_hostname">
+      <method name="set_hostname" c:identifier="webkit_dom_html_anchor_element_set_hostname" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7242,7 +7676,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_href" c:identifier="webkit_dom_html_anchor_element_set_href">
+      <method name="set_href" c:identifier="webkit_dom_html_anchor_element_set_href" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7257,7 +7692,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_hreflang" c:identifier="webkit_dom_html_anchor_element_set_hreflang">
+      <method name="set_hreflang" c:identifier="webkit_dom_html_anchor_element_set_hreflang" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7272,7 +7708,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_anchor_element_set_name">
+      <method name="set_name" c:identifier="webkit_dom_html_anchor_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7287,7 +7724,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_pathname" c:identifier="webkit_dom_html_anchor_element_set_pathname">
+      <method name="set_pathname" c:identifier="webkit_dom_html_anchor_element_set_pathname" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7302,7 +7740,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_port" c:identifier="webkit_dom_html_anchor_element_set_port">
+      <method name="set_port" c:identifier="webkit_dom_html_anchor_element_set_port" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7317,7 +7756,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_protocol" c:identifier="webkit_dom_html_anchor_element_set_protocol">
+      <method name="set_protocol" c:identifier="webkit_dom_html_anchor_element_set_protocol" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7332,7 +7772,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_rel" c:identifier="webkit_dom_html_anchor_element_set_rel">
+      <method name="set_rel" c:identifier="webkit_dom_html_anchor_element_set_rel" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7347,7 +7788,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_rev" c:identifier="webkit_dom_html_anchor_element_set_rev">
+      <method name="set_rev" c:identifier="webkit_dom_html_anchor_element_set_rev" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7362,7 +7804,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_search" c:identifier="webkit_dom_html_anchor_element_set_search">
+      <method name="set_search" c:identifier="webkit_dom_html_anchor_element_set_search" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7377,7 +7820,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_shape" c:identifier="webkit_dom_html_anchor_element_set_shape">
+      <method name="set_shape" c:identifier="webkit_dom_html_anchor_element_set_shape" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7392,7 +7836,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_target" c:identifier="webkit_dom_html_anchor_element_set_target">
+      <method name="set_target" c:identifier="webkit_dom_html_anchor_element_set_target" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7407,7 +7852,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_text" c:identifier="webkit_dom_html_anchor_element_set_text" version="2.16">
+      <method name="set_text" c:identifier="webkit_dom_html_anchor_element_set_text" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7422,7 +7868,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_type_attr" c:identifier="webkit_dom_html_anchor_element_set_type_attr">
+      <method name="set_type_attr" c:identifier="webkit_dom_html_anchor_element_set_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7502,7 +7949,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLAppletElement" c:symbol-prefix="dom_html_applet_element" c:type="WebKitDOMHTMLAppletElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLAppletElement" glib:get-type="webkit_dom_html_applet_element_get_type" glib:type-struct="DOMHTMLAppletElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_align" c:identifier="webkit_dom_html_applet_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_applet_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7514,7 +7962,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_alt" c:identifier="webkit_dom_html_applet_element_get_alt">
+      <method name="get_alt" c:identifier="webkit_dom_html_applet_element_get_alt" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7526,7 +7975,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_archive" c:identifier="webkit_dom_html_applet_element_get_archive">
+      <method name="get_archive" c:identifier="webkit_dom_html_applet_element_get_archive" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7538,7 +7988,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_code" c:identifier="webkit_dom_html_applet_element_get_code">
+      <method name="get_code" c:identifier="webkit_dom_html_applet_element_get_code" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7550,7 +8001,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_code_base" c:identifier="webkit_dom_html_applet_element_get_code_base">
+      <method name="get_code_base" c:identifier="webkit_dom_html_applet_element_get_code_base" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7562,7 +8014,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_height" c:identifier="webkit_dom_html_applet_element_get_height">
+      <method name="get_height" c:identifier="webkit_dom_html_applet_element_get_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7574,7 +8027,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_hspace" c:identifier="webkit_dom_html_applet_element_get_hspace">
+      <method name="get_hspace" c:identifier="webkit_dom_html_applet_element_get_hspace" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -7586,7 +8040,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_html_applet_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_applet_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7598,7 +8053,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_object" c:identifier="webkit_dom_html_applet_element_get_object">
+      <method name="get_object" c:identifier="webkit_dom_html_applet_element_get_object" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7610,7 +8066,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_vspace" c:identifier="webkit_dom_html_applet_element_get_vspace">
+      <method name="get_vspace" c:identifier="webkit_dom_html_applet_element_get_vspace" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -7622,7 +8079,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_width" c:identifier="webkit_dom_html_applet_element_get_width">
+      <method name="get_width" c:identifier="webkit_dom_html_applet_element_get_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7634,7 +8092,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_applet_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_applet_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7649,7 +8108,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_alt" c:identifier="webkit_dom_html_applet_element_set_alt">
+      <method name="set_alt" c:identifier="webkit_dom_html_applet_element_set_alt" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7664,7 +8124,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_archive" c:identifier="webkit_dom_html_applet_element_set_archive">
+      <method name="set_archive" c:identifier="webkit_dom_html_applet_element_set_archive" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7679,7 +8140,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_code" c:identifier="webkit_dom_html_applet_element_set_code">
+      <method name="set_code" c:identifier="webkit_dom_html_applet_element_set_code" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7694,7 +8156,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_code_base" c:identifier="webkit_dom_html_applet_element_set_code_base">
+      <method name="set_code_base" c:identifier="webkit_dom_html_applet_element_set_code_base" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7709,7 +8172,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_height" c:identifier="webkit_dom_html_applet_element_set_height">
+      <method name="set_height" c:identifier="webkit_dom_html_applet_element_set_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7724,7 +8188,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_hspace" c:identifier="webkit_dom_html_applet_element_set_hspace">
+      <method name="set_hspace" c:identifier="webkit_dom_html_applet_element_set_hspace" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7739,7 +8204,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_applet_element_set_name">
+      <method name="set_name" c:identifier="webkit_dom_html_applet_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7754,7 +8220,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_object" c:identifier="webkit_dom_html_applet_element_set_object">
+      <method name="set_object" c:identifier="webkit_dom_html_applet_element_set_object" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7769,7 +8236,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_vspace" c:identifier="webkit_dom_html_applet_element_set_vspace">
+      <method name="set_vspace" c:identifier="webkit_dom_html_applet_element_set_vspace" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7784,7 +8252,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_width" c:identifier="webkit_dom_html_applet_element_set_width">
+      <method name="set_width" c:identifier="webkit_dom_html_applet_element_set_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -7843,7 +8312,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLAreaElement" c:symbol-prefix="dom_html_area_element" c:type="WebKitDOMHTMLAreaElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLAreaElement" glib:get-type="webkit_dom_html_area_element_get_type" glib:type-struct="DOMHTMLAreaElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_alt" c:identifier="webkit_dom_html_area_element_get_alt">
+      <method name="get_alt" c:identifier="webkit_dom_html_area_element_get_alt" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7855,7 +8325,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_coords" c:identifier="webkit_dom_html_area_element_get_coords">
+      <method name="get_coords" c:identifier="webkit_dom_html_area_element_get_coords" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7867,7 +8338,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_hash" c:identifier="webkit_dom_html_area_element_get_hash">
+      <method name="get_hash" c:identifier="webkit_dom_html_area_element_get_hash" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7879,7 +8351,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_host" c:identifier="webkit_dom_html_area_element_get_host">
+      <method name="get_host" c:identifier="webkit_dom_html_area_element_get_host" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7891,7 +8364,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_hostname" c:identifier="webkit_dom_html_area_element_get_hostname">
+      <method name="get_hostname" c:identifier="webkit_dom_html_area_element_get_hostname" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7903,7 +8377,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_href" c:identifier="webkit_dom_html_area_element_get_href">
+      <method name="get_href" c:identifier="webkit_dom_html_area_element_get_href" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7915,7 +8390,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_no_href" c:identifier="webkit_dom_html_area_element_get_no_href">
+      <method name="get_no_href" c:identifier="webkit_dom_html_area_element_get_no_href" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -7927,7 +8403,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_pathname" c:identifier="webkit_dom_html_area_element_get_pathname">
+      <method name="get_pathname" c:identifier="webkit_dom_html_area_element_get_pathname" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7939,7 +8416,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_port" c:identifier="webkit_dom_html_area_element_get_port">
+      <method name="get_port" c:identifier="webkit_dom_html_area_element_get_port" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7951,7 +8429,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_protocol" c:identifier="webkit_dom_html_area_element_get_protocol">
+      <method name="get_protocol" c:identifier="webkit_dom_html_area_element_get_protocol" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7963,7 +8442,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_search" c:identifier="webkit_dom_html_area_element_get_search">
+      <method name="get_search" c:identifier="webkit_dom_html_area_element_get_search" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7975,7 +8455,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_shape" c:identifier="webkit_dom_html_area_element_get_shape">
+      <method name="get_shape" c:identifier="webkit_dom_html_area_element_get_shape" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7987,7 +8468,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_target" c:identifier="webkit_dom_html_area_element_get_target">
+      <method name="get_target" c:identifier="webkit_dom_html_area_element_get_target" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -7999,7 +8481,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_alt" c:identifier="webkit_dom_html_area_element_set_alt">
+      <method name="set_alt" c:identifier="webkit_dom_html_area_element_set_alt" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8014,7 +8497,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_coords" c:identifier="webkit_dom_html_area_element_set_coords">
+      <method name="set_coords" c:identifier="webkit_dom_html_area_element_set_coords" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8029,7 +8513,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_hash" c:identifier="webkit_dom_html_area_element_set_hash" stability="Unstable">
+      <method name="set_hash" c:identifier="webkit_dom_html_area_element_set_hash" deprecated="1" deprecated-version="2.22" stability="Unstable">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8044,7 +8529,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_host" c:identifier="webkit_dom_html_area_element_set_host" version="2.16">
+      <method name="set_host" c:identifier="webkit_dom_html_area_element_set_host" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8059,7 +8545,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_hostname" c:identifier="webkit_dom_html_area_element_set_hostname" version="2.16">
+      <method name="set_hostname" c:identifier="webkit_dom_html_area_element_set_hostname" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8074,7 +8561,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_href" c:identifier="webkit_dom_html_area_element_set_href">
+      <method name="set_href" c:identifier="webkit_dom_html_area_element_set_href" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8089,7 +8577,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_no_href" c:identifier="webkit_dom_html_area_element_set_no_href">
+      <method name="set_no_href" c:identifier="webkit_dom_html_area_element_set_no_href" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8104,7 +8593,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_pathname" c:identifier="webkit_dom_html_area_element_set_pathname" version="2.16">
+      <method name="set_pathname" c:identifier="webkit_dom_html_area_element_set_pathname" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8119,7 +8609,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_port" c:identifier="webkit_dom_html_area_element_set_port" version="2.16">
+      <method name="set_port" c:identifier="webkit_dom_html_area_element_set_port" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8134,7 +8625,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_protocol" c:identifier="webkit_dom_html_area_element_set_protocol" version="2.16">
+      <method name="set_protocol" c:identifier="webkit_dom_html_area_element_set_protocol" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8149,7 +8641,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_search" c:identifier="webkit_dom_html_area_element_set_search" version="2.16">
+      <method name="set_search" c:identifier="webkit_dom_html_area_element_set_search" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8164,7 +8657,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_shape" c:identifier="webkit_dom_html_area_element_set_shape">
+      <method name="set_shape" c:identifier="webkit_dom_html_area_element_set_shape" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8179,7 +8673,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_target" c:identifier="webkit_dom_html_area_element_set_target">
+      <method name="set_target" c:identifier="webkit_dom_html_area_element_set_target" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8244,7 +8739,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLBRElement" c:symbol-prefix="dom_html_br_element" c:type="WebKitDOMHTMLBRElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLBRElement" glib:get-type="webkit_dom_html_br_element_get_type" glib:type-struct="DOMHTMLBRElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_clear" c:identifier="webkit_dom_html_br_element_get_clear">
+      <method name="get_clear" c:identifier="webkit_dom_html_br_element_get_clear" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -8256,7 +8752,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_clear" c:identifier="webkit_dom_html_br_element_set_clear">
+      <method name="set_clear" c:identifier="webkit_dom_html_br_element_set_clear" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8285,7 +8782,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLBaseElement" c:symbol-prefix="dom_html_base_element" c:type="WebKitDOMHTMLBaseElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLBaseElement" glib:get-type="webkit_dom_html_base_element_get_type" glib:type-struct="DOMHTMLBaseElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_href" c:identifier="webkit_dom_html_base_element_get_href">
+      <method name="get_href" c:identifier="webkit_dom_html_base_element_get_href" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -8297,7 +8795,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_target" c:identifier="webkit_dom_html_base_element_get_target">
+      <method name="get_target" c:identifier="webkit_dom_html_base_element_get_target" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -8309,7 +8808,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_href" c:identifier="webkit_dom_html_base_element_set_href">
+      <method name="set_href" c:identifier="webkit_dom_html_base_element_set_href" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8324,7 +8824,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_target" c:identifier="webkit_dom_html_base_element_set_target">
+      <method name="set_target" c:identifier="webkit_dom_html_base_element_set_target" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8454,7 +8955,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLBodyElement" c:symbol-prefix="dom_html_body_element" c:type="WebKitDOMHTMLBodyElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLBodyElement" glib:get-type="webkit_dom_html_body_element_get_type" glib:type-struct="DOMHTMLBodyElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_a_link" c:identifier="webkit_dom_html_body_element_get_a_link">
+      <method name="get_a_link" c:identifier="webkit_dom_html_body_element_get_a_link" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -8466,7 +8968,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_background" c:identifier="webkit_dom_html_body_element_get_background">
+      <method name="get_background" c:identifier="webkit_dom_html_body_element_get_background" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -8478,7 +8981,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_bg_color" c:identifier="webkit_dom_html_body_element_get_bg_color">
+      <method name="get_bg_color" c:identifier="webkit_dom_html_body_element_get_bg_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -8490,7 +8994,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_link" c:identifier="webkit_dom_html_body_element_get_link">
+      <method name="get_link" c:identifier="webkit_dom_html_body_element_get_link" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -8502,7 +9007,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_text" c:identifier="webkit_dom_html_body_element_get_text">
+      <method name="get_text" c:identifier="webkit_dom_html_body_element_get_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -8514,7 +9020,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_v_link" c:identifier="webkit_dom_html_body_element_get_v_link">
+      <method name="get_v_link" c:identifier="webkit_dom_html_body_element_get_v_link" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -8526,7 +9033,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_a_link" c:identifier="webkit_dom_html_body_element_set_a_link">
+      <method name="set_a_link" c:identifier="webkit_dom_html_body_element_set_a_link" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8541,7 +9049,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_background" c:identifier="webkit_dom_html_body_element_set_background">
+      <method name="set_background" c:identifier="webkit_dom_html_body_element_set_background" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8556,7 +9065,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_bg_color" c:identifier="webkit_dom_html_body_element_set_bg_color">
+      <method name="set_bg_color" c:identifier="webkit_dom_html_body_element_set_bg_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8571,7 +9081,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_link" c:identifier="webkit_dom_html_body_element_set_link">
+      <method name="set_link" c:identifier="webkit_dom_html_body_element_set_link" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8586,7 +9097,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_text" c:identifier="webkit_dom_html_body_element_set_text">
+      <method name="set_text" c:identifier="webkit_dom_html_body_element_set_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8601,7 +9113,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_v_link" c:identifier="webkit_dom_html_body_element_set_v_link">
+      <method name="set_v_link" c:identifier="webkit_dom_html_body_element_set_v_link" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8645,7 +9158,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLButtonElement" c:symbol-prefix="dom_html_button_element" c:type="WebKitDOMHTMLButtonElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLButtonElement" glib:get-type="webkit_dom_html_button_element_get_type" glib:type-struct="DOMHTMLButtonElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_autofocus" c:identifier="webkit_dom_html_button_element_get_autofocus">
+      <method name="get_autofocus" c:identifier="webkit_dom_html_button_element_get_autofocus" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -8657,7 +9171,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_button_type" c:identifier="webkit_dom_html_button_element_get_button_type">
+      <method name="get_button_type" c:identifier="webkit_dom_html_button_element_get_button_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -8669,7 +9184,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_disabled" c:identifier="webkit_dom_html_button_element_get_disabled">
+      <method name="get_disabled" c:identifier="webkit_dom_html_button_element_get_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -8681,7 +9197,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_form" c:identifier="webkit_dom_html_button_element_get_form">
+      <method name="get_form" c:identifier="webkit_dom_html_button_element_get_form" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLFormElement</doc>
           <type name="DOMHTMLFormElement" c:type="WebKitDOMHTMLFormElement*"/>
@@ -8693,7 +9210,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_html_button_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_button_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -8705,7 +9223,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_value" c:identifier="webkit_dom_html_button_element_get_value">
+      <method name="get_value" c:identifier="webkit_dom_html_button_element_get_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -8717,7 +9236,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_will_validate" c:identifier="webkit_dom_html_button_element_get_will_validate">
+      <method name="get_will_validate" c:identifier="webkit_dom_html_button_element_get_will_validate" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -8729,7 +9249,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_autofocus" c:identifier="webkit_dom_html_button_element_set_autofocus">
+      <method name="set_autofocus" c:identifier="webkit_dom_html_button_element_set_autofocus" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8744,7 +9265,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_button_type" c:identifier="webkit_dom_html_button_element_set_button_type">
+      <method name="set_button_type" c:identifier="webkit_dom_html_button_element_set_button_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8759,7 +9281,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_disabled" c:identifier="webkit_dom_html_button_element_set_disabled">
+      <method name="set_disabled" c:identifier="webkit_dom_html_button_element_set_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8774,7 +9297,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_button_element_set_name">
+      <method name="set_name" c:identifier="webkit_dom_html_button_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8789,7 +9313,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_value" c:identifier="webkit_dom_html_button_element_set_value">
+      <method name="set_value" c:identifier="webkit_dom_html_button_element_set_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8836,7 +9361,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLCanvasElement" c:symbol-prefix="dom_html_canvas_element" c:type="WebKitDOMHTMLCanvasElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLCanvasElement" glib:get-type="webkit_dom_html_canvas_element_get_type" glib:type-struct="DOMHTMLCanvasElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_height" c:identifier="webkit_dom_html_canvas_element_get_height">
+      <method name="get_height" c:identifier="webkit_dom_html_canvas_element_get_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -8848,7 +9374,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_width" c:identifier="webkit_dom_html_canvas_element_get_width">
+      <method name="get_width" c:identifier="webkit_dom_html_canvas_element_get_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -8860,7 +9387,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_height" c:identifier="webkit_dom_html_canvas_element_set_height">
+      <method name="set_height" c:identifier="webkit_dom_html_canvas_element_set_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8875,7 +9403,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_width" c:identifier="webkit_dom_html_canvas_element_set_width">
+      <method name="set_width" c:identifier="webkit_dom_html_canvas_element_set_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -8906,7 +9435,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMHTMLCollection" c:symbol-prefix="dom_html_collection" c:type="WebKitDOMHTMLCollection" parent="DOMObject" glib:type-name="WebKitDOMHTMLCollection" glib:get-type="webkit_dom_html_collection_get_type" glib:type-struct="DOMHTMLCollectionClass">
-      <method name="get_length" c:identifier="webkit_dom_html_collection_get_length">
+      <method name="get_length" c:identifier="webkit_dom_html_collection_get_length" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -8918,7 +9448,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="item" c:identifier="webkit_dom_html_collection_item">
+      <method name="item" c:identifier="webkit_dom_html_collection_item" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -8934,7 +9465,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="named_item" c:identifier="webkit_dom_html_collection_named_item">
+      <method name="named_item" c:identifier="webkit_dom_html_collection_named_item" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -8964,7 +9496,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLDListElement" c:symbol-prefix="dom_html_d_list_element" c:type="WebKitDOMHTMLDListElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLDListElement" glib:get-type="webkit_dom_html_d_list_element_get_type" glib:type-struct="DOMHTMLDListElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_compact" c:identifier="webkit_dom_html_d_list_element_get_compact">
+      <method name="get_compact" c:identifier="webkit_dom_html_d_list_element_get_compact" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -8976,7 +9509,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_compact" c:identifier="webkit_dom_html_d_list_element_set_compact">
+      <method name="set_compact" c:identifier="webkit_dom_html_d_list_element_set_compact" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9005,7 +9539,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLDirectoryElement" c:symbol-prefix="dom_html_directory_element" c:type="WebKitDOMHTMLDirectoryElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLDirectoryElement" glib:get-type="webkit_dom_html_directory_element_get_type" glib:type-struct="DOMHTMLDirectoryElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_compact" c:identifier="webkit_dom_html_directory_element_get_compact">
+      <method name="get_compact" c:identifier="webkit_dom_html_directory_element_get_compact" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -9017,7 +9552,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_compact" c:identifier="webkit_dom_html_directory_element_set_compact">
+      <method name="set_compact" c:identifier="webkit_dom_html_directory_element_set_compact" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9046,7 +9582,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLDivElement" c:symbol-prefix="dom_html_div_element" c:type="WebKitDOMHTMLDivElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLDivElement" glib:get-type="webkit_dom_html_div_element_get_type" glib:type-struct="DOMHTMLDivElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_align" c:identifier="webkit_dom_html_div_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_div_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9058,7 +9595,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_div_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_div_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9087,7 +9625,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLDocument" c:symbol-prefix="dom_html_document" c:type="WebKitDOMHTMLDocument" parent="DOMDocument" glib:type-name="WebKitDOMHTMLDocument" glib:get-type="webkit_dom_html_document_get_type" glib:type-struct="DOMHTMLDocumentClass">
       <implements name="DOMEventTarget"/>
-      <method name="capture_events" c:identifier="webkit_dom_html_document_capture_events">
+      <method name="capture_events" c:identifier="webkit_dom_html_document_capture_events" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9098,7 +9637,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="clear" c:identifier="webkit_dom_html_document_clear">
+      <method name="clear" c:identifier="webkit_dom_html_document_clear" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9109,7 +9649,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="close" c:identifier="webkit_dom_html_document_close">
+      <method name="close" c:identifier="webkit_dom_html_document_close" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9120,7 +9661,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_alink_color" c:identifier="webkit_dom_html_document_get_alink_color">
+      <method name="get_alink_color" c:identifier="webkit_dom_html_document_get_alink_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9132,7 +9674,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_bg_color" c:identifier="webkit_dom_html_document_get_bg_color">
+      <method name="get_bg_color" c:identifier="webkit_dom_html_document_get_bg_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9170,7 +9713,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_dir" c:identifier="webkit_dom_html_document_get_dir">
+      <method name="get_dir" c:identifier="webkit_dom_html_document_get_dir" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9195,7 +9739,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_fg_color" c:identifier="webkit_dom_html_document_get_fg_color">
+      <method name="get_fg_color" c:identifier="webkit_dom_html_document_get_fg_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9207,7 +9752,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_height" c:identifier="webkit_dom_html_document_get_height">
+      <method name="get_height" c:identifier="webkit_dom_html_document_get_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -9219,7 +9765,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_link_color" c:identifier="webkit_dom_html_document_get_link_color">
+      <method name="get_link_color" c:identifier="webkit_dom_html_document_get_link_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9257,7 +9804,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_vlink_color" c:identifier="webkit_dom_html_document_get_vlink_color">
+      <method name="get_vlink_color" c:identifier="webkit_dom_html_document_get_vlink_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9269,7 +9817,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_width" c:identifier="webkit_dom_html_document_get_width">
+      <method name="get_width" c:identifier="webkit_dom_html_document_get_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -9281,7 +9830,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="release_events" c:identifier="webkit_dom_html_document_release_events">
+      <method name="release_events" c:identifier="webkit_dom_html_document_release_events" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9292,7 +9842,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_alink_color" c:identifier="webkit_dom_html_document_set_alink_color">
+      <method name="set_alink_color" c:identifier="webkit_dom_html_document_set_alink_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9307,7 +9858,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_bg_color" c:identifier="webkit_dom_html_document_set_bg_color">
+      <method name="set_bg_color" c:identifier="webkit_dom_html_document_set_bg_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9338,7 +9890,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_dir" c:identifier="webkit_dom_html_document_set_dir">
+      <method name="set_dir" c:identifier="webkit_dom_html_document_set_dir" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9353,7 +9906,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_fg_color" c:identifier="webkit_dom_html_document_set_fg_color">
+      <method name="set_fg_color" c:identifier="webkit_dom_html_document_set_fg_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9368,7 +9922,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_link_color" c:identifier="webkit_dom_html_document_set_link_color">
+      <method name="set_link_color" c:identifier="webkit_dom_html_document_set_link_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9383,7 +9938,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_vlink_color" c:identifier="webkit_dom_html_document_set_vlink_color">
+      <method name="set_vlink_color" c:identifier="webkit_dom_html_document_set_vlink_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9433,7 +9989,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLElement" c:symbol-prefix="dom_html_element" c:type="WebKitDOMHTMLElement" parent="DOMElement" glib:type-name="WebKitDOMHTMLElement" glib:get-type="webkit_dom_html_element_get_type" glib:type-struct="DOMHTMLElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="click" c:identifier="webkit_dom_html_element_click">
+      <method name="click" c:identifier="webkit_dom_html_element_click" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9444,7 +10001,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_access_key" c:identifier="webkit_dom_html_element_get_access_key">
+      <method name="get_access_key" c:identifier="webkit_dom_html_element_get_access_key" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9469,7 +10027,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_content_editable" c:identifier="webkit_dom_html_element_get_content_editable">
+      <method name="get_content_editable" c:identifier="webkit_dom_html_element_get_content_editable" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9481,7 +10040,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_dir" c:identifier="webkit_dom_html_element_get_dir">
+      <method name="get_dir" c:identifier="webkit_dom_html_element_get_dir" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9493,7 +10053,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_draggable" c:identifier="webkit_dom_html_element_get_draggable" version="2.16">
+      <method name="get_draggable" c:identifier="webkit_dom_html_element_get_draggable" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -9505,7 +10066,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_hidden" c:identifier="webkit_dom_html_element_get_hidden" version="2.16">
+      <method name="get_hidden" c:identifier="webkit_dom_html_element_get_hidden" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -9530,7 +10092,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_inner_text" c:identifier="webkit_dom_html_element_get_inner_text">
+      <method name="get_inner_text" c:identifier="webkit_dom_html_element_get_inner_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9542,7 +10105,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_is_content_editable" c:identifier="webkit_dom_html_element_get_is_content_editable">
+      <method name="get_is_content_editable" c:identifier="webkit_dom_html_element_get_is_content_editable" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -9554,7 +10118,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_lang" c:identifier="webkit_dom_html_element_get_lang">
+      <method name="get_lang" c:identifier="webkit_dom_html_element_get_lang" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9579,7 +10144,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_outer_text" c:identifier="webkit_dom_html_element_get_outer_text">
+      <method name="get_outer_text" c:identifier="webkit_dom_html_element_get_outer_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9591,7 +10157,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_spellcheck" c:identifier="webkit_dom_html_element_get_spellcheck" version="2.16">
+      <method name="get_spellcheck" c:identifier="webkit_dom_html_element_get_spellcheck" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -9603,7 +10170,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_tab_index" c:identifier="webkit_dom_html_element_get_tab_index">
+      <method name="get_tab_index" c:identifier="webkit_dom_html_element_get_tab_index" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -9615,7 +10183,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_title" c:identifier="webkit_dom_html_element_get_title">
+      <method name="get_title" c:identifier="webkit_dom_html_element_get_title" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9627,7 +10196,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_translate" c:identifier="webkit_dom_html_element_get_translate" version="2.16">
+      <method name="get_translate" c:identifier="webkit_dom_html_element_get_translate" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -9639,7 +10209,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_webkitdropzone" c:identifier="webkit_dom_html_element_get_webkitdropzone" version="2.16">
+      <method name="get_webkitdropzone" c:identifier="webkit_dom_html_element_get_webkitdropzone" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9651,7 +10222,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_access_key" c:identifier="webkit_dom_html_element_set_access_key">
+      <method name="set_access_key" c:identifier="webkit_dom_html_element_set_access_key" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9666,7 +10238,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_content_editable" c:identifier="webkit_dom_html_element_set_content_editable" throws="1">
+      <method name="set_content_editable" c:identifier="webkit_dom_html_element_set_content_editable" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9681,7 +10254,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_dir" c:identifier="webkit_dom_html_element_set_dir">
+      <method name="set_dir" c:identifier="webkit_dom_html_element_set_dir" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9696,7 +10270,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_draggable" c:identifier="webkit_dom_html_element_set_draggable" version="2.16">
+      <method name="set_draggable" c:identifier="webkit_dom_html_element_set_draggable" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9711,7 +10286,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_hidden" c:identifier="webkit_dom_html_element_set_hidden" version="2.16">
+      <method name="set_hidden" c:identifier="webkit_dom_html_element_set_hidden" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9742,7 +10318,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_inner_text" c:identifier="webkit_dom_html_element_set_inner_text" throws="1">
+      <method name="set_inner_text" c:identifier="webkit_dom_html_element_set_inner_text" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9757,7 +10334,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_lang" c:identifier="webkit_dom_html_element_set_lang">
+      <method name="set_lang" c:identifier="webkit_dom_html_element_set_lang" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9788,7 +10366,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_outer_text" c:identifier="webkit_dom_html_element_set_outer_text" throws="1">
+      <method name="set_outer_text" c:identifier="webkit_dom_html_element_set_outer_text" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9803,7 +10382,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_spellcheck" c:identifier="webkit_dom_html_element_set_spellcheck" version="2.16">
+      <method name="set_spellcheck" c:identifier="webkit_dom_html_element_set_spellcheck" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9818,7 +10398,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_tab_index" c:identifier="webkit_dom_html_element_set_tab_index">
+      <method name="set_tab_index" c:identifier="webkit_dom_html_element_set_tab_index" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9833,7 +10414,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_title" c:identifier="webkit_dom_html_element_set_title">
+      <method name="set_title" c:identifier="webkit_dom_html_element_set_title" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9848,7 +10430,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_translate" c:identifier="webkit_dom_html_element_set_translate" version="2.16">
+      <method name="set_translate" c:identifier="webkit_dom_html_element_set_translate" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9863,7 +10446,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_webkitdropzone" c:identifier="webkit_dom_html_element_set_webkitdropzone" version="2.16">
+      <method name="set_webkitdropzone" c:identifier="webkit_dom_html_element_set_webkitdropzone" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -9931,7 +10515,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLEmbedElement" c:symbol-prefix="dom_html_embed_element" c:type="WebKitDOMHTMLEmbedElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLEmbedElement" glib:get-type="webkit_dom_html_embed_element_get_type" glib:type-struct="DOMHTMLEmbedElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_align" c:identifier="webkit_dom_html_embed_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_embed_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9943,7 +10528,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_height" c:identifier="webkit_dom_html_embed_element_get_height">
+      <method name="get_height" c:identifier="webkit_dom_html_embed_element_get_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -9955,7 +10541,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_html_embed_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_embed_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9967,7 +10554,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_src" c:identifier="webkit_dom_html_embed_element_get_src">
+      <method name="get_src" c:identifier="webkit_dom_html_embed_element_get_src" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9979,7 +10567,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_type_attr" c:identifier="webkit_dom_html_embed_element_get_type_attr">
+      <method name="get_type_attr" c:identifier="webkit_dom_html_embed_element_get_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -9991,7 +10580,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_width" c:identifier="webkit_dom_html_embed_element_get_width">
+      <method name="get_width" c:identifier="webkit_dom_html_embed_element_get_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -10003,7 +10593,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_embed_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_embed_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10018,7 +10609,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_height" c:identifier="webkit_dom_html_embed_element_set_height">
+      <method name="set_height" c:identifier="webkit_dom_html_embed_element_set_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10033,7 +10625,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_embed_element_set_name">
+      <method name="set_name" c:identifier="webkit_dom_html_embed_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10048,7 +10641,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_src" c:identifier="webkit_dom_html_embed_element_set_src">
+      <method name="set_src" c:identifier="webkit_dom_html_embed_element_set_src" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10063,7 +10657,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_type_attr" c:identifier="webkit_dom_html_embed_element_set_type_attr">
+      <method name="set_type_attr" c:identifier="webkit_dom_html_embed_element_set_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10078,7 +10673,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_width" c:identifier="webkit_dom_html_embed_element_set_width">
+      <method name="set_width" c:identifier="webkit_dom_html_embed_element_set_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10122,7 +10718,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLFieldSetElement" c:symbol-prefix="dom_html_field_set_element" c:type="WebKitDOMHTMLFieldSetElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLFieldSetElement" glib:get-type="webkit_dom_html_field_set_element_get_type" glib:type-struct="DOMHTMLFieldSetElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_form" c:identifier="webkit_dom_html_field_set_element_get_form">
+      <method name="get_form" c:identifier="webkit_dom_html_field_set_element_get_form" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLFormElement</doc>
           <type name="DOMHTMLFormElement" c:type="WebKitDOMHTMLFormElement*"/>
@@ -10148,7 +10745,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLFontElement" c:symbol-prefix="dom_html_font_element" c:type="WebKitDOMHTMLFontElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLFontElement" glib:get-type="webkit_dom_html_font_element_get_type" glib:type-struct="DOMHTMLFontElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_color" c:identifier="webkit_dom_html_font_element_get_color">
+      <method name="get_color" c:identifier="webkit_dom_html_font_element_get_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10160,7 +10758,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_face" c:identifier="webkit_dom_html_font_element_get_face">
+      <method name="get_face" c:identifier="webkit_dom_html_font_element_get_face" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10172,7 +10771,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_size" c:identifier="webkit_dom_html_font_element_get_size">
+      <method name="get_size" c:identifier="webkit_dom_html_font_element_get_size" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10184,7 +10784,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_color" c:identifier="webkit_dom_html_font_element_set_color">
+      <method name="set_color" c:identifier="webkit_dom_html_font_element_set_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10199,7 +10800,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_face" c:identifier="webkit_dom_html_font_element_set_face">
+      <method name="set_face" c:identifier="webkit_dom_html_font_element_set_face" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10214,7 +10816,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_size" c:identifier="webkit_dom_html_font_element_set_size">
+      <method name="set_size" c:identifier="webkit_dom_html_font_element_set_size" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10249,7 +10852,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLFormElement" c:symbol-prefix="dom_html_form_element" c:type="WebKitDOMHTMLFormElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLFormElement" glib:get-type="webkit_dom_html_form_element_get_type" glib:type-struct="DOMHTMLFormElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_accept_charset" c:identifier="webkit_dom_html_form_element_get_accept_charset">
+      <method name="get_accept_charset" c:identifier="webkit_dom_html_form_element_get_accept_charset" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10261,7 +10865,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_action" c:identifier="webkit_dom_html_form_element_get_action">
+      <method name="get_action" c:identifier="webkit_dom_html_form_element_get_action" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10273,7 +10878,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_elements" c:identifier="webkit_dom_html_form_element_get_elements">
+      <method name="get_elements" c:identifier="webkit_dom_html_form_element_get_elements" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -10285,7 +10891,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_encoding" c:identifier="webkit_dom_html_form_element_get_encoding">
+      <method name="get_encoding" c:identifier="webkit_dom_html_form_element_get_encoding" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10297,7 +10904,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_enctype" c:identifier="webkit_dom_html_form_element_get_enctype">
+      <method name="get_enctype" c:identifier="webkit_dom_html_form_element_get_enctype" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10309,7 +10917,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_length" c:identifier="webkit_dom_html_form_element_get_length">
+      <method name="get_length" c:identifier="webkit_dom_html_form_element_get_length" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -10321,7 +10930,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_method" c:identifier="webkit_dom_html_form_element_get_method">
+      <method name="get_method" c:identifier="webkit_dom_html_form_element_get_method" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10333,7 +10943,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_html_form_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_form_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10345,7 +10956,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_target" c:identifier="webkit_dom_html_form_element_get_target">
+      <method name="get_target" c:identifier="webkit_dom_html_form_element_get_target" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10357,7 +10969,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="reset" c:identifier="webkit_dom_html_form_element_reset">
+      <method name="reset" c:identifier="webkit_dom_html_form_element_reset" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10368,22 +10981,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_accept_charset" c:identifier="webkit_dom_html_form_element_set_accept_charset">
-        <return-value transfer-ownership="none">
-          <type name="none" c:type="void"/>
-        </return-value>
-        <parameters>
-          <instance-parameter name="self" transfer-ownership="none">
-            <doc xml:space="preserve">A #WebKitDOMHTMLFormElement</doc>
-            <type name="DOMHTMLFormElement" c:type="WebKitDOMHTMLFormElement*"/>
-          </instance-parameter>
-          <parameter name="value" transfer-ownership="none">
-            <doc xml:space="preserve">A #gchar</doc>
-            <type name="utf8" c:type="const gchar*"/>
-          </parameter>
-        </parameters>
-      </method>
-      <method name="set_action" c:identifier="webkit_dom_html_form_element_set_action">
+      <method name="set_accept_charset" c:identifier="webkit_dom_html_form_element_set_accept_charset" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10398,7 +10997,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_encoding" c:identifier="webkit_dom_html_form_element_set_encoding">
+      <method name="set_action" c:identifier="webkit_dom_html_form_element_set_action" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10413,7 +11013,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_enctype" c:identifier="webkit_dom_html_form_element_set_enctype">
+      <method name="set_encoding" c:identifier="webkit_dom_html_form_element_set_encoding" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10428,7 +11029,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_method" c:identifier="webkit_dom_html_form_element_set_method">
+      <method name="set_enctype" c:identifier="webkit_dom_html_form_element_set_enctype" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10443,7 +11045,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_form_element_set_name">
+      <method name="set_method" c:identifier="webkit_dom_html_form_element_set_method" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10458,7 +11061,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_target" c:identifier="webkit_dom_html_form_element_set_target">
+      <method name="set_name" c:identifier="webkit_dom_html_form_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10473,7 +11077,24 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="submit" c:identifier="webkit_dom_html_form_element_submit">
+      <method name="set_target" c:identifier="webkit_dom_html_form_element_set_target" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitDOMHTMLFormElement</doc>
+            <type name="DOMHTMLFormElement" c:type="WebKitDOMHTMLFormElement*"/>
+          </instance-parameter>
+          <parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">A #gchar</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="submit" c:identifier="webkit_dom_html_form_element_submit" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10522,7 +11143,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLFrameElement" c:symbol-prefix="dom_html_frame_element" c:type="WebKitDOMHTMLFrameElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLFrameElement" glib:get-type="webkit_dom_html_frame_element_get_type" glib:type-struct="DOMHTMLFrameElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_content_document" c:identifier="webkit_dom_html_frame_element_get_content_document">
+      <method name="get_content_document" c:identifier="webkit_dom_html_frame_element_get_content_document" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMDocument</doc>
           <type name="DOMDocument" c:type="WebKitDOMDocument*"/>
@@ -10534,7 +11156,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_content_window" c:identifier="webkit_dom_html_frame_element_get_content_window">
+      <method name="get_content_window" c:identifier="webkit_dom_html_frame_element_get_content_window" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMDOMWindow</doc>
           <type name="DOMDOMWindow" c:type="WebKitDOMDOMWindow*"/>
@@ -10546,7 +11169,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_frame_border" c:identifier="webkit_dom_html_frame_element_get_frame_border">
+      <method name="get_frame_border" c:identifier="webkit_dom_html_frame_element_get_frame_border" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10558,7 +11182,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_height" c:identifier="webkit_dom_html_frame_element_get_height">
+      <method name="get_height" c:identifier="webkit_dom_html_frame_element_get_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -10570,7 +11195,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_long_desc" c:identifier="webkit_dom_html_frame_element_get_long_desc">
+      <method name="get_long_desc" c:identifier="webkit_dom_html_frame_element_get_long_desc" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10582,7 +11208,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_margin_height" c:identifier="webkit_dom_html_frame_element_get_margin_height">
+      <method name="get_margin_height" c:identifier="webkit_dom_html_frame_element_get_margin_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10594,7 +11221,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_margin_width" c:identifier="webkit_dom_html_frame_element_get_margin_width">
+      <method name="get_margin_width" c:identifier="webkit_dom_html_frame_element_get_margin_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10606,7 +11234,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_html_frame_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_frame_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10618,7 +11247,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_no_resize" c:identifier="webkit_dom_html_frame_element_get_no_resize">
+      <method name="get_no_resize" c:identifier="webkit_dom_html_frame_element_get_no_resize" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -10630,7 +11260,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_scrolling" c:identifier="webkit_dom_html_frame_element_get_scrolling">
+      <method name="get_scrolling" c:identifier="webkit_dom_html_frame_element_get_scrolling" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10642,7 +11273,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_src" c:identifier="webkit_dom_html_frame_element_get_src">
+      <method name="get_src" c:identifier="webkit_dom_html_frame_element_get_src" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10654,7 +11286,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_width" c:identifier="webkit_dom_html_frame_element_get_width">
+      <method name="get_width" c:identifier="webkit_dom_html_frame_element_get_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -10666,7 +11299,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_frame_border" c:identifier="webkit_dom_html_frame_element_set_frame_border">
+      <method name="set_frame_border" c:identifier="webkit_dom_html_frame_element_set_frame_border" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10681,7 +11315,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_long_desc" c:identifier="webkit_dom_html_frame_element_set_long_desc">
+      <method name="set_long_desc" c:identifier="webkit_dom_html_frame_element_set_long_desc" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10696,7 +11331,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_margin_height" c:identifier="webkit_dom_html_frame_element_set_margin_height">
+      <method name="set_margin_height" c:identifier="webkit_dom_html_frame_element_set_margin_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10711,7 +11347,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_margin_width" c:identifier="webkit_dom_html_frame_element_set_margin_width">
+      <method name="set_margin_width" c:identifier="webkit_dom_html_frame_element_set_margin_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10726,7 +11363,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_frame_element_set_name">
+      <method name="set_name" c:identifier="webkit_dom_html_frame_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10741,7 +11379,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_no_resize" c:identifier="webkit_dom_html_frame_element_set_no_resize">
+      <method name="set_no_resize" c:identifier="webkit_dom_html_frame_element_set_no_resize" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10756,7 +11395,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_scrolling" c:identifier="webkit_dom_html_frame_element_set_scrolling">
+      <method name="set_scrolling" c:identifier="webkit_dom_html_frame_element_set_scrolling" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10771,7 +11411,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_src" c:identifier="webkit_dom_html_frame_element_set_src">
+      <method name="set_src" c:identifier="webkit_dom_html_frame_element_set_src" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10833,7 +11474,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLFrameSetElement" c:symbol-prefix="dom_html_frame_set_element" c:type="WebKitDOMHTMLFrameSetElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLFrameSetElement" glib:get-type="webkit_dom_html_frame_set_element_get_type" glib:type-struct="DOMHTMLFrameSetElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_cols" c:identifier="webkit_dom_html_frame_set_element_get_cols">
+      <method name="get_cols" c:identifier="webkit_dom_html_frame_set_element_get_cols" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10845,7 +11487,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_rows" c:identifier="webkit_dom_html_frame_set_element_get_rows">
+      <method name="get_rows" c:identifier="webkit_dom_html_frame_set_element_get_rows" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10857,7 +11500,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_cols" c:identifier="webkit_dom_html_frame_set_element_set_cols">
+      <method name="set_cols" c:identifier="webkit_dom_html_frame_set_element_set_cols" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10872,7 +11516,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_rows" c:identifier="webkit_dom_html_frame_set_element_set_rows">
+      <method name="set_rows" c:identifier="webkit_dom_html_frame_set_element_set_rows" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10904,7 +11549,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLHRElement" c:symbol-prefix="dom_html_hr_element" c:type="WebKitDOMHTMLHRElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLHRElement" glib:get-type="webkit_dom_html_hr_element_get_type" glib:type-struct="DOMHTMLHRElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_align" c:identifier="webkit_dom_html_hr_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_hr_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10916,7 +11562,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_no_shade" c:identifier="webkit_dom_html_hr_element_get_no_shade">
+      <method name="get_no_shade" c:identifier="webkit_dom_html_hr_element_get_no_shade" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -10928,7 +11575,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_size" c:identifier="webkit_dom_html_hr_element_get_size">
+      <method name="get_size" c:identifier="webkit_dom_html_hr_element_get_size" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10940,7 +11588,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_width" c:identifier="webkit_dom_html_hr_element_get_width">
+      <method name="get_width" c:identifier="webkit_dom_html_hr_element_get_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -10952,7 +11601,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_hr_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_hr_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10967,7 +11617,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_no_shade" c:identifier="webkit_dom_html_hr_element_set_no_shade">
+      <method name="set_no_shade" c:identifier="webkit_dom_html_hr_element_set_no_shade" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10982,7 +11633,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_size" c:identifier="webkit_dom_html_hr_element_set_size">
+      <method name="set_size" c:identifier="webkit_dom_html_hr_element_set_size" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -10997,7 +11649,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_width" c:identifier="webkit_dom_html_hr_element_set_width">
+      <method name="set_width" c:identifier="webkit_dom_html_hr_element_set_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11035,7 +11688,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLHeadElement" c:symbol-prefix="dom_html_head_element" c:type="WebKitDOMHTMLHeadElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLHeadElement" glib:get-type="webkit_dom_html_head_element_get_type" glib:type-struct="DOMHTMLHeadElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_profile" c:identifier="webkit_dom_html_head_element_get_profile">
+      <method name="get_profile" c:identifier="webkit_dom_html_head_element_get_profile" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11047,7 +11701,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_profile" c:identifier="webkit_dom_html_head_element_set_profile">
+      <method name="set_profile" c:identifier="webkit_dom_html_head_element_set_profile" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11076,7 +11731,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLHeadingElement" c:symbol-prefix="dom_html_heading_element" c:type="WebKitDOMHTMLHeadingElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLHeadingElement" glib:get-type="webkit_dom_html_heading_element_get_type" glib:type-struct="DOMHTMLHeadingElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_align" c:identifier="webkit_dom_html_heading_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_heading_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11088,7 +11744,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_heading_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_heading_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11117,7 +11774,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLHtmlElement" c:symbol-prefix="dom_html_html_element" c:type="WebKitDOMHTMLHtmlElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLHtmlElement" glib:get-type="webkit_dom_html_html_element_get_type" glib:type-struct="DOMHTMLHtmlElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_version" c:identifier="webkit_dom_html_html_element_get_version">
+      <method name="get_version" c:identifier="webkit_dom_html_html_element_get_version" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11129,7 +11787,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_version" c:identifier="webkit_dom_html_html_element_set_version">
+      <method name="set_version" c:identifier="webkit_dom_html_html_element_set_version" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11158,7 +11817,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLIFrameElement" c:symbol-prefix="dom_html_iframe_element" c:type="WebKitDOMHTMLIFrameElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLIFrameElement" glib:get-type="webkit_dom_html_iframe_element_get_type" glib:type-struct="DOMHTMLIFrameElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_align" c:identifier="webkit_dom_html_iframe_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_iframe_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11170,7 +11830,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_content_document" c:identifier="webkit_dom_html_iframe_element_get_content_document">
+      <method name="get_content_document" c:identifier="webkit_dom_html_iframe_element_get_content_document" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMDocument</doc>
           <type name="DOMDocument" c:type="WebKitDOMDocument*"/>
@@ -11182,7 +11843,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_content_window" c:identifier="webkit_dom_html_iframe_element_get_content_window">
+      <method name="get_content_window" c:identifier="webkit_dom_html_iframe_element_get_content_window" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMDOMWindow</doc>
           <type name="DOMDOMWindow" c:type="WebKitDOMDOMWindow*"/>
@@ -11194,7 +11856,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_frame_border" c:identifier="webkit_dom_html_iframe_element_get_frame_border">
+      <method name="get_frame_border" c:identifier="webkit_dom_html_iframe_element_get_frame_border" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11206,7 +11869,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_height" c:identifier="webkit_dom_html_iframe_element_get_height">
+      <method name="get_height" c:identifier="webkit_dom_html_iframe_element_get_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11218,7 +11882,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_long_desc" c:identifier="webkit_dom_html_iframe_element_get_long_desc">
+      <method name="get_long_desc" c:identifier="webkit_dom_html_iframe_element_get_long_desc" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11230,7 +11895,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_margin_height" c:identifier="webkit_dom_html_iframe_element_get_margin_height">
+      <method name="get_margin_height" c:identifier="webkit_dom_html_iframe_element_get_margin_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11242,7 +11908,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_margin_width" c:identifier="webkit_dom_html_iframe_element_get_margin_width">
+      <method name="get_margin_width" c:identifier="webkit_dom_html_iframe_element_get_margin_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11254,7 +11921,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_html_iframe_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_iframe_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11266,7 +11934,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_scrolling" c:identifier="webkit_dom_html_iframe_element_get_scrolling">
+      <method name="get_scrolling" c:identifier="webkit_dom_html_iframe_element_get_scrolling" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11278,7 +11947,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_src" c:identifier="webkit_dom_html_iframe_element_get_src">
+      <method name="get_src" c:identifier="webkit_dom_html_iframe_element_get_src" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11290,7 +11960,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_width" c:identifier="webkit_dom_html_iframe_element_get_width">
+      <method name="get_width" c:identifier="webkit_dom_html_iframe_element_get_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11302,7 +11973,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_iframe_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_iframe_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11317,7 +11989,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_frame_border" c:identifier="webkit_dom_html_iframe_element_set_frame_border">
+      <method name="set_frame_border" c:identifier="webkit_dom_html_iframe_element_set_frame_border" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11332,7 +12005,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_height" c:identifier="webkit_dom_html_iframe_element_set_height">
+      <method name="set_height" c:identifier="webkit_dom_html_iframe_element_set_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11347,7 +12021,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_long_desc" c:identifier="webkit_dom_html_iframe_element_set_long_desc">
+      <method name="set_long_desc" c:identifier="webkit_dom_html_iframe_element_set_long_desc" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11362,7 +12037,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_margin_height" c:identifier="webkit_dom_html_iframe_element_set_margin_height">
+      <method name="set_margin_height" c:identifier="webkit_dom_html_iframe_element_set_margin_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11377,7 +12053,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_margin_width" c:identifier="webkit_dom_html_iframe_element_set_margin_width">
+      <method name="set_margin_width" c:identifier="webkit_dom_html_iframe_element_set_margin_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11392,7 +12069,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_iframe_element_set_name">
+      <method name="set_name" c:identifier="webkit_dom_html_iframe_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11407,7 +12085,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_scrolling" c:identifier="webkit_dom_html_iframe_element_set_scrolling">
+      <method name="set_scrolling" c:identifier="webkit_dom_html_iframe_element_set_scrolling" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11422,7 +12101,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_src" c:identifier="webkit_dom_html_iframe_element_set_src">
+      <method name="set_src" c:identifier="webkit_dom_html_iframe_element_set_src" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11437,7 +12117,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_width" c:identifier="webkit_dom_html_iframe_element_set_width">
+      <method name="set_width" c:identifier="webkit_dom_html_iframe_element_set_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11499,7 +12180,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLImageElement" c:symbol-prefix="dom_html_image_element" c:type="WebKitDOMHTMLImageElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLImageElement" glib:get-type="webkit_dom_html_image_element_get_type" glib:type-struct="DOMHTMLImageElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_align" c:identifier="webkit_dom_html_image_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_image_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11511,7 +12193,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_alt" c:identifier="webkit_dom_html_image_element_get_alt">
+      <method name="get_alt" c:identifier="webkit_dom_html_image_element_get_alt" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11523,7 +12206,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_border" c:identifier="webkit_dom_html_image_element_get_border">
+      <method name="get_border" c:identifier="webkit_dom_html_image_element_get_border" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11535,7 +12219,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_complete" c:identifier="webkit_dom_html_image_element_get_complete">
+      <method name="get_complete" c:identifier="webkit_dom_html_image_element_get_complete" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -11547,7 +12232,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_height" c:identifier="webkit_dom_html_image_element_get_height">
+      <method name="get_height" c:identifier="webkit_dom_html_image_element_get_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -11559,7 +12245,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_hspace" c:identifier="webkit_dom_html_image_element_get_hspace">
+      <method name="get_hspace" c:identifier="webkit_dom_html_image_element_get_hspace" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -11571,7 +12258,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_is_map" c:identifier="webkit_dom_html_image_element_get_is_map">
+      <method name="get_is_map" c:identifier="webkit_dom_html_image_element_get_is_map" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -11583,7 +12271,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_long_desc" c:identifier="webkit_dom_html_image_element_get_long_desc">
+      <method name="get_long_desc" c:identifier="webkit_dom_html_image_element_get_long_desc" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11595,7 +12284,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_lowsrc" c:identifier="webkit_dom_html_image_element_get_lowsrc">
+      <method name="get_lowsrc" c:identifier="webkit_dom_html_image_element_get_lowsrc" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11607,7 +12297,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_html_image_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_image_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11619,7 +12310,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_natural_height" c:identifier="webkit_dom_html_image_element_get_natural_height">
+      <method name="get_natural_height" c:identifier="webkit_dom_html_image_element_get_natural_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -11631,7 +12323,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_natural_width" c:identifier="webkit_dom_html_image_element_get_natural_width">
+      <method name="get_natural_width" c:identifier="webkit_dom_html_image_element_get_natural_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -11643,7 +12336,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_src" c:identifier="webkit_dom_html_image_element_get_src">
+      <method name="get_src" c:identifier="webkit_dom_html_image_element_get_src" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11655,7 +12349,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_use_map" c:identifier="webkit_dom_html_image_element_get_use_map">
+      <method name="get_use_map" c:identifier="webkit_dom_html_image_element_get_use_map" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11667,7 +12362,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_vspace" c:identifier="webkit_dom_html_image_element_get_vspace">
+      <method name="get_vspace" c:identifier="webkit_dom_html_image_element_get_vspace" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -11679,7 +12375,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_width" c:identifier="webkit_dom_html_image_element_get_width">
+      <method name="get_width" c:identifier="webkit_dom_html_image_element_get_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -11691,7 +12388,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_x" c:identifier="webkit_dom_html_image_element_get_x">
+      <method name="get_x" c:identifier="webkit_dom_html_image_element_get_x" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -11703,7 +12401,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_y" c:identifier="webkit_dom_html_image_element_get_y">
+      <method name="get_y" c:identifier="webkit_dom_html_image_element_get_y" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -11715,7 +12414,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_image_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_image_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11730,7 +12430,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_alt" c:identifier="webkit_dom_html_image_element_set_alt">
+      <method name="set_alt" c:identifier="webkit_dom_html_image_element_set_alt" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11745,7 +12446,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_border" c:identifier="webkit_dom_html_image_element_set_border">
+      <method name="set_border" c:identifier="webkit_dom_html_image_element_set_border" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11760,7 +12462,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_height" c:identifier="webkit_dom_html_image_element_set_height">
+      <method name="set_height" c:identifier="webkit_dom_html_image_element_set_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11775,7 +12478,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_hspace" c:identifier="webkit_dom_html_image_element_set_hspace">
+      <method name="set_hspace" c:identifier="webkit_dom_html_image_element_set_hspace" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11790,7 +12494,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_is_map" c:identifier="webkit_dom_html_image_element_set_is_map">
+      <method name="set_is_map" c:identifier="webkit_dom_html_image_element_set_is_map" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11805,7 +12510,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_long_desc" c:identifier="webkit_dom_html_image_element_set_long_desc">
+      <method name="set_long_desc" c:identifier="webkit_dom_html_image_element_set_long_desc" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11820,7 +12526,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_lowsrc" c:identifier="webkit_dom_html_image_element_set_lowsrc">
+      <method name="set_lowsrc" c:identifier="webkit_dom_html_image_element_set_lowsrc" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11835,7 +12542,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_image_element_set_name">
+      <method name="set_name" c:identifier="webkit_dom_html_image_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11850,7 +12558,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_src" c:identifier="webkit_dom_html_image_element_set_src">
+      <method name="set_src" c:identifier="webkit_dom_html_image_element_set_src" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11865,7 +12574,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_use_map" c:identifier="webkit_dom_html_image_element_set_use_map">
+      <method name="set_use_map" c:identifier="webkit_dom_html_image_element_set_use_map" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11880,7 +12590,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_vspace" c:identifier="webkit_dom_html_image_element_set_vspace">
+      <method name="set_vspace" c:identifier="webkit_dom_html_image_element_set_vspace" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11895,7 +12606,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_width" c:identifier="webkit_dom_html_image_element_set_width">
+      <method name="set_width" c:identifier="webkit_dom_html_image_element_set_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -11975,7 +12687,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLInputElement" c:symbol-prefix="dom_html_input_element" c:type="WebKitDOMHTMLInputElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLInputElement" glib:get-type="webkit_dom_html_input_element_get_type" glib:type-struct="DOMHTMLInputElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_accept" c:identifier="webkit_dom_html_input_element_get_accept">
+      <method name="get_accept" c:identifier="webkit_dom_html_input_element_get_accept" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11987,7 +12700,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_align" c:identifier="webkit_dom_html_input_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_input_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -11999,7 +12713,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_alt" c:identifier="webkit_dom_html_input_element_get_alt">
+      <method name="get_alt" c:identifier="webkit_dom_html_input_element_get_alt" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12011,7 +12726,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_auto_filled" c:identifier="webkit_dom_html_input_element_get_auto_filled" version="2.16">
+      <method name="get_auto_filled" c:identifier="webkit_dom_html_input_element_get_auto_filled" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use webkit_dom_element_html_input_element_get_auto_filled() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -12023,7 +12739,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_autofocus" c:identifier="webkit_dom_html_input_element_get_autofocus">
+      <method name="get_autofocus" c:identifier="webkit_dom_html_input_element_get_autofocus" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -12048,7 +12765,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_capture_type" c:identifier="webkit_dom_html_input_element_get_capture_type" version="2.14">
+      <method name="get_capture_type" c:identifier="webkit_dom_html_input_element_get_capture_type" version="2.14" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12060,7 +12778,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_checked" c:identifier="webkit_dom_html_input_element_get_checked">
+      <method name="get_checked" c:identifier="webkit_dom_html_input_element_get_checked" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -12072,7 +12791,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_default_checked" c:identifier="webkit_dom_html_input_element_get_default_checked">
+      <method name="get_default_checked" c:identifier="webkit_dom_html_input_element_get_default_checked" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -12084,7 +12804,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_default_value" c:identifier="webkit_dom_html_input_element_get_default_value">
+      <method name="get_default_value" c:identifier="webkit_dom_html_input_element_get_default_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12096,7 +12817,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_disabled" c:identifier="webkit_dom_html_input_element_get_disabled">
+      <method name="get_disabled" c:identifier="webkit_dom_html_input_element_get_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -12108,7 +12830,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_files" c:identifier="webkit_dom_html_input_element_get_files">
+      <method name="get_files" c:identifier="webkit_dom_html_input_element_get_files" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMFileList</doc>
           <type name="DOMFileList" c:type="WebKitDOMFileList*"/>
@@ -12120,7 +12843,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_form" c:identifier="webkit_dom_html_input_element_get_form">
+      <method name="get_form" c:identifier="webkit_dom_html_input_element_get_form" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLFormElement</doc>
           <type name="DOMHTMLFormElement" c:type="WebKitDOMHTMLFormElement*"/>
@@ -12132,7 +12856,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_height" c:identifier="webkit_dom_html_input_element_get_height">
+      <method name="get_height" c:identifier="webkit_dom_html_input_element_get_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -12144,7 +12869,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_indeterminate" c:identifier="webkit_dom_html_input_element_get_indeterminate">
+      <method name="get_indeterminate" c:identifier="webkit_dom_html_input_element_get_indeterminate" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -12156,7 +12882,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_input_type" c:identifier="webkit_dom_html_input_element_get_input_type">
+      <method name="get_input_type" c:identifier="webkit_dom_html_input_element_get_input_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12168,7 +12895,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_max_length" c:identifier="webkit_dom_html_input_element_get_max_length">
+      <method name="get_max_length" c:identifier="webkit_dom_html_input_element_get_max_length" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -12180,7 +12908,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_multiple" c:identifier="webkit_dom_html_input_element_get_multiple">
+      <method name="get_multiple" c:identifier="webkit_dom_html_input_element_get_multiple" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -12192,7 +12921,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_html_input_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_input_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12204,7 +12934,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_read_only" c:identifier="webkit_dom_html_input_element_get_read_only" version="2.16">
+      <method name="get_read_only" c:identifier="webkit_dom_html_input_element_get_read_only" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -12216,7 +12947,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_size" c:identifier="webkit_dom_html_input_element_get_size">
+      <method name="get_size" c:identifier="webkit_dom_html_input_element_get_size" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -12228,7 +12960,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_src" c:identifier="webkit_dom_html_input_element_get_src">
+      <method name="get_src" c:identifier="webkit_dom_html_input_element_get_src" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12240,7 +12973,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_use_map" c:identifier="webkit_dom_html_input_element_get_use_map">
+      <method name="get_use_map" c:identifier="webkit_dom_html_input_element_get_use_map" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12252,7 +12986,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_value" c:identifier="webkit_dom_html_input_element_get_value">
+      <method name="get_value" c:identifier="webkit_dom_html_input_element_get_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12264,7 +12999,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_width" c:identifier="webkit_dom_html_input_element_get_width">
+      <method name="get_width" c:identifier="webkit_dom_html_input_element_get_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -12276,7 +13012,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_will_validate" c:identifier="webkit_dom_html_input_element_get_will_validate">
+      <method name="get_will_validate" c:identifier="webkit_dom_html_input_element_get_will_validate" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -12288,7 +13025,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="is_edited" c:identifier="webkit_dom_html_input_element_is_edited">
+      <method name="is_edited" c:identifier="webkit_dom_html_input_element_is_edited" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use webkit_dom_element_html_input_element_is_user_edited() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -12300,7 +13038,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="select" c:identifier="webkit_dom_html_input_element_select">
+      <method name="select" c:identifier="webkit_dom_html_input_element_select" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12311,22 +13050,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_accept" c:identifier="webkit_dom_html_input_element_set_accept">
-        <return-value transfer-ownership="none">
-          <type name="none" c:type="void"/>
-        </return-value>
-        <parameters>
-          <instance-parameter name="self" transfer-ownership="none">
-            <doc xml:space="preserve">A #WebKitDOMHTMLInputElement</doc>
-            <type name="DOMHTMLInputElement" c:type="WebKitDOMHTMLInputElement*"/>
-          </instance-parameter>
-          <parameter name="value" transfer-ownership="none">
-            <doc xml:space="preserve">A #gchar</doc>
-            <type name="utf8" c:type="const gchar*"/>
-          </parameter>
-        </parameters>
-      </method>
-      <method name="set_align" c:identifier="webkit_dom_html_input_element_set_align">
+      <method name="set_accept" c:identifier="webkit_dom_html_input_element_set_accept" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12341,7 +13066,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_alt" c:identifier="webkit_dom_html_input_element_set_alt">
+      <method name="set_align" c:identifier="webkit_dom_html_input_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12356,7 +13082,24 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_auto_filled" c:identifier="webkit_dom_html_input_element_set_auto_filled" version="2.16">
+      <method name="set_alt" c:identifier="webkit_dom_html_input_element_set_alt" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitDOMHTMLInputElement</doc>
+            <type name="DOMHTMLInputElement" c:type="WebKitDOMHTMLInputElement*"/>
+          </instance-parameter>
+          <parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">A #gchar</doc>
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_auto_filled" c:identifier="webkit_dom_html_input_element_set_auto_filled" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use webkit_dom_element_html_input_element_set_auto_filled() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12371,7 +13114,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_autofocus" c:identifier="webkit_dom_html_input_element_set_autofocus">
+      <method name="set_autofocus" c:identifier="webkit_dom_html_input_element_set_autofocus" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12386,7 +13130,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_capture_type" c:identifier="webkit_dom_html_input_element_set_capture_type" version="2.16">
+      <method name="set_capture_type" c:identifier="webkit_dom_html_input_element_set_capture_type" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12401,7 +13146,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_checked" c:identifier="webkit_dom_html_input_element_set_checked">
+      <method name="set_checked" c:identifier="webkit_dom_html_input_element_set_checked" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12416,7 +13162,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_default_checked" c:identifier="webkit_dom_html_input_element_set_default_checked" version="2.16">
+      <method name="set_default_checked" c:identifier="webkit_dom_html_input_element_set_default_checked" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12431,7 +13178,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_default_value" c:identifier="webkit_dom_html_input_element_set_default_value">
+      <method name="set_default_value" c:identifier="webkit_dom_html_input_element_set_default_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12446,7 +13194,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_disabled" c:identifier="webkit_dom_html_input_element_set_disabled">
+      <method name="set_disabled" c:identifier="webkit_dom_html_input_element_set_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12461,7 +13210,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_editing_value" c:identifier="webkit_dom_html_input_element_set_editing_value" version="2.16">
+      <method name="set_editing_value" c:identifier="webkit_dom_html_input_element_set_editing_value" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use webkit_dom_element_html_input_element_set_editing_value() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12476,7 +13226,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_files" c:identifier="webkit_dom_html_input_element_set_files">
+      <method name="set_files" c:identifier="webkit_dom_html_input_element_set_files" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12491,7 +13242,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_height" c:identifier="webkit_dom_html_input_element_set_height">
+      <method name="set_height" c:identifier="webkit_dom_html_input_element_set_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12506,7 +13258,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_indeterminate" c:identifier="webkit_dom_html_input_element_set_indeterminate">
+      <method name="set_indeterminate" c:identifier="webkit_dom_html_input_element_set_indeterminate" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12521,7 +13274,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_input_type" c:identifier="webkit_dom_html_input_element_set_input_type">
+      <method name="set_input_type" c:identifier="webkit_dom_html_input_element_set_input_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12536,7 +13290,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_max_length" c:identifier="webkit_dom_html_input_element_set_max_length" throws="1">
+      <method name="set_max_length" c:identifier="webkit_dom_html_input_element_set_max_length" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12551,7 +13306,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_multiple" c:identifier="webkit_dom_html_input_element_set_multiple">
+      <method name="set_multiple" c:identifier="webkit_dom_html_input_element_set_multiple" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12566,7 +13322,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_input_element_set_name">
+      <method name="set_name" c:identifier="webkit_dom_html_input_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12581,7 +13338,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_read_only" c:identifier="webkit_dom_html_input_element_set_read_only">
+      <method name="set_read_only" c:identifier="webkit_dom_html_input_element_set_read_only" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12596,7 +13354,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_size" c:identifier="webkit_dom_html_input_element_set_size" throws="1">
+      <method name="set_size" c:identifier="webkit_dom_html_input_element_set_size" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12611,7 +13370,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_src" c:identifier="webkit_dom_html_input_element_set_src">
+      <method name="set_src" c:identifier="webkit_dom_html_input_element_set_src" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12626,7 +13386,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_use_map" c:identifier="webkit_dom_html_input_element_set_use_map">
+      <method name="set_use_map" c:identifier="webkit_dom_html_input_element_set_use_map" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12641,7 +13402,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_value" c:identifier="webkit_dom_html_input_element_set_value">
+      <method name="set_value" c:identifier="webkit_dom_html_input_element_set_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12656,7 +13418,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_width" c:identifier="webkit_dom_html_input_element_set_width">
+      <method name="set_width" c:identifier="webkit_dom_html_input_element_set_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12754,7 +13517,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLLIElement" c:symbol-prefix="dom_html_li_element" c:type="WebKitDOMHTMLLIElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLLIElement" glib:get-type="webkit_dom_html_li_element_get_type" glib:type-struct="DOMHTMLLIElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_type_attr" c:identifier="webkit_dom_html_li_element_get_type_attr">
+      <method name="get_type_attr" c:identifier="webkit_dom_html_li_element_get_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12766,7 +13530,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_value" c:identifier="webkit_dom_html_li_element_get_value">
+      <method name="get_value" c:identifier="webkit_dom_html_li_element_get_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -12778,7 +13543,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_type_attr" c:identifier="webkit_dom_html_li_element_set_type_attr">
+      <method name="set_type_attr" c:identifier="webkit_dom_html_li_element_set_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12793,7 +13559,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_value" c:identifier="webkit_dom_html_li_element_set_value">
+      <method name="set_value" c:identifier="webkit_dom_html_li_element_set_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12825,7 +13592,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLLabelElement" c:symbol-prefix="dom_html_label_element" c:type="WebKitDOMHTMLLabelElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLLabelElement" glib:get-type="webkit_dom_html_label_element_get_type" glib:type-struct="DOMHTMLLabelElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_form" c:identifier="webkit_dom_html_label_element_get_form">
+      <method name="get_form" c:identifier="webkit_dom_html_label_element_get_form" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLFormElement</doc>
           <type name="DOMHTMLFormElement" c:type="WebKitDOMHTMLFormElement*"/>
@@ -12837,7 +13605,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_html_for" c:identifier="webkit_dom_html_label_element_get_html_for">
+      <method name="get_html_for" c:identifier="webkit_dom_html_label_element_get_html_for" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12849,7 +13618,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_html_for" c:identifier="webkit_dom_html_label_element_set_html_for">
+      <method name="set_html_for" c:identifier="webkit_dom_html_label_element_set_html_for" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12881,7 +13651,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLLegendElement" c:symbol-prefix="dom_html_legend_element" c:type="WebKitDOMHTMLLegendElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLLegendElement" glib:get-type="webkit_dom_html_legend_element_get_type" glib:type-struct="DOMHTMLLegendElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_align" c:identifier="webkit_dom_html_legend_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_legend_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12893,7 +13664,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_form" c:identifier="webkit_dom_html_legend_element_get_form">
+      <method name="get_form" c:identifier="webkit_dom_html_legend_element_get_form" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLFormElement</doc>
           <type name="DOMHTMLFormElement" c:type="WebKitDOMHTMLFormElement*"/>
@@ -12905,7 +13677,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_legend_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_legend_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -12937,7 +13710,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLLinkElement" c:symbol-prefix="dom_html_link_element" c:type="WebKitDOMHTMLLinkElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLLinkElement" glib:get-type="webkit_dom_html_link_element_get_type" glib:type-struct="DOMHTMLLinkElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_charset" c:identifier="webkit_dom_html_link_element_get_charset">
+      <method name="get_charset" c:identifier="webkit_dom_html_link_element_get_charset" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12949,7 +13723,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_disabled" c:identifier="webkit_dom_html_link_element_get_disabled">
+      <method name="get_disabled" c:identifier="webkit_dom_html_link_element_get_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -12961,7 +13736,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_href" c:identifier="webkit_dom_html_link_element_get_href">
+      <method name="get_href" c:identifier="webkit_dom_html_link_element_get_href" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12973,7 +13749,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_hreflang" c:identifier="webkit_dom_html_link_element_get_hreflang">
+      <method name="get_hreflang" c:identifier="webkit_dom_html_link_element_get_hreflang" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12985,7 +13762,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_media" c:identifier="webkit_dom_html_link_element_get_media">
+      <method name="get_media" c:identifier="webkit_dom_html_link_element_get_media" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -12997,7 +13775,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_rel" c:identifier="webkit_dom_html_link_element_get_rel">
+      <method name="get_rel" c:identifier="webkit_dom_html_link_element_get_rel" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13009,7 +13788,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_rev" c:identifier="webkit_dom_html_link_element_get_rev">
+      <method name="get_rev" c:identifier="webkit_dom_html_link_element_get_rev" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13021,7 +13801,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_sheet" c:identifier="webkit_dom_html_link_element_get_sheet">
+      <method name="get_sheet" c:identifier="webkit_dom_html_link_element_get_sheet" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMStyleSheet</doc>
           <type name="DOMStyleSheet" c:type="WebKitDOMStyleSheet*"/>
@@ -13033,7 +13814,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_sizes" c:identifier="webkit_dom_html_link_element_get_sizes" version="2.16">
+      <method name="get_sizes" c:identifier="webkit_dom_html_link_element_get_sizes" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMDOMTokenList</doc>
           <type name="DOMDOMTokenList" c:type="WebKitDOMDOMTokenList*"/>
@@ -13045,7 +13827,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_target" c:identifier="webkit_dom_html_link_element_get_target">
+      <method name="get_target" c:identifier="webkit_dom_html_link_element_get_target" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13057,7 +13840,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_type_attr" c:identifier="webkit_dom_html_link_element_get_type_attr">
+      <method name="get_type_attr" c:identifier="webkit_dom_html_link_element_get_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13069,7 +13853,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_charset" c:identifier="webkit_dom_html_link_element_set_charset">
+      <method name="set_charset" c:identifier="webkit_dom_html_link_element_set_charset" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13084,7 +13869,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_disabled" c:identifier="webkit_dom_html_link_element_set_disabled">
+      <method name="set_disabled" c:identifier="webkit_dom_html_link_element_set_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13099,7 +13885,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_href" c:identifier="webkit_dom_html_link_element_set_href">
+      <method name="set_href" c:identifier="webkit_dom_html_link_element_set_href" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13114,7 +13901,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_hreflang" c:identifier="webkit_dom_html_link_element_set_hreflang">
+      <method name="set_hreflang" c:identifier="webkit_dom_html_link_element_set_hreflang" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13129,7 +13917,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_media" c:identifier="webkit_dom_html_link_element_set_media">
+      <method name="set_media" c:identifier="webkit_dom_html_link_element_set_media" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13144,7 +13933,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_rel" c:identifier="webkit_dom_html_link_element_set_rel">
+      <method name="set_rel" c:identifier="webkit_dom_html_link_element_set_rel" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13159,7 +13949,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_rev" c:identifier="webkit_dom_html_link_element_set_rev">
+      <method name="set_rev" c:identifier="webkit_dom_html_link_element_set_rev" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13174,7 +13965,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_sizes" c:identifier="webkit_dom_html_link_element_set_sizes" version="2.16">
+      <method name="set_sizes" c:identifier="webkit_dom_html_link_element_set_sizes" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13189,7 +13981,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_target" c:identifier="webkit_dom_html_link_element_set_target">
+      <method name="set_target" c:identifier="webkit_dom_html_link_element_set_target" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13204,7 +13997,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_type_attr" c:identifier="webkit_dom_html_link_element_set_type_attr">
+      <method name="set_type_attr" c:identifier="webkit_dom_html_link_element_set_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13263,7 +14057,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLMapElement" c:symbol-prefix="dom_html_map_element" c:type="WebKitDOMHTMLMapElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLMapElement" glib:get-type="webkit_dom_html_map_element_get_type" glib:type-struct="DOMHTMLMapElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_areas" c:identifier="webkit_dom_html_map_element_get_areas">
+      <method name="get_areas" c:identifier="webkit_dom_html_map_element_get_areas" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -13275,7 +14070,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_html_map_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_map_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13287,7 +14083,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_map_element_set_name">
+      <method name="set_name" c:identifier="webkit_dom_html_map_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13319,7 +14116,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLMarqueeElement" c:symbol-prefix="dom_html_marquee_element" c:type="WebKitDOMHTMLMarqueeElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLMarqueeElement" glib:get-type="webkit_dom_html_marquee_element_get_type" glib:type-struct="DOMHTMLMarqueeElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="start" c:identifier="webkit_dom_html_marquee_element_start">
+      <method name="start" c:identifier="webkit_dom_html_marquee_element_start" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13330,7 +14128,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="stop" c:identifier="webkit_dom_html_marquee_element_stop">
+      <method name="stop" c:identifier="webkit_dom_html_marquee_element_stop" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13352,7 +14151,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLMenuElement" c:symbol-prefix="dom_html_menu_element" c:type="WebKitDOMHTMLMenuElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLMenuElement" glib:get-type="webkit_dom_html_menu_element_get_type" glib:type-struct="DOMHTMLMenuElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_compact" c:identifier="webkit_dom_html_menu_element_get_compact">
+      <method name="get_compact" c:identifier="webkit_dom_html_menu_element_get_compact" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -13364,7 +14164,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_compact" c:identifier="webkit_dom_html_menu_element_set_compact">
+      <method name="set_compact" c:identifier="webkit_dom_html_menu_element_set_compact" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13393,7 +14194,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLMetaElement" c:symbol-prefix="dom_html_meta_element" c:type="WebKitDOMHTMLMetaElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLMetaElement" glib:get-type="webkit_dom_html_meta_element_get_type" glib:type-struct="DOMHTMLMetaElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_content" c:identifier="webkit_dom_html_meta_element_get_content">
+      <method name="get_content" c:identifier="webkit_dom_html_meta_element_get_content" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13405,7 +14207,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_http_equiv" c:identifier="webkit_dom_html_meta_element_get_http_equiv">
+      <method name="get_http_equiv" c:identifier="webkit_dom_html_meta_element_get_http_equiv" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13417,7 +14220,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_html_meta_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_meta_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13429,7 +14233,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_scheme" c:identifier="webkit_dom_html_meta_element_get_scheme">
+      <method name="get_scheme" c:identifier="webkit_dom_html_meta_element_get_scheme" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13441,7 +14246,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_content" c:identifier="webkit_dom_html_meta_element_set_content">
+      <method name="set_content" c:identifier="webkit_dom_html_meta_element_set_content" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13456,7 +14262,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_http_equiv" c:identifier="webkit_dom_html_meta_element_set_http_equiv">
+      <method name="set_http_equiv" c:identifier="webkit_dom_html_meta_element_set_http_equiv" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13471,7 +14278,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_meta_element_set_name">
+      <method name="set_name" c:identifier="webkit_dom_html_meta_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13486,7 +14294,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_scheme" c:identifier="webkit_dom_html_meta_element_set_scheme">
+      <method name="set_scheme" c:identifier="webkit_dom_html_meta_element_set_scheme" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13524,7 +14333,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLModElement" c:symbol-prefix="dom_html_mod_element" c:type="WebKitDOMHTMLModElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLModElement" glib:get-type="webkit_dom_html_mod_element_get_type" glib:type-struct="DOMHTMLModElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_cite" c:identifier="webkit_dom_html_mod_element_get_cite">
+      <method name="get_cite" c:identifier="webkit_dom_html_mod_element_get_cite" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13536,7 +14346,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_date_time" c:identifier="webkit_dom_html_mod_element_get_date_time">
+      <method name="get_date_time" c:identifier="webkit_dom_html_mod_element_get_date_time" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13548,7 +14359,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_cite" c:identifier="webkit_dom_html_mod_element_set_cite">
+      <method name="set_cite" c:identifier="webkit_dom_html_mod_element_set_cite" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13563,7 +14375,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_date_time" c:identifier="webkit_dom_html_mod_element_set_date_time">
+      <method name="set_date_time" c:identifier="webkit_dom_html_mod_element_set_date_time" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13595,7 +14408,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLOListElement" c:symbol-prefix="dom_html_o_list_element" c:type="WebKitDOMHTMLOListElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLOListElement" glib:get-type="webkit_dom_html_o_list_element_get_type" glib:type-struct="DOMHTMLOListElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_compact" c:identifier="webkit_dom_html_o_list_element_get_compact">
+      <method name="get_compact" c:identifier="webkit_dom_html_o_list_element_get_compact" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -13607,7 +14421,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_start" c:identifier="webkit_dom_html_o_list_element_get_start">
+      <method name="get_start" c:identifier="webkit_dom_html_o_list_element_get_start" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -13619,7 +14434,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_type_attr" c:identifier="webkit_dom_html_o_list_element_get_type_attr">
+      <method name="get_type_attr" c:identifier="webkit_dom_html_o_list_element_get_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13631,7 +14447,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_compact" c:identifier="webkit_dom_html_o_list_element_set_compact">
+      <method name="set_compact" c:identifier="webkit_dom_html_o_list_element_set_compact" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13646,7 +14463,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_start" c:identifier="webkit_dom_html_o_list_element_set_start">
+      <method name="set_start" c:identifier="webkit_dom_html_o_list_element_set_start" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13661,7 +14479,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_type_attr" c:identifier="webkit_dom_html_o_list_element_set_type_attr">
+      <method name="set_type_attr" c:identifier="webkit_dom_html_o_list_element_set_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13696,7 +14515,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLObjectElement" c:symbol-prefix="dom_html_object_element" c:type="WebKitDOMHTMLObjectElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLObjectElement" glib:get-type="webkit_dom_html_object_element_get_type" glib:type-struct="DOMHTMLObjectElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_align" c:identifier="webkit_dom_html_object_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_object_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13708,7 +14528,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_archive" c:identifier="webkit_dom_html_object_element_get_archive">
+      <method name="get_archive" c:identifier="webkit_dom_html_object_element_get_archive" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13720,7 +14541,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_border" c:identifier="webkit_dom_html_object_element_get_border">
+      <method name="get_border" c:identifier="webkit_dom_html_object_element_get_border" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13732,7 +14554,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_code" c:identifier="webkit_dom_html_object_element_get_code">
+      <method name="get_code" c:identifier="webkit_dom_html_object_element_get_code" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13744,7 +14567,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_code_base" c:identifier="webkit_dom_html_object_element_get_code_base">
+      <method name="get_code_base" c:identifier="webkit_dom_html_object_element_get_code_base" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13756,7 +14580,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_code_type" c:identifier="webkit_dom_html_object_element_get_code_type">
+      <method name="get_code_type" c:identifier="webkit_dom_html_object_element_get_code_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13768,7 +14593,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_content_document" c:identifier="webkit_dom_html_object_element_get_content_document">
+      <method name="get_content_document" c:identifier="webkit_dom_html_object_element_get_content_document" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMDocument</doc>
           <type name="DOMDocument" c:type="WebKitDOMDocument*"/>
@@ -13780,7 +14606,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_data" c:identifier="webkit_dom_html_object_element_get_data">
+      <method name="get_data" c:identifier="webkit_dom_html_object_element_get_data" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13792,7 +14619,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_declare" c:identifier="webkit_dom_html_object_element_get_declare">
+      <method name="get_declare" c:identifier="webkit_dom_html_object_element_get_declare" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -13804,7 +14632,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_form" c:identifier="webkit_dom_html_object_element_get_form">
+      <method name="get_form" c:identifier="webkit_dom_html_object_element_get_form" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLFormElement</doc>
           <type name="DOMHTMLFormElement" c:type="WebKitDOMHTMLFormElement*"/>
@@ -13816,7 +14645,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_height" c:identifier="webkit_dom_html_object_element_get_height">
+      <method name="get_height" c:identifier="webkit_dom_html_object_element_get_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13828,7 +14658,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_hspace" c:identifier="webkit_dom_html_object_element_get_hspace">
+      <method name="get_hspace" c:identifier="webkit_dom_html_object_element_get_hspace" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -13840,7 +14671,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_html_object_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_object_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13852,7 +14684,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_standby" c:identifier="webkit_dom_html_object_element_get_standby">
+      <method name="get_standby" c:identifier="webkit_dom_html_object_element_get_standby" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13864,7 +14697,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_type_attr" c:identifier="webkit_dom_html_object_element_get_type_attr">
+      <method name="get_type_attr" c:identifier="webkit_dom_html_object_element_get_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13876,7 +14710,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_use_map" c:identifier="webkit_dom_html_object_element_get_use_map">
+      <method name="get_use_map" c:identifier="webkit_dom_html_object_element_get_use_map" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13888,7 +14723,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_vspace" c:identifier="webkit_dom_html_object_element_get_vspace">
+      <method name="get_vspace" c:identifier="webkit_dom_html_object_element_get_vspace" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -13900,7 +14736,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_width" c:identifier="webkit_dom_html_object_element_get_width">
+      <method name="get_width" c:identifier="webkit_dom_html_object_element_get_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -13912,7 +14749,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_object_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_object_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13927,7 +14765,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_archive" c:identifier="webkit_dom_html_object_element_set_archive">
+      <method name="set_archive" c:identifier="webkit_dom_html_object_element_set_archive" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13942,7 +14781,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_border" c:identifier="webkit_dom_html_object_element_set_border">
+      <method name="set_border" c:identifier="webkit_dom_html_object_element_set_border" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13957,7 +14797,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_code" c:identifier="webkit_dom_html_object_element_set_code">
+      <method name="set_code" c:identifier="webkit_dom_html_object_element_set_code" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13972,7 +14813,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_code_base" c:identifier="webkit_dom_html_object_element_set_code_base">
+      <method name="set_code_base" c:identifier="webkit_dom_html_object_element_set_code_base" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -13987,7 +14829,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_code_type" c:identifier="webkit_dom_html_object_element_set_code_type">
+      <method name="set_code_type" c:identifier="webkit_dom_html_object_element_set_code_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14002,7 +14845,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_data" c:identifier="webkit_dom_html_object_element_set_data">
+      <method name="set_data" c:identifier="webkit_dom_html_object_element_set_data" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14017,7 +14861,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_declare" c:identifier="webkit_dom_html_object_element_set_declare">
+      <method name="set_declare" c:identifier="webkit_dom_html_object_element_set_declare" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14032,7 +14877,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_height" c:identifier="webkit_dom_html_object_element_set_height">
+      <method name="set_height" c:identifier="webkit_dom_html_object_element_set_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14047,7 +14893,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_hspace" c:identifier="webkit_dom_html_object_element_set_hspace">
+      <method name="set_hspace" c:identifier="webkit_dom_html_object_element_set_hspace" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14062,7 +14909,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_object_element_set_name">
+      <method name="set_name" c:identifier="webkit_dom_html_object_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14077,7 +14925,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_standby" c:identifier="webkit_dom_html_object_element_set_standby">
+      <method name="set_standby" c:identifier="webkit_dom_html_object_element_set_standby" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14092,7 +14941,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_type_attr" c:identifier="webkit_dom_html_object_element_set_type_attr">
+      <method name="set_type_attr" c:identifier="webkit_dom_html_object_element_set_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14107,7 +14957,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_use_map" c:identifier="webkit_dom_html_object_element_set_use_map">
+      <method name="set_use_map" c:identifier="webkit_dom_html_object_element_set_use_map" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14122,7 +14973,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_vspace" c:identifier="webkit_dom_html_object_element_set_vspace">
+      <method name="set_vspace" c:identifier="webkit_dom_html_object_element_set_vspace" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14137,7 +14989,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_width" c:identifier="webkit_dom_html_object_element_set_width">
+      <method name="set_width" c:identifier="webkit_dom_html_object_element_set_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14217,7 +15070,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLOptGroupElement" c:symbol-prefix="dom_html_opt_group_element" c:type="WebKitDOMHTMLOptGroupElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLOptGroupElement" glib:get-type="webkit_dom_html_opt_group_element_get_type" glib:type-struct="DOMHTMLOptGroupElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_disabled" c:identifier="webkit_dom_html_opt_group_element_get_disabled">
+      <method name="get_disabled" c:identifier="webkit_dom_html_opt_group_element_get_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -14229,7 +15083,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_label" c:identifier="webkit_dom_html_opt_group_element_get_label">
+      <method name="get_label" c:identifier="webkit_dom_html_opt_group_element_get_label" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14241,7 +15096,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_disabled" c:identifier="webkit_dom_html_opt_group_element_set_disabled">
+      <method name="set_disabled" c:identifier="webkit_dom_html_opt_group_element_set_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14256,7 +15112,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_label" c:identifier="webkit_dom_html_opt_group_element_set_label">
+      <method name="set_label" c:identifier="webkit_dom_html_opt_group_element_set_label" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14288,7 +15145,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLOptionElement" c:symbol-prefix="dom_html_option_element" c:type="WebKitDOMHTMLOptionElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLOptionElement" glib:get-type="webkit_dom_html_option_element_get_type" glib:type-struct="DOMHTMLOptionElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_default_selected" c:identifier="webkit_dom_html_option_element_get_default_selected">
+      <method name="get_default_selected" c:identifier="webkit_dom_html_option_element_get_default_selected" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -14300,7 +15158,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_disabled" c:identifier="webkit_dom_html_option_element_get_disabled">
+      <method name="get_disabled" c:identifier="webkit_dom_html_option_element_get_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -14312,7 +15171,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_form" c:identifier="webkit_dom_html_option_element_get_form">
+      <method name="get_form" c:identifier="webkit_dom_html_option_element_get_form" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLFormElement</doc>
           <type name="DOMHTMLFormElement" c:type="WebKitDOMHTMLFormElement*"/>
@@ -14324,7 +15184,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_index" c:identifier="webkit_dom_html_option_element_get_index">
+      <method name="get_index" c:identifier="webkit_dom_html_option_element_get_index" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -14336,7 +15197,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_label" c:identifier="webkit_dom_html_option_element_get_label">
+      <method name="get_label" c:identifier="webkit_dom_html_option_element_get_label" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14348,7 +15210,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_selected" c:identifier="webkit_dom_html_option_element_get_selected">
+      <method name="get_selected" c:identifier="webkit_dom_html_option_element_get_selected" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -14360,7 +15223,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_text" c:identifier="webkit_dom_html_option_element_get_text">
+      <method name="get_text" c:identifier="webkit_dom_html_option_element_get_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14372,7 +15236,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_value" c:identifier="webkit_dom_html_option_element_get_value">
+      <method name="get_value" c:identifier="webkit_dom_html_option_element_get_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14384,7 +15249,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_default_selected" c:identifier="webkit_dom_html_option_element_set_default_selected">
+      <method name="set_default_selected" c:identifier="webkit_dom_html_option_element_set_default_selected" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14399,7 +15265,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_disabled" c:identifier="webkit_dom_html_option_element_set_disabled">
+      <method name="set_disabled" c:identifier="webkit_dom_html_option_element_set_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14414,7 +15281,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_label" c:identifier="webkit_dom_html_option_element_set_label">
+      <method name="set_label" c:identifier="webkit_dom_html_option_element_set_label" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14429,7 +15297,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_selected" c:identifier="webkit_dom_html_option_element_set_selected">
+      <method name="set_selected" c:identifier="webkit_dom_html_option_element_set_selected" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14444,7 +15313,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_value" c:identifier="webkit_dom_html_option_element_set_value">
+      <method name="set_value" c:identifier="webkit_dom_html_option_element_set_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14493,7 +15363,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMHTMLOptionsCollection" c:symbol-prefix="dom_html_options_collection" c:type="WebKitDOMHTMLOptionsCollection" parent="DOMHTMLCollection" glib:type-name="WebKitDOMHTMLOptionsCollection" glib:get-type="webkit_dom_html_options_collection_get_type" glib:type-struct="DOMHTMLOptionsCollectionClass">
-      <method name="get_length" c:identifier="webkit_dom_html_options_collection_get_length">
+      <method name="get_length" c:identifier="webkit_dom_html_options_collection_get_length" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -14505,7 +15376,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_selected_index" c:identifier="webkit_dom_html_options_collection_get_selected_index">
+      <method name="get_selected_index" c:identifier="webkit_dom_html_options_collection_get_selected_index" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -14517,7 +15389,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="named_item" c:identifier="webkit_dom_html_options_collection_named_item">
+      <method name="named_item" c:identifier="webkit_dom_html_options_collection_named_item" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -14533,7 +15406,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_selected_index" c:identifier="webkit_dom_html_options_collection_set_selected_index">
+      <method name="set_selected_index" c:identifier="webkit_dom_html_options_collection_set_selected_index" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14565,7 +15439,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLParagraphElement" c:symbol-prefix="dom_html_paragraph_element" c:type="WebKitDOMHTMLParagraphElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLParagraphElement" glib:get-type="webkit_dom_html_paragraph_element_get_type" glib:type-struct="DOMHTMLParagraphElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_align" c:identifier="webkit_dom_html_paragraph_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_paragraph_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14577,7 +15452,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_paragraph_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_paragraph_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14606,7 +15482,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLParamElement" c:symbol-prefix="dom_html_param_element" c:type="WebKitDOMHTMLParamElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLParamElement" glib:get-type="webkit_dom_html_param_element_get_type" glib:type-struct="DOMHTMLParamElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_name" c:identifier="webkit_dom_html_param_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_param_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14618,7 +15495,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_type_attr" c:identifier="webkit_dom_html_param_element_get_type_attr">
+      <method name="get_type_attr" c:identifier="webkit_dom_html_param_element_get_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14630,7 +15508,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_value" c:identifier="webkit_dom_html_param_element_get_value">
+      <method name="get_value" c:identifier="webkit_dom_html_param_element_get_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14642,7 +15521,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_value_type" c:identifier="webkit_dom_html_param_element_get_value_type">
+      <method name="get_value_type" c:identifier="webkit_dom_html_param_element_get_value_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14654,7 +15534,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_param_element_set_name">
+      <method name="set_name" c:identifier="webkit_dom_html_param_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14669,7 +15550,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_type_attr" c:identifier="webkit_dom_html_param_element_set_type_attr">
+      <method name="set_type_attr" c:identifier="webkit_dom_html_param_element_set_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14684,7 +15566,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_value" c:identifier="webkit_dom_html_param_element_set_value">
+      <method name="set_value" c:identifier="webkit_dom_html_param_element_set_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14699,7 +15582,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_value_type" c:identifier="webkit_dom_html_param_element_set_value_type">
+      <method name="set_value_type" c:identifier="webkit_dom_html_param_element_set_value_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14737,7 +15621,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLPreElement" c:symbol-prefix="dom_html_pre_element" c:type="WebKitDOMHTMLPreElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLPreElement" glib:get-type="webkit_dom_html_pre_element_get_type" glib:type-struct="DOMHTMLPreElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_width" c:identifier="webkit_dom_html_pre_element_get_width">
+      <method name="get_width" c:identifier="webkit_dom_html_pre_element_get_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -14749,7 +15634,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_wrap" c:identifier="webkit_dom_html_pre_element_get_wrap">
+      <method name="get_wrap" c:identifier="webkit_dom_html_pre_element_get_wrap" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -14761,7 +15647,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_width" c:identifier="webkit_dom_html_pre_element_set_width">
+      <method name="set_width" c:identifier="webkit_dom_html_pre_element_set_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14776,7 +15663,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_wrap" c:identifier="webkit_dom_html_pre_element_set_wrap">
+      <method name="set_wrap" c:identifier="webkit_dom_html_pre_element_set_wrap" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14808,7 +15696,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLQuoteElement" c:symbol-prefix="dom_html_quote_element" c:type="WebKitDOMHTMLQuoteElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLQuoteElement" glib:get-type="webkit_dom_html_quote_element_get_type" glib:type-struct="DOMHTMLQuoteElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_cite" c:identifier="webkit_dom_html_quote_element_get_cite">
+      <method name="get_cite" c:identifier="webkit_dom_html_quote_element_get_cite" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14820,7 +15709,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_cite" c:identifier="webkit_dom_html_quote_element_set_cite">
+      <method name="set_cite" c:identifier="webkit_dom_html_quote_element_set_cite" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14849,7 +15739,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLScriptElement" c:symbol-prefix="dom_html_script_element" c:type="WebKitDOMHTMLScriptElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLScriptElement" glib:get-type="webkit_dom_html_script_element_get_type" glib:type-struct="DOMHTMLScriptElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_charset" c:identifier="webkit_dom_html_script_element_get_charset">
+      <method name="get_charset" c:identifier="webkit_dom_html_script_element_get_charset" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14861,7 +15752,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_defer" c:identifier="webkit_dom_html_script_element_get_defer">
+      <method name="get_defer" c:identifier="webkit_dom_html_script_element_get_defer" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -14873,7 +15765,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_event" c:identifier="webkit_dom_html_script_element_get_event">
+      <method name="get_event" c:identifier="webkit_dom_html_script_element_get_event" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14885,7 +15778,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_html_for" c:identifier="webkit_dom_html_script_element_get_html_for">
+      <method name="get_html_for" c:identifier="webkit_dom_html_script_element_get_html_for" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14897,7 +15791,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_src" c:identifier="webkit_dom_html_script_element_get_src">
+      <method name="get_src" c:identifier="webkit_dom_html_script_element_get_src" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14909,7 +15804,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_text" c:identifier="webkit_dom_html_script_element_get_text">
+      <method name="get_text" c:identifier="webkit_dom_html_script_element_get_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14921,7 +15817,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_type_attr" c:identifier="webkit_dom_html_script_element_get_type_attr">
+      <method name="get_type_attr" c:identifier="webkit_dom_html_script_element_get_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -14933,7 +15830,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_charset" c:identifier="webkit_dom_html_script_element_set_charset" version="2.16">
+      <method name="set_charset" c:identifier="webkit_dom_html_script_element_set_charset" version="2.16" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14948,7 +15846,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_defer" c:identifier="webkit_dom_html_script_element_set_defer">
+      <method name="set_defer" c:identifier="webkit_dom_html_script_element_set_defer" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14963,7 +15862,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_event" c:identifier="webkit_dom_html_script_element_set_event">
+      <method name="set_event" c:identifier="webkit_dom_html_script_element_set_event" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14978,7 +15878,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_html_for" c:identifier="webkit_dom_html_script_element_set_html_for">
+      <method name="set_html_for" c:identifier="webkit_dom_html_script_element_set_html_for" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14993,7 +15894,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_src" c:identifier="webkit_dom_html_script_element_set_src">
+      <method name="set_src" c:identifier="webkit_dom_html_script_element_set_src" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15008,7 +15910,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_text" c:identifier="webkit_dom_html_script_element_set_text">
+      <method name="set_text" c:identifier="webkit_dom_html_script_element_set_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15023,7 +15926,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_type_attr" c:identifier="webkit_dom_html_script_element_set_type_attr">
+      <method name="set_type_attr" c:identifier="webkit_dom_html_script_element_set_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15070,7 +15974,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLSelectElement" c:symbol-prefix="dom_html_select_element" c:type="WebKitDOMHTMLSelectElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLSelectElement" glib:get-type="webkit_dom_html_select_element_get_type" glib:type-struct="DOMHTMLSelectElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="add" c:identifier="webkit_dom_html_select_element_add" throws="1">
+      <method name="add" c:identifier="webkit_dom_html_select_element_add" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15089,7 +15994,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_autofocus" c:identifier="webkit_dom_html_select_element_get_autofocus">
+      <method name="get_autofocus" c:identifier="webkit_dom_html_select_element_get_autofocus" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -15101,7 +16007,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_disabled" c:identifier="webkit_dom_html_select_element_get_disabled">
+      <method name="get_disabled" c:identifier="webkit_dom_html_select_element_get_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -15113,7 +16020,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_form" c:identifier="webkit_dom_html_select_element_get_form">
+      <method name="get_form" c:identifier="webkit_dom_html_select_element_get_form" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLFormElement</doc>
           <type name="DOMHTMLFormElement" c:type="WebKitDOMHTMLFormElement*"/>
@@ -15125,7 +16033,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_length" c:identifier="webkit_dom_html_select_element_get_length">
+      <method name="get_length" c:identifier="webkit_dom_html_select_element_get_length" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -15137,7 +16046,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_multiple" c:identifier="webkit_dom_html_select_element_get_multiple">
+      <method name="get_multiple" c:identifier="webkit_dom_html_select_element_get_multiple" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -15149,7 +16059,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_html_select_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_select_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15161,7 +16072,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_options" c:identifier="webkit_dom_html_select_element_get_options">
+      <method name="get_options" c:identifier="webkit_dom_html_select_element_get_options" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLOptionsCollection</doc>
           <type name="DOMHTMLOptionsCollection" c:type="WebKitDOMHTMLOptionsCollection*"/>
@@ -15173,7 +16085,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_select_type" c:identifier="webkit_dom_html_select_element_get_select_type">
+      <method name="get_select_type" c:identifier="webkit_dom_html_select_element_get_select_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15185,7 +16098,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_selected_index" c:identifier="webkit_dom_html_select_element_get_selected_index">
+      <method name="get_selected_index" c:identifier="webkit_dom_html_select_element_get_selected_index" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -15197,7 +16111,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_size" c:identifier="webkit_dom_html_select_element_get_size">
+      <method name="get_size" c:identifier="webkit_dom_html_select_element_get_size" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -15209,7 +16124,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_value" c:identifier="webkit_dom_html_select_element_get_value">
+      <method name="get_value" c:identifier="webkit_dom_html_select_element_get_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15221,7 +16137,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_will_validate" c:identifier="webkit_dom_html_select_element_get_will_validate">
+      <method name="get_will_validate" c:identifier="webkit_dom_html_select_element_get_will_validate" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -15233,7 +16150,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="item" c:identifier="webkit_dom_html_select_element_item">
+      <method name="item" c:identifier="webkit_dom_html_select_element_item" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -15249,7 +16167,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="named_item" c:identifier="webkit_dom_html_select_element_named_item">
+      <method name="named_item" c:identifier="webkit_dom_html_select_element_named_item" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -15265,7 +16184,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="remove" c:identifier="webkit_dom_html_select_element_remove">
+      <method name="remove" c:identifier="webkit_dom_html_select_element_remove" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15280,7 +16200,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_autofocus" c:identifier="webkit_dom_html_select_element_set_autofocus">
+      <method name="set_autofocus" c:identifier="webkit_dom_html_select_element_set_autofocus" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15295,7 +16216,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_disabled" c:identifier="webkit_dom_html_select_element_set_disabled">
+      <method name="set_disabled" c:identifier="webkit_dom_html_select_element_set_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15310,7 +16232,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_length" c:identifier="webkit_dom_html_select_element_set_length" throws="1">
+      <method name="set_length" c:identifier="webkit_dom_html_select_element_set_length" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15325,7 +16248,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_multiple" c:identifier="webkit_dom_html_select_element_set_multiple">
+      <method name="set_multiple" c:identifier="webkit_dom_html_select_element_set_multiple" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15340,7 +16264,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_select_element_set_name">
+      <method name="set_name" c:identifier="webkit_dom_html_select_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15355,7 +16280,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_selected_index" c:identifier="webkit_dom_html_select_element_set_selected_index">
+      <method name="set_selected_index" c:identifier="webkit_dom_html_select_element_set_selected_index" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15370,7 +16296,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_size" c:identifier="webkit_dom_html_select_element_set_size">
+      <method name="set_size" c:identifier="webkit_dom_html_select_element_set_size" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15385,7 +16312,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_value" c:identifier="webkit_dom_html_select_element_set_value">
+      <method name="set_value" c:identifier="webkit_dom_html_select_element_set_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15447,7 +16375,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLStyleElement" c:symbol-prefix="dom_html_style_element" c:type="WebKitDOMHTMLStyleElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLStyleElement" glib:get-type="webkit_dom_html_style_element_get_type" glib:type-struct="DOMHTMLStyleElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_disabled" c:identifier="webkit_dom_html_style_element_get_disabled">
+      <method name="get_disabled" c:identifier="webkit_dom_html_style_element_get_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -15459,7 +16388,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_media" c:identifier="webkit_dom_html_style_element_get_media">
+      <method name="get_media" c:identifier="webkit_dom_html_style_element_get_media" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15471,7 +16401,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_sheet" c:identifier="webkit_dom_html_style_element_get_sheet">
+      <method name="get_sheet" c:identifier="webkit_dom_html_style_element_get_sheet" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMStyleSheet</doc>
           <type name="DOMStyleSheet" c:type="WebKitDOMStyleSheet*"/>
@@ -15483,7 +16414,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_type_attr" c:identifier="webkit_dom_html_style_element_get_type_attr">
+      <method name="get_type_attr" c:identifier="webkit_dom_html_style_element_get_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15495,7 +16427,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_disabled" c:identifier="webkit_dom_html_style_element_set_disabled">
+      <method name="set_disabled" c:identifier="webkit_dom_html_style_element_set_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15510,7 +16443,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_media" c:identifier="webkit_dom_html_style_element_set_media">
+      <method name="set_media" c:identifier="webkit_dom_html_style_element_set_media" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15525,7 +16459,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_type_attr" c:identifier="webkit_dom_html_style_element_set_type_attr">
+      <method name="set_type_attr" c:identifier="webkit_dom_html_style_element_set_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15563,7 +16498,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLTableCaptionElement" c:symbol-prefix="dom_html_table_caption_element" c:type="WebKitDOMHTMLTableCaptionElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLTableCaptionElement" glib:get-type="webkit_dom_html_table_caption_element_get_type" glib:type-struct="DOMHTMLTableCaptionElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_align" c:identifier="webkit_dom_html_table_caption_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_table_caption_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15575,7 +16511,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_table_caption_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_table_caption_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15604,7 +16541,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLTableCellElement" c:symbol-prefix="dom_html_table_cell_element" c:type="WebKitDOMHTMLTableCellElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLTableCellElement" glib:get-type="webkit_dom_html_table_cell_element_get_type" glib:type-struct="DOMHTMLTableCellElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_abbr" c:identifier="webkit_dom_html_table_cell_element_get_abbr">
+      <method name="get_abbr" c:identifier="webkit_dom_html_table_cell_element_get_abbr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15616,7 +16554,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_align" c:identifier="webkit_dom_html_table_cell_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_table_cell_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15628,7 +16567,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_axis" c:identifier="webkit_dom_html_table_cell_element_get_axis">
+      <method name="get_axis" c:identifier="webkit_dom_html_table_cell_element_get_axis" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15640,7 +16580,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_bg_color" c:identifier="webkit_dom_html_table_cell_element_get_bg_color">
+      <method name="get_bg_color" c:identifier="webkit_dom_html_table_cell_element_get_bg_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15652,7 +16593,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_cell_index" c:identifier="webkit_dom_html_table_cell_element_get_cell_index">
+      <method name="get_cell_index" c:identifier="webkit_dom_html_table_cell_element_get_cell_index" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -15664,7 +16606,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_ch" c:identifier="webkit_dom_html_table_cell_element_get_ch">
+      <method name="get_ch" c:identifier="webkit_dom_html_table_cell_element_get_ch" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15676,7 +16619,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_ch_off" c:identifier="webkit_dom_html_table_cell_element_get_ch_off">
+      <method name="get_ch_off" c:identifier="webkit_dom_html_table_cell_element_get_ch_off" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15688,7 +16632,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_col_span" c:identifier="webkit_dom_html_table_cell_element_get_col_span">
+      <method name="get_col_span" c:identifier="webkit_dom_html_table_cell_element_get_col_span" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -15700,7 +16645,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_headers" c:identifier="webkit_dom_html_table_cell_element_get_headers">
+      <method name="get_headers" c:identifier="webkit_dom_html_table_cell_element_get_headers" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15712,7 +16658,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_height" c:identifier="webkit_dom_html_table_cell_element_get_height">
+      <method name="get_height" c:identifier="webkit_dom_html_table_cell_element_get_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15724,7 +16671,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_no_wrap" c:identifier="webkit_dom_html_table_cell_element_get_no_wrap">
+      <method name="get_no_wrap" c:identifier="webkit_dom_html_table_cell_element_get_no_wrap" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -15736,7 +16684,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_row_span" c:identifier="webkit_dom_html_table_cell_element_get_row_span">
+      <method name="get_row_span" c:identifier="webkit_dom_html_table_cell_element_get_row_span" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -15748,7 +16697,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_scope" c:identifier="webkit_dom_html_table_cell_element_get_scope">
+      <method name="get_scope" c:identifier="webkit_dom_html_table_cell_element_get_scope" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15760,7 +16710,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_v_align" c:identifier="webkit_dom_html_table_cell_element_get_v_align">
+      <method name="get_v_align" c:identifier="webkit_dom_html_table_cell_element_get_v_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15772,7 +16723,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_width" c:identifier="webkit_dom_html_table_cell_element_get_width">
+      <method name="get_width" c:identifier="webkit_dom_html_table_cell_element_get_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -15784,7 +16736,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_abbr" c:identifier="webkit_dom_html_table_cell_element_set_abbr">
+      <method name="set_abbr" c:identifier="webkit_dom_html_table_cell_element_set_abbr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15799,7 +16752,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_table_cell_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_table_cell_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15814,7 +16768,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_axis" c:identifier="webkit_dom_html_table_cell_element_set_axis">
+      <method name="set_axis" c:identifier="webkit_dom_html_table_cell_element_set_axis" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15829,7 +16784,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_bg_color" c:identifier="webkit_dom_html_table_cell_element_set_bg_color">
+      <method name="set_bg_color" c:identifier="webkit_dom_html_table_cell_element_set_bg_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15844,7 +16800,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_ch" c:identifier="webkit_dom_html_table_cell_element_set_ch">
+      <method name="set_ch" c:identifier="webkit_dom_html_table_cell_element_set_ch" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15859,7 +16816,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_ch_off" c:identifier="webkit_dom_html_table_cell_element_set_ch_off">
+      <method name="set_ch_off" c:identifier="webkit_dom_html_table_cell_element_set_ch_off" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15874,7 +16832,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_col_span" c:identifier="webkit_dom_html_table_cell_element_set_col_span">
+      <method name="set_col_span" c:identifier="webkit_dom_html_table_cell_element_set_col_span" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15889,7 +16848,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_headers" c:identifier="webkit_dom_html_table_cell_element_set_headers">
+      <method name="set_headers" c:identifier="webkit_dom_html_table_cell_element_set_headers" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15904,7 +16864,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_height" c:identifier="webkit_dom_html_table_cell_element_set_height">
+      <method name="set_height" c:identifier="webkit_dom_html_table_cell_element_set_height" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15919,7 +16880,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_no_wrap" c:identifier="webkit_dom_html_table_cell_element_set_no_wrap">
+      <method name="set_no_wrap" c:identifier="webkit_dom_html_table_cell_element_set_no_wrap" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15934,7 +16896,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_row_span" c:identifier="webkit_dom_html_table_cell_element_set_row_span">
+      <method name="set_row_span" c:identifier="webkit_dom_html_table_cell_element_set_row_span" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15949,7 +16912,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_scope" c:identifier="webkit_dom_html_table_cell_element_set_scope">
+      <method name="set_scope" c:identifier="webkit_dom_html_table_cell_element_set_scope" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15964,7 +16928,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_v_align" c:identifier="webkit_dom_html_table_cell_element_set_v_align">
+      <method name="set_v_align" c:identifier="webkit_dom_html_table_cell_element_set_v_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15979,7 +16944,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_width" c:identifier="webkit_dom_html_table_cell_element_set_width">
+      <method name="set_width" c:identifier="webkit_dom_html_table_cell_element_set_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16050,7 +17016,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLTableColElement" c:symbol-prefix="dom_html_table_col_element" c:type="WebKitDOMHTMLTableColElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLTableColElement" glib:get-type="webkit_dom_html_table_col_element_get_type" glib:type-struct="DOMHTMLTableColElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_align" c:identifier="webkit_dom_html_table_col_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_table_col_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16062,7 +17029,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_ch" c:identifier="webkit_dom_html_table_col_element_get_ch">
+      <method name="get_ch" c:identifier="webkit_dom_html_table_col_element_get_ch" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16074,7 +17042,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_ch_off" c:identifier="webkit_dom_html_table_col_element_get_ch_off">
+      <method name="get_ch_off" c:identifier="webkit_dom_html_table_col_element_get_ch_off" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16086,7 +17055,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_span" c:identifier="webkit_dom_html_table_col_element_get_span">
+      <method name="get_span" c:identifier="webkit_dom_html_table_col_element_get_span" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -16098,7 +17068,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_v_align" c:identifier="webkit_dom_html_table_col_element_get_v_align">
+      <method name="get_v_align" c:identifier="webkit_dom_html_table_col_element_get_v_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16110,7 +17081,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_width" c:identifier="webkit_dom_html_table_col_element_get_width">
+      <method name="get_width" c:identifier="webkit_dom_html_table_col_element_get_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16122,7 +17094,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_table_col_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_table_col_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16137,7 +17110,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_ch" c:identifier="webkit_dom_html_table_col_element_set_ch">
+      <method name="set_ch" c:identifier="webkit_dom_html_table_col_element_set_ch" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16152,7 +17126,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_ch_off" c:identifier="webkit_dom_html_table_col_element_set_ch_off">
+      <method name="set_ch_off" c:identifier="webkit_dom_html_table_col_element_set_ch_off" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16167,7 +17142,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_span" c:identifier="webkit_dom_html_table_col_element_set_span">
+      <method name="set_span" c:identifier="webkit_dom_html_table_col_element_set_span" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16182,7 +17158,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_v_align" c:identifier="webkit_dom_html_table_col_element_set_v_align">
+      <method name="set_v_align" c:identifier="webkit_dom_html_table_col_element_set_v_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16197,7 +17174,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_width" c:identifier="webkit_dom_html_table_col_element_set_width">
+      <method name="set_width" c:identifier="webkit_dom_html_table_col_element_set_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16241,7 +17219,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLTableElement" c:symbol-prefix="dom_html_table_element" c:type="WebKitDOMHTMLTableElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLTableElement" glib:get-type="webkit_dom_html_table_element_get_type" glib:type-struct="DOMHTMLTableElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="create_caption" c:identifier="webkit_dom_html_table_element_create_caption">
+      <method name="create_caption" c:identifier="webkit_dom_html_table_element_create_caption" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLElement</doc>
           <type name="DOMHTMLElement" c:type="WebKitDOMHTMLElement*"/>
@@ -16253,7 +17232,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="create_t_foot" c:identifier="webkit_dom_html_table_element_create_t_foot">
+      <method name="create_t_foot" c:identifier="webkit_dom_html_table_element_create_t_foot" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLElement</doc>
           <type name="DOMHTMLElement" c:type="WebKitDOMHTMLElement*"/>
@@ -16265,7 +17245,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="create_t_head" c:identifier="webkit_dom_html_table_element_create_t_head">
+      <method name="create_t_head" c:identifier="webkit_dom_html_table_element_create_t_head" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLElement</doc>
           <type name="DOMHTMLElement" c:type="WebKitDOMHTMLElement*"/>
@@ -16277,7 +17258,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="delete_caption" c:identifier="webkit_dom_html_table_element_delete_caption">
+      <method name="delete_caption" c:identifier="webkit_dom_html_table_element_delete_caption" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16288,7 +17270,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="delete_row" c:identifier="webkit_dom_html_table_element_delete_row" throws="1">
+      <method name="delete_row" c:identifier="webkit_dom_html_table_element_delete_row" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16303,7 +17286,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="delete_t_foot" c:identifier="webkit_dom_html_table_element_delete_t_foot">
+      <method name="delete_t_foot" c:identifier="webkit_dom_html_table_element_delete_t_foot" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16314,7 +17298,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="delete_t_head" c:identifier="webkit_dom_html_table_element_delete_t_head">
+      <method name="delete_t_head" c:identifier="webkit_dom_html_table_element_delete_t_head" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16325,7 +17310,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_align" c:identifier="webkit_dom_html_table_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_table_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16337,7 +17323,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_bg_color" c:identifier="webkit_dom_html_table_element_get_bg_color">
+      <method name="get_bg_color" c:identifier="webkit_dom_html_table_element_get_bg_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16349,7 +17336,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_border" c:identifier="webkit_dom_html_table_element_get_border">
+      <method name="get_border" c:identifier="webkit_dom_html_table_element_get_border" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16361,7 +17349,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_caption" c:identifier="webkit_dom_html_table_element_get_caption">
+      <method name="get_caption" c:identifier="webkit_dom_html_table_element_get_caption" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLTableCaptionElement</doc>
           <type name="DOMHTMLTableCaptionElement" c:type="WebKitDOMHTMLTableCaptionElement*"/>
@@ -16373,7 +17362,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_cell_padding" c:identifier="webkit_dom_html_table_element_get_cell_padding">
+      <method name="get_cell_padding" c:identifier="webkit_dom_html_table_element_get_cell_padding" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16385,7 +17375,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_cell_spacing" c:identifier="webkit_dom_html_table_element_get_cell_spacing">
+      <method name="get_cell_spacing" c:identifier="webkit_dom_html_table_element_get_cell_spacing" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16397,7 +17388,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_rows" c:identifier="webkit_dom_html_table_element_get_rows">
+      <method name="get_rows" c:identifier="webkit_dom_html_table_element_get_rows" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -16409,7 +17401,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_rules" c:identifier="webkit_dom_html_table_element_get_rules">
+      <method name="get_rules" c:identifier="webkit_dom_html_table_element_get_rules" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16421,7 +17414,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_summary" c:identifier="webkit_dom_html_table_element_get_summary">
+      <method name="get_summary" c:identifier="webkit_dom_html_table_element_get_summary" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16433,7 +17427,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_t_bodies" c:identifier="webkit_dom_html_table_element_get_t_bodies">
+      <method name="get_t_bodies" c:identifier="webkit_dom_html_table_element_get_t_bodies" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -16445,7 +17440,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_t_foot" c:identifier="webkit_dom_html_table_element_get_t_foot">
+      <method name="get_t_foot" c:identifier="webkit_dom_html_table_element_get_t_foot" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLTableSectionElement</doc>
           <type name="DOMHTMLTableSectionElement" c:type="WebKitDOMHTMLTableSectionElement*"/>
@@ -16457,7 +17453,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_t_head" c:identifier="webkit_dom_html_table_element_get_t_head">
+      <method name="get_t_head" c:identifier="webkit_dom_html_table_element_get_t_head" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLTableSectionElement</doc>
           <type name="DOMHTMLTableSectionElement" c:type="WebKitDOMHTMLTableSectionElement*"/>
@@ -16469,7 +17466,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_width" c:identifier="webkit_dom_html_table_element_get_width">
+      <method name="get_width" c:identifier="webkit_dom_html_table_element_get_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16481,7 +17479,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="insert_row" c:identifier="webkit_dom_html_table_element_insert_row" throws="1">
+      <method name="insert_row" c:identifier="webkit_dom_html_table_element_insert_row" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLElement</doc>
           <type name="DOMHTMLElement" c:type="WebKitDOMHTMLElement*"/>
@@ -16497,7 +17496,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_table_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_table_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16512,7 +17512,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_bg_color" c:identifier="webkit_dom_html_table_element_set_bg_color">
+      <method name="set_bg_color" c:identifier="webkit_dom_html_table_element_set_bg_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16527,7 +17528,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_border" c:identifier="webkit_dom_html_table_element_set_border">
+      <method name="set_border" c:identifier="webkit_dom_html_table_element_set_border" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16542,7 +17544,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_caption" c:identifier="webkit_dom_html_table_element_set_caption" throws="1">
+      <method name="set_caption" c:identifier="webkit_dom_html_table_element_set_caption" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16557,7 +17560,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_cell_padding" c:identifier="webkit_dom_html_table_element_set_cell_padding">
+      <method name="set_cell_padding" c:identifier="webkit_dom_html_table_element_set_cell_padding" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16572,7 +17576,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_cell_spacing" c:identifier="webkit_dom_html_table_element_set_cell_spacing">
+      <method name="set_cell_spacing" c:identifier="webkit_dom_html_table_element_set_cell_spacing" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16587,7 +17592,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_rules" c:identifier="webkit_dom_html_table_element_set_rules">
+      <method name="set_rules" c:identifier="webkit_dom_html_table_element_set_rules" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16602,7 +17608,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_summary" c:identifier="webkit_dom_html_table_element_set_summary">
+      <method name="set_summary" c:identifier="webkit_dom_html_table_element_set_summary" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16617,7 +17624,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_t_foot" c:identifier="webkit_dom_html_table_element_set_t_foot" throws="1">
+      <method name="set_t_foot" c:identifier="webkit_dom_html_table_element_set_t_foot" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16632,7 +17640,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_t_head" c:identifier="webkit_dom_html_table_element_set_t_head" throws="1">
+      <method name="set_t_head" c:identifier="webkit_dom_html_table_element_set_t_head" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16647,7 +17656,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_width" c:identifier="webkit_dom_html_table_element_set_width">
+      <method name="set_width" c:identifier="webkit_dom_html_table_element_set_width" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16712,7 +17722,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLTableRowElement" c:symbol-prefix="dom_html_table_row_element" c:type="WebKitDOMHTMLTableRowElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLTableRowElement" glib:get-type="webkit_dom_html_table_row_element_get_type" glib:type-struct="DOMHTMLTableRowElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="delete_cell" c:identifier="webkit_dom_html_table_row_element_delete_cell" throws="1">
+      <method name="delete_cell" c:identifier="webkit_dom_html_table_row_element_delete_cell" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16727,7 +17738,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_align" c:identifier="webkit_dom_html_table_row_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_table_row_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16739,7 +17751,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_bg_color" c:identifier="webkit_dom_html_table_row_element_get_bg_color">
+      <method name="get_bg_color" c:identifier="webkit_dom_html_table_row_element_get_bg_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16751,7 +17764,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_cells" c:identifier="webkit_dom_html_table_row_element_get_cells">
+      <method name="get_cells" c:identifier="webkit_dom_html_table_row_element_get_cells" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -16763,7 +17777,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_ch" c:identifier="webkit_dom_html_table_row_element_get_ch">
+      <method name="get_ch" c:identifier="webkit_dom_html_table_row_element_get_ch" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16775,7 +17790,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_ch_off" c:identifier="webkit_dom_html_table_row_element_get_ch_off">
+      <method name="get_ch_off" c:identifier="webkit_dom_html_table_row_element_get_ch_off" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16787,7 +17803,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_row_index" c:identifier="webkit_dom_html_table_row_element_get_row_index">
+      <method name="get_row_index" c:identifier="webkit_dom_html_table_row_element_get_row_index" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -16799,7 +17816,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_section_row_index" c:identifier="webkit_dom_html_table_row_element_get_section_row_index">
+      <method name="get_section_row_index" c:identifier="webkit_dom_html_table_row_element_get_section_row_index" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -16811,7 +17829,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_v_align" c:identifier="webkit_dom_html_table_row_element_get_v_align">
+      <method name="get_v_align" c:identifier="webkit_dom_html_table_row_element_get_v_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16823,7 +17842,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="insert_cell" c:identifier="webkit_dom_html_table_row_element_insert_cell" throws="1">
+      <method name="insert_cell" c:identifier="webkit_dom_html_table_row_element_insert_cell" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLElement</doc>
           <type name="DOMHTMLElement" c:type="WebKitDOMHTMLElement*"/>
@@ -16839,7 +17859,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_table_row_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_table_row_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16854,7 +17875,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_bg_color" c:identifier="webkit_dom_html_table_row_element_set_bg_color">
+      <method name="set_bg_color" c:identifier="webkit_dom_html_table_row_element_set_bg_color" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16869,7 +17891,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_ch" c:identifier="webkit_dom_html_table_row_element_set_ch">
+      <method name="set_ch" c:identifier="webkit_dom_html_table_row_element_set_ch" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16884,7 +17907,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_ch_off" c:identifier="webkit_dom_html_table_row_element_set_ch_off">
+      <method name="set_ch_off" c:identifier="webkit_dom_html_table_row_element_set_ch_off" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16899,7 +17923,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_v_align" c:identifier="webkit_dom_html_table_row_element_set_v_align">
+      <method name="set_v_align" c:identifier="webkit_dom_html_table_row_element_set_v_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16949,7 +17974,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLTableSectionElement" c:symbol-prefix="dom_html_table_section_element" c:type="WebKitDOMHTMLTableSectionElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLTableSectionElement" glib:get-type="webkit_dom_html_table_section_element_get_type" glib:type-struct="DOMHTMLTableSectionElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="delete_row" c:identifier="webkit_dom_html_table_section_element_delete_row" throws="1">
+      <method name="delete_row" c:identifier="webkit_dom_html_table_section_element_delete_row" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -16964,7 +17990,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_align" c:identifier="webkit_dom_html_table_section_element_get_align">
+      <method name="get_align" c:identifier="webkit_dom_html_table_section_element_get_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16976,7 +18003,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_ch" c:identifier="webkit_dom_html_table_section_element_get_ch">
+      <method name="get_ch" c:identifier="webkit_dom_html_table_section_element_get_ch" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -16988,7 +18016,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_ch_off" c:identifier="webkit_dom_html_table_section_element_get_ch_off">
+      <method name="get_ch_off" c:identifier="webkit_dom_html_table_section_element_get_ch_off" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -17000,7 +18029,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_rows" c:identifier="webkit_dom_html_table_section_element_get_rows">
+      <method name="get_rows" c:identifier="webkit_dom_html_table_section_element_get_rows" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMHTMLCollection</doc>
           <type name="DOMHTMLCollection" c:type="WebKitDOMHTMLCollection*"/>
@@ -17012,7 +18042,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_v_align" c:identifier="webkit_dom_html_table_section_element_get_v_align">
+      <method name="get_v_align" c:identifier="webkit_dom_html_table_section_element_get_v_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -17024,7 +18055,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="insert_row" c:identifier="webkit_dom_html_table_section_element_insert_row" throws="1">
+      <method name="insert_row" c:identifier="webkit_dom_html_table_section_element_insert_row" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLElement</doc>
           <type name="DOMHTMLElement" c:type="WebKitDOMHTMLElement*"/>
@@ -17040,7 +18072,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_align" c:identifier="webkit_dom_html_table_section_element_set_align">
+      <method name="set_align" c:identifier="webkit_dom_html_table_section_element_set_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17055,7 +18088,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_ch" c:identifier="webkit_dom_html_table_section_element_set_ch">
+      <method name="set_ch" c:identifier="webkit_dom_html_table_section_element_set_ch" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17070,7 +18104,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_ch_off" c:identifier="webkit_dom_html_table_section_element_set_ch_off">
+      <method name="set_ch_off" c:identifier="webkit_dom_html_table_section_element_set_ch_off" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17085,7 +18120,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_v_align" c:identifier="webkit_dom_html_table_section_element_set_v_align">
+      <method name="set_v_align" c:identifier="webkit_dom_html_table_section_element_set_v_align" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17126,7 +18162,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLTextAreaElement" c:symbol-prefix="dom_html_text_area_element" c:type="WebKitDOMHTMLTextAreaElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLTextAreaElement" glib:get-type="webkit_dom_html_text_area_element_get_type" glib:type-struct="DOMHTMLTextAreaElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_area_type" c:identifier="webkit_dom_html_text_area_element_get_area_type">
+      <method name="get_area_type" c:identifier="webkit_dom_html_text_area_element_get_area_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -17138,7 +18175,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_autofocus" c:identifier="webkit_dom_html_text_area_element_get_autofocus">
+      <method name="get_autofocus" c:identifier="webkit_dom_html_text_area_element_get_autofocus" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -17150,7 +18188,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_cols" c:identifier="webkit_dom_html_text_area_element_get_cols">
+      <method name="get_cols" c:identifier="webkit_dom_html_text_area_element_get_cols" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -17162,7 +18201,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_default_value" c:identifier="webkit_dom_html_text_area_element_get_default_value">
+      <method name="get_default_value" c:identifier="webkit_dom_html_text_area_element_get_default_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -17174,7 +18214,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_disabled" c:identifier="webkit_dom_html_text_area_element_get_disabled">
+      <method name="get_disabled" c:identifier="webkit_dom_html_text_area_element_get_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -17186,7 +18227,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_form" c:identifier="webkit_dom_html_text_area_element_get_form">
+      <method name="get_form" c:identifier="webkit_dom_html_text_area_element_get_form" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMHTMLFormElement</doc>
           <type name="DOMHTMLFormElement" c:type="WebKitDOMHTMLFormElement*"/>
@@ -17198,7 +18240,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_name" c:identifier="webkit_dom_html_text_area_element_get_name">
+      <method name="get_name" c:identifier="webkit_dom_html_text_area_element_get_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -17210,7 +18253,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_read_only" c:identifier="webkit_dom_html_text_area_element_get_read_only">
+      <method name="get_read_only" c:identifier="webkit_dom_html_text_area_element_get_read_only" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -17222,7 +18266,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_rows" c:identifier="webkit_dom_html_text_area_element_get_rows">
+      <method name="get_rows" c:identifier="webkit_dom_html_text_area_element_get_rows" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -17234,7 +18279,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_selection_end" c:identifier="webkit_dom_html_text_area_element_get_selection_end">
+      <method name="get_selection_end" c:identifier="webkit_dom_html_text_area_element_get_selection_end" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -17246,7 +18292,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_selection_start" c:identifier="webkit_dom_html_text_area_element_get_selection_start">
+      <method name="get_selection_start" c:identifier="webkit_dom_html_text_area_element_get_selection_start" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -17258,7 +18305,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_value" c:identifier="webkit_dom_html_text_area_element_get_value">
+      <method name="get_value" c:identifier="webkit_dom_html_text_area_element_get_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -17270,7 +18318,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_will_validate" c:identifier="webkit_dom_html_text_area_element_get_will_validate">
+      <method name="get_will_validate" c:identifier="webkit_dom_html_text_area_element_get_will_validate" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -17282,7 +18331,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="is_edited" c:identifier="webkit_dom_html_text_area_element_is_edited">
+      <method name="is_edited" c:identifier="webkit_dom_html_text_area_element_is_edited" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -17294,7 +18344,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="select" c:identifier="webkit_dom_html_text_area_element_select">
+      <method name="select" c:identifier="webkit_dom_html_text_area_element_select" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17305,7 +18356,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_autofocus" c:identifier="webkit_dom_html_text_area_element_set_autofocus">
+      <method name="set_autofocus" c:identifier="webkit_dom_html_text_area_element_set_autofocus" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17320,7 +18372,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_cols" c:identifier="webkit_dom_html_text_area_element_set_cols">
+      <method name="set_cols" c:identifier="webkit_dom_html_text_area_element_set_cols" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17335,7 +18388,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_default_value" c:identifier="webkit_dom_html_text_area_element_set_default_value">
+      <method name="set_default_value" c:identifier="webkit_dom_html_text_area_element_set_default_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17350,7 +18404,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_disabled" c:identifier="webkit_dom_html_text_area_element_set_disabled">
+      <method name="set_disabled" c:identifier="webkit_dom_html_text_area_element_set_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17365,7 +18420,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_name" c:identifier="webkit_dom_html_text_area_element_set_name">
+      <method name="set_name" c:identifier="webkit_dom_html_text_area_element_set_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17380,7 +18436,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_read_only" c:identifier="webkit_dom_html_text_area_element_set_read_only">
+      <method name="set_read_only" c:identifier="webkit_dom_html_text_area_element_set_read_only" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17395,7 +18452,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_rows" c:identifier="webkit_dom_html_text_area_element_set_rows">
+      <method name="set_rows" c:identifier="webkit_dom_html_text_area_element_set_rows" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17410,7 +18468,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_selection_end" c:identifier="webkit_dom_html_text_area_element_set_selection_end">
+      <method name="set_selection_end" c:identifier="webkit_dom_html_text_area_element_set_selection_end" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17425,7 +18484,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_selection_range" c:identifier="webkit_dom_html_text_area_element_set_selection_range">
+      <method name="set_selection_range" c:identifier="webkit_dom_html_text_area_element_set_selection_range" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17448,7 +18508,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_selection_start" c:identifier="webkit_dom_html_text_area_element_set_selection_start">
+      <method name="set_selection_start" c:identifier="webkit_dom_html_text_area_element_set_selection_start" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17463,7 +18524,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_value" c:identifier="webkit_dom_html_text_area_element_set_value">
+      <method name="set_value" c:identifier="webkit_dom_html_text_area_element_set_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17528,7 +18590,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLTitleElement" c:symbol-prefix="dom_html_title_element" c:type="WebKitDOMHTMLTitleElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLTitleElement" glib:get-type="webkit_dom_html_title_element_get_type" glib:type-struct="DOMHTMLTitleElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_text" c:identifier="webkit_dom_html_title_element_get_text">
+      <method name="get_text" c:identifier="webkit_dom_html_title_element_get_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -17540,7 +18603,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_text" c:identifier="webkit_dom_html_title_element_set_text">
+      <method name="set_text" c:identifier="webkit_dom_html_title_element_set_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17569,7 +18633,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMHTMLUListElement" c:symbol-prefix="dom_html_u_list_element" c:type="WebKitDOMHTMLUListElement" parent="DOMHTMLElement" glib:type-name="WebKitDOMHTMLUListElement" glib:get-type="webkit_dom_html_u_list_element_get_type" glib:type-struct="DOMHTMLUListElementClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_compact" c:identifier="webkit_dom_html_u_list_element_get_compact">
+      <method name="get_compact" c:identifier="webkit_dom_html_u_list_element_get_compact" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -17581,7 +18646,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_type_attr" c:identifier="webkit_dom_html_u_list_element_get_type_attr">
+      <method name="get_type_attr" c:identifier="webkit_dom_html_u_list_element_get_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -17593,7 +18659,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_compact" c:identifier="webkit_dom_html_u_list_element_set_compact">
+      <method name="set_compact" c:identifier="webkit_dom_html_u_list_element_set_compact" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17608,7 +18675,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_type_attr" c:identifier="webkit_dom_html_u_list_element_set_type_attr">
+      <method name="set_type_attr" c:identifier="webkit_dom_html_u_list_element_set_type_attr" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17639,7 +18707,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMKeyboardEvent" c:symbol-prefix="dom_keyboard_event" c:type="WebKitDOMKeyboardEvent" parent="DOMUIEvent" glib:type-name="WebKitDOMKeyboardEvent" glib:get-type="webkit_dom_keyboard_event_get_type" glib:type-struct="DOMKeyboardEventClass">
-      <method name="get_alt_graph_key" c:identifier="webkit_dom_keyboard_event_get_alt_graph_key">
+      <method name="get_alt_graph_key" c:identifier="webkit_dom_keyboard_event_get_alt_graph_key" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -17651,7 +18720,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_alt_key" c:identifier="webkit_dom_keyboard_event_get_alt_key">
+      <method name="get_alt_key" c:identifier="webkit_dom_keyboard_event_get_alt_key" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -17663,7 +18733,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_ctrl_key" c:identifier="webkit_dom_keyboard_event_get_ctrl_key">
+      <method name="get_ctrl_key" c:identifier="webkit_dom_keyboard_event_get_ctrl_key" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -17675,7 +18746,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_key_identifier" c:identifier="webkit_dom_keyboard_event_get_key_identifier">
+      <method name="get_key_identifier" c:identifier="webkit_dom_keyboard_event_get_key_identifier" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -17687,7 +18759,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_key_location" c:identifier="webkit_dom_keyboard_event_get_key_location">
+      <method name="get_key_location" c:identifier="webkit_dom_keyboard_event_get_key_location" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -17699,7 +18772,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_meta_key" c:identifier="webkit_dom_keyboard_event_get_meta_key">
+      <method name="get_meta_key" c:identifier="webkit_dom_keyboard_event_get_meta_key" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -17711,7 +18785,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_modifier_state" c:identifier="webkit_dom_keyboard_event_get_modifier_state">
+      <method name="get_modifier_state" c:identifier="webkit_dom_keyboard_event_get_modifier_state" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -17727,7 +18802,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_shift_key" c:identifier="webkit_dom_keyboard_event_get_shift_key">
+      <method name="get_shift_key" c:identifier="webkit_dom_keyboard_event_get_shift_key" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -17739,7 +18815,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="init_keyboard_event" c:identifier="webkit_dom_keyboard_event_init_keyboard_event">
+      <method name="init_keyboard_event" c:identifier="webkit_dom_keyboard_event_init_keyboard_event" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17825,7 +18902,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMMediaList" c:symbol-prefix="dom_media_list" c:type="WebKitDOMMediaList" parent="DOMObject" glib:type-name="WebKitDOMMediaList" glib:get-type="webkit_dom_media_list_get_type" glib:type-struct="DOMMediaListClass">
-      <method name="append_medium" c:identifier="webkit_dom_media_list_append_medium" throws="1">
+      <method name="append_medium" c:identifier="webkit_dom_media_list_append_medium" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17840,7 +18918,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="delete_medium" c:identifier="webkit_dom_media_list_delete_medium" throws="1">
+      <method name="delete_medium" c:identifier="webkit_dom_media_list_delete_medium" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17855,7 +18934,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_length" c:identifier="webkit_dom_media_list_get_length">
+      <method name="get_length" c:identifier="webkit_dom_media_list_get_length" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -17867,7 +18947,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_media_text" c:identifier="webkit_dom_media_list_get_media_text">
+      <method name="get_media_text" c:identifier="webkit_dom_media_list_get_media_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -17879,7 +18960,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="item" c:identifier="webkit_dom_media_list_item">
+      <method name="item" c:identifier="webkit_dom_media_list_item" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -17895,7 +18977,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_media_text" c:identifier="webkit_dom_media_list_set_media_text" throws="1">
+      <method name="set_media_text" c:identifier="webkit_dom_media_list_set_media_text" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17926,7 +19009,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMMouseEvent" c:symbol-prefix="dom_mouse_event" c:type="WebKitDOMMouseEvent" parent="DOMUIEvent" glib:type-name="WebKitDOMMouseEvent" glib:get-type="webkit_dom_mouse_event_get_type" glib:type-struct="DOMMouseEventClass">
-      <method name="get_alt_key" c:identifier="webkit_dom_mouse_event_get_alt_key">
+      <method name="get_alt_key" c:identifier="webkit_dom_mouse_event_get_alt_key" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -17938,7 +19022,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_button" c:identifier="webkit_dom_mouse_event_get_button">
+      <method name="get_button" c:identifier="webkit_dom_mouse_event_get_button" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gushort</doc>
           <type name="gushort" c:type="gushort"/>
@@ -17950,7 +19035,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_client_x" c:identifier="webkit_dom_mouse_event_get_client_x">
+      <method name="get_client_x" c:identifier="webkit_dom_mouse_event_get_client_x" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -17962,7 +19048,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_client_y" c:identifier="webkit_dom_mouse_event_get_client_y">
+      <method name="get_client_y" c:identifier="webkit_dom_mouse_event_get_client_y" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -17974,7 +19061,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_ctrl_key" c:identifier="webkit_dom_mouse_event_get_ctrl_key">
+      <method name="get_ctrl_key" c:identifier="webkit_dom_mouse_event_get_ctrl_key" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -17986,7 +19074,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_from_element" c:identifier="webkit_dom_mouse_event_get_from_element">
+      <method name="get_from_element" c:identifier="webkit_dom_mouse_event_get_from_element" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -17998,7 +19087,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_meta_key" c:identifier="webkit_dom_mouse_event_get_meta_key">
+      <method name="get_meta_key" c:identifier="webkit_dom_mouse_event_get_meta_key" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -18010,7 +19100,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_offset_x" c:identifier="webkit_dom_mouse_event_get_offset_x">
+      <method name="get_offset_x" c:identifier="webkit_dom_mouse_event_get_offset_x" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -18022,7 +19113,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_offset_y" c:identifier="webkit_dom_mouse_event_get_offset_y">
+      <method name="get_offset_y" c:identifier="webkit_dom_mouse_event_get_offset_y" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -18034,7 +19126,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_related_target" c:identifier="webkit_dom_mouse_event_get_related_target">
+      <method name="get_related_target" c:identifier="webkit_dom_mouse_event_get_related_target" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMEventTarget</doc>
           <type name="DOMEventTarget" c:type="WebKitDOMEventTarget*"/>
@@ -18046,7 +19139,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_screen_x" c:identifier="webkit_dom_mouse_event_get_screen_x">
+      <method name="get_screen_x" c:identifier="webkit_dom_mouse_event_get_screen_x" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -18058,7 +19152,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_screen_y" c:identifier="webkit_dom_mouse_event_get_screen_y">
+      <method name="get_screen_y" c:identifier="webkit_dom_mouse_event_get_screen_y" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -18070,7 +19165,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_shift_key" c:identifier="webkit_dom_mouse_event_get_shift_key">
+      <method name="get_shift_key" c:identifier="webkit_dom_mouse_event_get_shift_key" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -18082,7 +19178,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_to_element" c:identifier="webkit_dom_mouse_event_get_to_element">
+      <method name="get_to_element" c:identifier="webkit_dom_mouse_event_get_to_element" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18094,7 +19191,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_x" c:identifier="webkit_dom_mouse_event_get_x">
+      <method name="get_x" c:identifier="webkit_dom_mouse_event_get_x" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -18106,7 +19204,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_y" c:identifier="webkit_dom_mouse_event_get_y">
+      <method name="get_y" c:identifier="webkit_dom_mouse_event_get_y" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -18118,7 +19217,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="init_mouse_event" c:identifier="webkit_dom_mouse_event_init_mouse_event">
+      <method name="init_mouse_event" c:identifier="webkit_dom_mouse_event_init_mouse_event" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -18247,7 +19347,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMNamedNodeMap" c:symbol-prefix="dom_named_node_map" c:type="WebKitDOMNamedNodeMap" parent="DOMObject" glib:type-name="WebKitDOMNamedNodeMap" glib:get-type="webkit_dom_named_node_map_get_type" glib:type-struct="DOMNamedNodeMapClass">
-      <method name="get_length" c:identifier="webkit_dom_named_node_map_get_length">
+      <method name="get_length" c:identifier="webkit_dom_named_node_map_get_length" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -18259,7 +19360,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_named_item" c:identifier="webkit_dom_named_node_map_get_named_item">
+      <method name="get_named_item" c:identifier="webkit_dom_named_node_map_get_named_item" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18275,7 +19377,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_named_item_ns" c:identifier="webkit_dom_named_node_map_get_named_item_ns">
+      <method name="get_named_item_ns" c:identifier="webkit_dom_named_node_map_get_named_item_ns" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18295,7 +19398,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="item" c:identifier="webkit_dom_named_node_map_item">
+      <method name="item" c:identifier="webkit_dom_named_node_map_item" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18311,7 +19415,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="remove_named_item" c:identifier="webkit_dom_named_node_map_remove_named_item" throws="1">
+      <method name="remove_named_item" c:identifier="webkit_dom_named_node_map_remove_named_item" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18327,7 +19432,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="remove_named_item_ns" c:identifier="webkit_dom_named_node_map_remove_named_item_ns" throws="1">
+      <method name="remove_named_item_ns" c:identifier="webkit_dom_named_node_map_remove_named_item_ns" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18347,7 +19453,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_named_item" c:identifier="webkit_dom_named_node_map_set_named_item" throws="1">
+      <method name="set_named_item" c:identifier="webkit_dom_named_node_map_set_named_item" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18363,7 +19470,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_named_item_ns" c:identifier="webkit_dom_named_node_map_set_named_item_ns" throws="1">
+      <method name="set_named_item_ns" c:identifier="webkit_dom_named_node_map_set_named_item_ns" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18393,7 +19501,21 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMNode" c:symbol-prefix="dom_node" c:type="WebKitDOMNode" parent="DOMObject" glib:type-name="WebKitDOMNode" glib:get-type="webkit_dom_node_get_type" glib:type-struct="DOMNodeClass">
       <implements name="DOMEventTarget"/>
-      <method name="append_child" c:identifier="webkit_dom_node_append_child" throws="1">
+      <function name="for_js_value" c:identifier="webkit_dom_node_for_js_value" version="2.22">
+        <doc xml:space="preserve">Get the #WebKitDOMNode for the DOM node referenced by @value.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">a #WebKitDOMNode, or %NULL if @value doesn't reference a DOM node.</doc>
+          <type name="DOMNode" c:type="WebKitDOMNode*"/>
+        </return-value>
+        <parameters>
+          <parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve">a #JSCValue</doc>
+            <type name="JavaScriptCore.Value" c:type="JSCValue*"/>
+          </parameter>
+        </parameters>
+      </function>
+      <method name="append_child" c:identifier="webkit_dom_node_append_child" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18426,7 +19548,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="clone_node_with_error" c:identifier="webkit_dom_node_clone_node_with_error" version="2.14" throws="1">
+      <method name="clone_node_with_error" c:identifier="webkit_dom_node_clone_node_with_error" version="2.14" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18442,7 +19565,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="compare_document_position" c:identifier="webkit_dom_node_compare_document_position">
+      <method name="compare_document_position" c:identifier="webkit_dom_node_compare_document_position" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gushort</doc>
           <type name="gushort" c:type="gushort"/>
@@ -18458,7 +19582,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="contains" c:identifier="webkit_dom_node_contains">
+      <method name="contains" c:identifier="webkit_dom_node_contains" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -18474,7 +19599,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_base_uri" c:identifier="webkit_dom_node_get_base_uri">
+      <method name="get_base_uri" c:identifier="webkit_dom_node_get_base_uri" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -18486,7 +19612,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_child_nodes" c:identifier="webkit_dom_node_get_child_nodes">
+      <method name="get_child_nodes" c:identifier="webkit_dom_node_get_child_nodes" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMNodeList</doc>
           <type name="DOMNodeList" c:type="WebKitDOMNodeList*"/>
@@ -18498,7 +19625,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_first_child" c:identifier="webkit_dom_node_get_first_child">
+      <method name="get_first_child" c:identifier="webkit_dom_node_get_first_child" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18510,7 +19638,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_last_child" c:identifier="webkit_dom_node_get_last_child">
+      <method name="get_last_child" c:identifier="webkit_dom_node_get_last_child" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18548,7 +19677,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_next_sibling" c:identifier="webkit_dom_node_get_next_sibling">
+      <method name="get_next_sibling" c:identifier="webkit_dom_node_get_next_sibling" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18560,7 +19690,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_node_name" c:identifier="webkit_dom_node_get_node_name">
+      <method name="get_node_name" c:identifier="webkit_dom_node_get_node_name" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -18572,7 +19703,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_node_type" c:identifier="webkit_dom_node_get_node_type">
+      <method name="get_node_type" c:identifier="webkit_dom_node_get_node_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gushort</doc>
           <type name="gushort" c:type="gushort"/>
@@ -18584,7 +19716,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_node_value" c:identifier="webkit_dom_node_get_node_value">
+      <method name="get_node_value" c:identifier="webkit_dom_node_get_node_value" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -18596,7 +19729,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_owner_document" c:identifier="webkit_dom_node_get_owner_document">
+      <method name="get_owner_document" c:identifier="webkit_dom_node_get_owner_document" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMDocument</doc>
           <type name="DOMDocument" c:type="WebKitDOMDocument*"/>
@@ -18608,7 +19742,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_parent_element" c:identifier="webkit_dom_node_get_parent_element">
+      <method name="get_parent_element" c:identifier="webkit_dom_node_get_parent_element" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMElement</doc>
           <type name="DOMElement" c:type="WebKitDOMElement*"/>
@@ -18620,7 +19755,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_parent_node" c:identifier="webkit_dom_node_get_parent_node">
+      <method name="get_parent_node" c:identifier="webkit_dom_node_get_parent_node" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18645,7 +19781,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_previous_sibling" c:identifier="webkit_dom_node_get_previous_sibling">
+      <method name="get_previous_sibling" c:identifier="webkit_dom_node_get_previous_sibling" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18657,7 +19794,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_text_content" c:identifier="webkit_dom_node_get_text_content">
+      <method name="get_text_content" c:identifier="webkit_dom_node_get_text_content" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -18669,7 +19807,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="has_child_nodes" c:identifier="webkit_dom_node_has_child_nodes">
+      <method name="has_child_nodes" c:identifier="webkit_dom_node_has_child_nodes" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -18681,7 +19820,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="insert_before" c:identifier="webkit_dom_node_insert_before" throws="1">
+      <method name="insert_before" c:identifier="webkit_dom_node_insert_before" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18701,7 +19841,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="is_default_namespace" c:identifier="webkit_dom_node_is_default_namespace">
+      <method name="is_default_namespace" c:identifier="webkit_dom_node_is_default_namespace" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -18717,7 +19858,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="is_equal_node" c:identifier="webkit_dom_node_is_equal_node">
+      <method name="is_equal_node" c:identifier="webkit_dom_node_is_equal_node" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -18733,7 +19875,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="is_same_node" c:identifier="webkit_dom_node_is_same_node">
+      <method name="is_same_node" c:identifier="webkit_dom_node_is_same_node" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -18749,7 +19892,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="is_supported" c:identifier="webkit_dom_node_is_supported">
+      <method name="is_supported" c:identifier="webkit_dom_node_is_supported" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -18769,7 +19913,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="lookup_namespace_uri" c:identifier="webkit_dom_node_lookup_namespace_uri">
+      <method name="lookup_namespace_uri" c:identifier="webkit_dom_node_lookup_namespace_uri" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -18785,7 +19930,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="lookup_prefix" c:identifier="webkit_dom_node_lookup_prefix">
+      <method name="lookup_prefix" c:identifier="webkit_dom_node_lookup_prefix" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -18801,7 +19947,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="normalize" c:identifier="webkit_dom_node_normalize">
+      <method name="normalize" c:identifier="webkit_dom_node_normalize" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -18812,7 +19959,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="remove_child" c:identifier="webkit_dom_node_remove_child" throws="1">
+      <method name="remove_child" c:identifier="webkit_dom_node_remove_child" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18828,7 +19976,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="replace_child" c:identifier="webkit_dom_node_replace_child" throws="1">
+      <method name="replace_child" c:identifier="webkit_dom_node_replace_child" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -18848,7 +19997,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_node_value" c:identifier="webkit_dom_node_set_node_value" throws="1">
+      <method name="set_node_value" c:identifier="webkit_dom_node_set_node_value" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -18878,7 +20028,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_text_content" c:identifier="webkit_dom_node_set_text_content" throws="1">
+      <method name="set_text_content" c:identifier="webkit_dom_node_set_text_content" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -18942,7 +20093,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <interface name="DOMNodeFilter" c:symbol-prefix="dom_node_filter" c:type="WebKitDOMNodeFilter" glib:type-name="WebKitDOMNodeFilter" glib:get-type="webkit_dom_node_filter_get_type" glib:type-struct="DOMNodeFilterIface">
-      <virtual-method name="accept_node" invoker="accept_node">
+      <virtual-method name="accept_node" invoker="accept_node" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a #gshort</doc>
           <type name="gshort" c:type="gshort"/>
@@ -18958,7 +20110,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <method name="accept_node" c:identifier="webkit_dom_node_filter_accept_node">
+      <method name="accept_node" c:identifier="webkit_dom_node_filter_accept_node" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a #gshort</doc>
           <type name="gshort" c:type="gshort"/>
@@ -19027,7 +20180,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMNodeIterator" c:symbol-prefix="dom_node_iterator" c:type="WebKitDOMNodeIterator" parent="DOMObject" glib:type-name="WebKitDOMNodeIterator" glib:get-type="webkit_dom_node_iterator_get_type" glib:type-struct="DOMNodeIteratorClass">
-      <method name="detach" c:identifier="webkit_dom_node_iterator_detach">
+      <method name="detach" c:identifier="webkit_dom_node_iterator_detach" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -19051,7 +20205,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_filter" c:identifier="webkit_dom_node_iterator_get_filter">
+      <method name="get_filter" c:identifier="webkit_dom_node_iterator_get_filter" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMNodeFilter</doc>
           <type name="DOMNodeFilter" c:type="WebKitDOMNodeFilter*"/>
@@ -19063,7 +20218,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_pointer_before_reference_node" c:identifier="webkit_dom_node_iterator_get_pointer_before_reference_node">
+      <method name="get_pointer_before_reference_node" c:identifier="webkit_dom_node_iterator_get_pointer_before_reference_node" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -19075,7 +20231,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_reference_node" c:identifier="webkit_dom_node_iterator_get_reference_node">
+      <method name="get_reference_node" c:identifier="webkit_dom_node_iterator_get_reference_node" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -19087,7 +20244,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_root" c:identifier="webkit_dom_node_iterator_get_root">
+      <method name="get_root" c:identifier="webkit_dom_node_iterator_get_root" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -19099,7 +20257,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_what_to_show" c:identifier="webkit_dom_node_iterator_get_what_to_show">
+      <method name="get_what_to_show" c:identifier="webkit_dom_node_iterator_get_what_to_show" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -19111,7 +20270,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="next_node" c:identifier="webkit_dom_node_iterator_next_node" throws="1">
+      <method name="next_node" c:identifier="webkit_dom_node_iterator_next_node" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -19123,7 +20283,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="previous_node" c:identifier="webkit_dom_node_iterator_previous_node" throws="1">
+      <method name="previous_node" c:identifier="webkit_dom_node_iterator_previous_node" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -19160,7 +20321,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMNodeList" c:symbol-prefix="dom_node_list" c:type="WebKitDOMNodeList" parent="DOMObject" glib:type-name="WebKitDOMNodeList" glib:get-type="webkit_dom_node_list_get_type" glib:type-struct="DOMNodeListClass">
-      <method name="get_length" c:identifier="webkit_dom_node_list_get_length">
+      <method name="get_length" c:identifier="webkit_dom_node_list_get_length" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -19172,7 +20334,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="item" c:identifier="webkit_dom_node_list_item">
+      <method name="item" c:identifier="webkit_dom_node_list_item" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -19216,11 +20379,10 @@ instead of a callbacks for easier binding in other languages.</doc>
         <type name="GObject.ObjectClass" c:type="GObjectClass"/>
       </field>
     </record>
-    <record name="DOMObjectPrivate" c:type="WebKitDOMObjectPrivate" disguised="1">
-    </record>
     <class name="DOMProcessingInstruction" c:symbol-prefix="dom_processing_instruction" c:type="WebKitDOMProcessingInstruction" parent="DOMCharacterData" glib:type-name="WebKitDOMProcessingInstruction" glib:get-type="webkit_dom_processing_instruction_get_type" glib:type-struct="DOMProcessingInstructionClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_sheet" c:identifier="webkit_dom_processing_instruction_get_sheet">
+      <method name="get_sheet" c:identifier="webkit_dom_processing_instruction_get_sheet" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMStyleSheet</doc>
           <type name="DOMStyleSheet" c:type="WebKitDOMStyleSheet*"/>
@@ -19232,7 +20394,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_target" c:identifier="webkit_dom_processing_instruction_get_target">
+      <method name="get_target" c:identifier="webkit_dom_processing_instruction_get_target" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -19260,7 +20423,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMRange" c:symbol-prefix="dom_range" c:type="WebKitDOMRange" parent="DOMObject" glib:type-name="WebKitDOMRange" glib:get-type="webkit_dom_range_get_type" glib:type-struct="DOMRangeClass">
-      <method name="clone_contents" c:identifier="webkit_dom_range_clone_contents" throws="1">
+      <method name="clone_contents" c:identifier="webkit_dom_range_clone_contents" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMDocumentFragment</doc>
           <type name="DOMDocumentFragment" c:type="WebKitDOMDocumentFragment*"/>
@@ -19272,7 +20436,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="clone_range" c:identifier="webkit_dom_range_clone_range" throws="1">
+      <method name="clone_range" c:identifier="webkit_dom_range_clone_range" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMRange</doc>
           <type name="DOMRange" c:type="WebKitDOMRange*"/>
@@ -19284,7 +20449,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="collapse" c:identifier="webkit_dom_range_collapse" throws="1">
+      <method name="collapse" c:identifier="webkit_dom_range_collapse" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -19299,7 +20465,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="compare_boundary_points" c:identifier="webkit_dom_range_compare_boundary_points" throws="1">
+      <method name="compare_boundary_points" c:identifier="webkit_dom_range_compare_boundary_points" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gshort</doc>
           <type name="gshort" c:type="gshort"/>
@@ -19319,7 +20486,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="compare_node" c:identifier="webkit_dom_range_compare_node" throws="1">
+      <method name="compare_node" c:identifier="webkit_dom_range_compare_node" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gshort</doc>
           <type name="gshort" c:type="gshort"/>
@@ -19335,7 +20503,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="compare_point" c:identifier="webkit_dom_range_compare_point" throws="1">
+      <method name="compare_point" c:identifier="webkit_dom_range_compare_point" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gshort</doc>
           <type name="gshort" c:type="gshort"/>
@@ -19355,7 +20524,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="create_contextual_fragment" c:identifier="webkit_dom_range_create_contextual_fragment" throws="1">
+      <method name="create_contextual_fragment" c:identifier="webkit_dom_range_create_contextual_fragment" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMDocumentFragment</doc>
           <type name="DOMDocumentFragment" c:type="WebKitDOMDocumentFragment*"/>
@@ -19371,7 +20541,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="delete_contents" c:identifier="webkit_dom_range_delete_contents" throws="1">
+      <method name="delete_contents" c:identifier="webkit_dom_range_delete_contents" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -19382,7 +20553,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="detach" c:identifier="webkit_dom_range_detach" throws="1">
+      <method name="detach" c:identifier="webkit_dom_range_detach" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -19393,7 +20565,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="expand" c:identifier="webkit_dom_range_expand" version="2.16" throws="1">
+      <method name="expand" c:identifier="webkit_dom_range_expand" version="2.16" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -19408,7 +20581,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="extract_contents" c:identifier="webkit_dom_range_extract_contents" throws="1">
+      <method name="extract_contents" c:identifier="webkit_dom_range_extract_contents" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMDocumentFragment</doc>
           <type name="DOMDocumentFragment" c:type="WebKitDOMDocumentFragment*"/>
@@ -19420,7 +20594,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_collapsed" c:identifier="webkit_dom_range_get_collapsed" throws="1">
+      <method name="get_collapsed" c:identifier="webkit_dom_range_get_collapsed" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -19432,7 +20607,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_common_ancestor_container" c:identifier="webkit_dom_range_get_common_ancestor_container" throws="1">
+      <method name="get_common_ancestor_container" c:identifier="webkit_dom_range_get_common_ancestor_container" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -19444,7 +20620,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_end_container" c:identifier="webkit_dom_range_get_end_container" throws="1">
+      <method name="get_end_container" c:identifier="webkit_dom_range_get_end_container" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -19456,7 +20633,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_end_offset" c:identifier="webkit_dom_range_get_end_offset" throws="1">
+      <method name="get_end_offset" c:identifier="webkit_dom_range_get_end_offset" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -19468,7 +20646,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_start_container" c:identifier="webkit_dom_range_get_start_container" throws="1">
+      <method name="get_start_container" c:identifier="webkit_dom_range_get_start_container" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -19480,7 +20659,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_start_offset" c:identifier="webkit_dom_range_get_start_offset" throws="1">
+      <method name="get_start_offset" c:identifier="webkit_dom_range_get_start_offset" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -19492,7 +20672,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_text" c:identifier="webkit_dom_range_get_text">
+      <method name="get_text" c:identifier="webkit_dom_range_get_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -19504,7 +20685,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="insert_node" c:identifier="webkit_dom_range_insert_node" throws="1">
+      <method name="insert_node" c:identifier="webkit_dom_range_insert_node" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -19519,7 +20701,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="intersects_node" c:identifier="webkit_dom_range_intersects_node" throws="1">
+      <method name="intersects_node" c:identifier="webkit_dom_range_intersects_node" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -19535,7 +20718,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="is_point_in_range" c:identifier="webkit_dom_range_is_point_in_range" throws="1">
+      <method name="is_point_in_range" c:identifier="webkit_dom_range_is_point_in_range" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -19555,7 +20739,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="select_node" c:identifier="webkit_dom_range_select_node" throws="1">
+      <method name="select_node" c:identifier="webkit_dom_range_select_node" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -19570,7 +20755,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="select_node_contents" c:identifier="webkit_dom_range_select_node_contents" throws="1">
+      <method name="select_node_contents" c:identifier="webkit_dom_range_select_node_contents" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -19585,56 +20771,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_end" c:identifier="webkit_dom_range_set_end" throws="1">
-        <return-value transfer-ownership="none">
-          <type name="none" c:type="void"/>
-        </return-value>
-        <parameters>
-          <instance-parameter name="self" transfer-ownership="none">
-            <doc xml:space="preserve">A #WebKitDOMRange</doc>
-            <type name="DOMRange" c:type="WebKitDOMRange*"/>
-          </instance-parameter>
-          <parameter name="refNode" transfer-ownership="none">
-            <doc xml:space="preserve">A #WebKitDOMNode</doc>
-            <type name="DOMNode" c:type="WebKitDOMNode*"/>
-          </parameter>
-          <parameter name="offset" transfer-ownership="none">
-            <doc xml:space="preserve">A #glong</doc>
-            <type name="glong" c:type="glong"/>
-          </parameter>
-        </parameters>
-      </method>
-      <method name="set_end_after" c:identifier="webkit_dom_range_set_end_after" throws="1">
-        <return-value transfer-ownership="none">
-          <type name="none" c:type="void"/>
-        </return-value>
-        <parameters>
-          <instance-parameter name="self" transfer-ownership="none">
-            <doc xml:space="preserve">A #WebKitDOMRange</doc>
-            <type name="DOMRange" c:type="WebKitDOMRange*"/>
-          </instance-parameter>
-          <parameter name="refNode" transfer-ownership="none">
-            <doc xml:space="preserve">A #WebKitDOMNode</doc>
-            <type name="DOMNode" c:type="WebKitDOMNode*"/>
-          </parameter>
-        </parameters>
-      </method>
-      <method name="set_end_before" c:identifier="webkit_dom_range_set_end_before" throws="1">
-        <return-value transfer-ownership="none">
-          <type name="none" c:type="void"/>
-        </return-value>
-        <parameters>
-          <instance-parameter name="self" transfer-ownership="none">
-            <doc xml:space="preserve">A #WebKitDOMRange</doc>
-            <type name="DOMRange" c:type="WebKitDOMRange*"/>
-          </instance-parameter>
-          <parameter name="refNode" transfer-ownership="none">
-            <doc xml:space="preserve">A #WebKitDOMNode</doc>
-            <type name="DOMNode" c:type="WebKitDOMNode*"/>
-          </parameter>
-        </parameters>
-      </method>
-      <method name="set_start" c:identifier="webkit_dom_range_set_start" throws="1">
+      <method name="set_end" c:identifier="webkit_dom_range_set_end" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -19653,7 +20791,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_start_after" c:identifier="webkit_dom_range_set_start_after" throws="1">
+      <method name="set_end_after" c:identifier="webkit_dom_range_set_end_after" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -19668,7 +20807,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="set_start_before" c:identifier="webkit_dom_range_set_start_before" throws="1">
+      <method name="set_end_before" c:identifier="webkit_dom_range_set_end_before" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -19683,7 +20823,60 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="surround_contents" c:identifier="webkit_dom_range_surround_contents" throws="1">
+      <method name="set_start" c:identifier="webkit_dom_range_set_start" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitDOMRange</doc>
+            <type name="DOMRange" c:type="WebKitDOMRange*"/>
+          </instance-parameter>
+          <parameter name="refNode" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitDOMNode</doc>
+            <type name="DOMNode" c:type="WebKitDOMNode*"/>
+          </parameter>
+          <parameter name="offset" transfer-ownership="none">
+            <doc xml:space="preserve">A #glong</doc>
+            <type name="glong" c:type="glong"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_start_after" c:identifier="webkit_dom_range_set_start_after" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitDOMRange</doc>
+            <type name="DOMRange" c:type="WebKitDOMRange*"/>
+          </instance-parameter>
+          <parameter name="refNode" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitDOMNode</doc>
+            <type name="DOMNode" c:type="WebKitDOMNode*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_start_before" c:identifier="webkit_dom_range_set_start_before" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitDOMRange</doc>
+            <type name="DOMRange" c:type="WebKitDOMRange*"/>
+          </instance-parameter>
+          <parameter name="refNode" transfer-ownership="none">
+            <doc xml:space="preserve">A #WebKitDOMNode</doc>
+            <type name="DOMNode" c:type="WebKitDOMNode*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="surround_contents" c:identifier="webkit_dom_range_surround_contents" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -19698,7 +20891,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="to_string" c:identifier="webkit_dom_range_to_string" throws="1">
+      <method name="to_string" c:identifier="webkit_dom_range_to_string" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -19741,7 +20935,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMStyleSheet" c:symbol-prefix="dom_style_sheet" c:type="WebKitDOMStyleSheet" parent="DOMObject" glib:type-name="WebKitDOMStyleSheet" glib:get-type="webkit_dom_style_sheet_get_type" glib:type-struct="DOMStyleSheetClass">
-      <method name="get_content_type" c:identifier="webkit_dom_style_sheet_get_content_type">
+      <method name="get_content_type" c:identifier="webkit_dom_style_sheet_get_content_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -19753,7 +20948,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_disabled" c:identifier="webkit_dom_style_sheet_get_disabled">
+      <method name="get_disabled" c:identifier="webkit_dom_style_sheet_get_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -19765,7 +20961,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_href" c:identifier="webkit_dom_style_sheet_get_href">
+      <method name="get_href" c:identifier="webkit_dom_style_sheet_get_href" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -19777,7 +20974,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_media" c:identifier="webkit_dom_style_sheet_get_media">
+      <method name="get_media" c:identifier="webkit_dom_style_sheet_get_media" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMMediaList</doc>
           <type name="DOMMediaList" c:type="WebKitDOMMediaList*"/>
@@ -19789,7 +20987,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_owner_node" c:identifier="webkit_dom_style_sheet_get_owner_node">
+      <method name="get_owner_node" c:identifier="webkit_dom_style_sheet_get_owner_node" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -19801,7 +21000,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_parent_style_sheet" c:identifier="webkit_dom_style_sheet_get_parent_style_sheet">
+      <method name="get_parent_style_sheet" c:identifier="webkit_dom_style_sheet_get_parent_style_sheet" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMStyleSheet</doc>
           <type name="DOMStyleSheet" c:type="WebKitDOMStyleSheet*"/>
@@ -19813,7 +21013,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_title" c:identifier="webkit_dom_style_sheet_get_title">
+      <method name="get_title" c:identifier="webkit_dom_style_sheet_get_title" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -19825,7 +21026,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_disabled" c:identifier="webkit_dom_style_sheet_set_disabled">
+      <method name="set_disabled" c:identifier="webkit_dom_style_sheet_set_disabled" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -19871,7 +21073,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMStyleSheetList" c:symbol-prefix="dom_style_sheet_list" c:type="WebKitDOMStyleSheetList" parent="DOMObject" glib:type-name="WebKitDOMStyleSheetList" glib:get-type="webkit_dom_style_sheet_list_get_type" glib:type-struct="DOMStyleSheetListClass">
-      <method name="get_length" c:identifier="webkit_dom_style_sheet_list_get_length">
+      <method name="get_length" c:identifier="webkit_dom_style_sheet_list_get_length" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -19883,7 +21086,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="item" c:identifier="webkit_dom_style_sheet_list_item">
+      <method name="item" c:identifier="webkit_dom_style_sheet_list_item" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMStyleSheet</doc>
           <type name="DOMStyleSheet" c:type="WebKitDOMStyleSheet*"/>
@@ -19913,7 +21117,8 @@ instead of a callbacks for easier binding in other languages.</doc>
     </record>
     <class name="DOMText" c:symbol-prefix="dom_text" c:type="WebKitDOMText" parent="DOMCharacterData" glib:type-name="WebKitDOMText" glib:get-type="webkit_dom_text_get_type" glib:type-struct="DOMTextClass">
       <implements name="DOMEventTarget"/>
-      <method name="get_whole_text" c:identifier="webkit_dom_text_get_whole_text">
+      <method name="get_whole_text" c:identifier="webkit_dom_text_get_whole_text" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -19941,7 +21146,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="split_text" c:identifier="webkit_dom_text_split_text" throws="1">
+      <method name="split_text" c:identifier="webkit_dom_text_split_text" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMText</doc>
           <type name="DOMText" c:type="WebKitDOMText*"/>
@@ -19970,7 +21176,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMTreeWalker" c:symbol-prefix="dom_tree_walker" c:type="WebKitDOMTreeWalker" parent="DOMObject" glib:type-name="WebKitDOMTreeWalker" glib:get-type="webkit_dom_tree_walker_get_type" glib:type-struct="DOMTreeWalkerClass">
-      <method name="first_child" c:identifier="webkit_dom_tree_walker_first_child">
+      <method name="first_child" c:identifier="webkit_dom_tree_walker_first_child" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -19982,7 +21189,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_current_node" c:identifier="webkit_dom_tree_walker_get_current_node">
+      <method name="get_current_node" c:identifier="webkit_dom_tree_walker_get_current_node" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -20007,7 +21215,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_filter" c:identifier="webkit_dom_tree_walker_get_filter">
+      <method name="get_filter" c:identifier="webkit_dom_tree_walker_get_filter" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMNodeFilter</doc>
           <type name="DOMNodeFilter" c:type="WebKitDOMNodeFilter*"/>
@@ -20019,7 +21228,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_root" c:identifier="webkit_dom_tree_walker_get_root">
+      <method name="get_root" c:identifier="webkit_dom_tree_walker_get_root" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -20031,7 +21241,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_what_to_show" c:identifier="webkit_dom_tree_walker_get_what_to_show">
+      <method name="get_what_to_show" c:identifier="webkit_dom_tree_walker_get_what_to_show" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -20043,7 +21254,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="last_child" c:identifier="webkit_dom_tree_walker_last_child">
+      <method name="last_child" c:identifier="webkit_dom_tree_walker_last_child" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -20055,7 +21267,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="next_node" c:identifier="webkit_dom_tree_walker_next_node">
+      <method name="next_node" c:identifier="webkit_dom_tree_walker_next_node" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -20067,7 +21280,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="next_sibling" c:identifier="webkit_dom_tree_walker_next_sibling">
+      <method name="next_sibling" c:identifier="webkit_dom_tree_walker_next_sibling" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -20079,7 +21293,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="parent_node" c:identifier="webkit_dom_tree_walker_parent_node">
+      <method name="parent_node" c:identifier="webkit_dom_tree_walker_parent_node" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -20091,7 +21306,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="previous_node" c:identifier="webkit_dom_tree_walker_previous_node">
+      <method name="previous_node" c:identifier="webkit_dom_tree_walker_previous_node" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -20103,7 +21319,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="previous_sibling" c:identifier="webkit_dom_tree_walker_previous_sibling">
+      <method name="previous_sibling" c:identifier="webkit_dom_tree_walker_previous_sibling" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -20115,7 +21332,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="set_current_node" c:identifier="webkit_dom_tree_walker_set_current_node" throws="1">
+      <method name="set_current_node" c:identifier="webkit_dom_tree_walker_set_current_node" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -20152,7 +21370,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMUIEvent" c:symbol-prefix="dom_ui_event" c:type="WebKitDOMUIEvent" parent="DOMEvent" glib:type-name="WebKitDOMUIEvent" glib:get-type="webkit_dom_ui_event_get_type" glib:type-struct="DOMUIEventClass">
-      <method name="get_char_code" c:identifier="webkit_dom_ui_event_get_char_code">
+      <method name="get_char_code" c:identifier="webkit_dom_ui_event_get_char_code" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -20164,7 +21383,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_detail" c:identifier="webkit_dom_ui_event_get_detail">
+      <method name="get_detail" c:identifier="webkit_dom_ui_event_get_detail" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -20176,7 +21396,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_key_code" c:identifier="webkit_dom_ui_event_get_key_code">
+      <method name="get_key_code" c:identifier="webkit_dom_ui_event_get_key_code" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -20188,7 +21409,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_layer_x" c:identifier="webkit_dom_ui_event_get_layer_x">
+      <method name="get_layer_x" c:identifier="webkit_dom_ui_event_get_layer_x" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -20200,7 +21422,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_layer_y" c:identifier="webkit_dom_ui_event_get_layer_y">
+      <method name="get_layer_y" c:identifier="webkit_dom_ui_event_get_layer_y" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -20212,7 +21435,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_page_x" c:identifier="webkit_dom_ui_event_get_page_x">
+      <method name="get_page_x" c:identifier="webkit_dom_ui_event_get_page_x" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -20224,7 +21448,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_page_y" c:identifier="webkit_dom_ui_event_get_page_y">
+      <method name="get_page_y" c:identifier="webkit_dom_ui_event_get_page_y" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -20236,7 +21461,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_view" c:identifier="webkit_dom_ui_event_get_view">
+      <method name="get_view" c:identifier="webkit_dom_ui_event_get_view" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMDOMWindow</doc>
           <type name="DOMDOMWindow" c:type="WebKitDOMDOMWindow*"/>
@@ -20248,7 +21474,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="init_ui_event" c:identifier="webkit_dom_ui_event_init_ui_event">
+      <method name="init_ui_event" c:identifier="webkit_dom_ui_event_init_ui_event" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -20313,7 +21540,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMWheelEvent" c:symbol-prefix="dom_wheel_event" c:type="WebKitDOMWheelEvent" parent="DOMMouseEvent" glib:type-name="WebKitDOMWheelEvent" glib:get-type="webkit_dom_wheel_event_get_type" glib:type-struct="DOMWheelEventClass">
-      <method name="get_wheel_delta" c:identifier="webkit_dom_wheel_event_get_wheel_delta">
+      <method name="get_wheel_delta" c:identifier="webkit_dom_wheel_event_get_wheel_delta" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -20325,7 +21553,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_wheel_delta_x" c:identifier="webkit_dom_wheel_event_get_wheel_delta_x">
+      <method name="get_wheel_delta_x" c:identifier="webkit_dom_wheel_event_get_wheel_delta_x" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -20337,7 +21566,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_wheel_delta_y" c:identifier="webkit_dom_wheel_event_get_wheel_delta_y">
+      <method name="get_wheel_delta_y" c:identifier="webkit_dom_wheel_event_get_wheel_delta_y" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #glong</doc>
           <type name="glong" c:type="glong"/>
@@ -20349,7 +21579,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="init_wheel_event" c:identifier="webkit_dom_wheel_event_init_wheel_event">
+      <method name="init_wheel_event" c:identifier="webkit_dom_wheel_event_init_wheel_event" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -20423,7 +21654,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMXPathExpression" c:symbol-prefix="dom_xpath_expression" c:type="WebKitDOMXPathExpression" parent="DOMObject" glib:type-name="WebKitDOMXPathExpression" glib:get-type="webkit_dom_xpath_expression_get_type" glib:type-struct="DOMXPathExpressionClass">
-      <method name="evaluate" c:identifier="webkit_dom_xpath_expression_evaluate" throws="1">
+      <method name="evaluate" c:identifier="webkit_dom_xpath_expression_evaluate" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #WebKitDOMXPathResult</doc>
           <type name="DOMXPathResult" c:type="WebKitDOMXPathResult*"/>
@@ -20457,7 +21689,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <interface name="DOMXPathNSResolver" c:symbol-prefix="dom_xpath_ns_resolver" c:type="WebKitDOMXPathNSResolver" glib:type-name="WebKitDOMXPathNSResolver" glib:get-type="webkit_dom_xpath_ns_resolver_get_type" glib:type-struct="DOMXPathNSResolverIface">
-      <virtual-method name="lookup_namespace_uri" invoker="lookup_namespace_uri">
+      <virtual-method name="lookup_namespace_uri" invoker="lookup_namespace_uri" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -20473,7 +21706,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </parameter>
         </parameters>
       </virtual-method>
-      <method name="lookup_namespace_uri" c:identifier="webkit_dom_xpath_ns_resolver_lookup_namespace_uri">
+      <method name="lookup_namespace_uri" c:identifier="webkit_dom_xpath_ns_resolver_lookup_namespace_uri" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -20542,7 +21776,8 @@ instead of a callbacks for easier binding in other languages.</doc>
       </field>
     </record>
     <class name="DOMXPathResult" c:symbol-prefix="dom_xpath_result" c:type="WebKitDOMXPathResult" parent="DOMObject" glib:type-name="WebKitDOMXPathResult" glib:get-type="webkit_dom_xpath_result_get_type" glib:type-struct="DOMXPathResultClass">
-      <method name="get_boolean_value" c:identifier="webkit_dom_xpath_result_get_boolean_value" throws="1">
+      <method name="get_boolean_value" c:identifier="webkit_dom_xpath_result_get_boolean_value" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -20554,7 +21789,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_invalid_iterator_state" c:identifier="webkit_dom_xpath_result_get_invalid_iterator_state">
+      <method name="get_invalid_iterator_state" c:identifier="webkit_dom_xpath_result_get_invalid_iterator_state" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gboolean</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -20566,7 +21802,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_number_value" c:identifier="webkit_dom_xpath_result_get_number_value" throws="1">
+      <method name="get_number_value" c:identifier="webkit_dom_xpath_result_get_number_value" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gdouble</doc>
           <type name="gdouble" c:type="gdouble"/>
@@ -20578,7 +21815,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_result_type" c:identifier="webkit_dom_xpath_result_get_result_type">
+      <method name="get_result_type" c:identifier="webkit_dom_xpath_result_get_result_type" deprecated="1" deprecated-version="2.22">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gushort</doc>
           <type name="gushort" c:type="gushort"/>
@@ -20590,7 +21828,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_single_node_value" c:identifier="webkit_dom_xpath_result_get_single_node_value" throws="1">
+      <method name="get_single_node_value" c:identifier="webkit_dom_xpath_result_get_single_node_value" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -20602,7 +21841,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_snapshot_length" c:identifier="webkit_dom_xpath_result_get_snapshot_length" throws="1">
+      <method name="get_snapshot_length" c:identifier="webkit_dom_xpath_result_get_snapshot_length" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #gulong</doc>
           <type name="gulong" c:type="gulong"/>
@@ -20614,7 +21854,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="get_string_value" c:identifier="webkit_dom_xpath_result_get_string_value" throws="1">
+      <method name="get_string_value" c:identifier="webkit_dom_xpath_result_get_string_value" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A #gchar</doc>
           <type name="utf8" c:type="gchar*"/>
@@ -20626,7 +21867,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="iterate_next" c:identifier="webkit_dom_xpath_result_iterate_next" throws="1">
+      <method name="iterate_next" c:identifier="webkit_dom_xpath_result_iterate_next" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -20638,7 +21880,8 @@ instead of a callbacks for easier binding in other languages.</doc>
           </instance-parameter>
         </parameters>
       </method>
-      <method name="snapshot_item" c:identifier="webkit_dom_xpath_result_snapshot_item" throws="1">
+      <method name="snapshot_item" c:identifier="webkit_dom_xpath_result_snapshot_item" deprecated="1" deprecated-version="2.22" throws="1">
+        <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">A #WebKitDOMNode</doc>
           <type name="DOMNode" c:type="WebKitDOMNode*"/>
@@ -20684,286 +21927,373 @@ instead of a callbacks for easier binding in other languages.</doc>
         <type name="DOMObjectClass" c:type="WebKitDOMObjectClass"/>
       </field>
     </record>
-    <constant name="DOM_CSS_RULE_CHARSET_RULE" value="2" c:type="WEBKIT_DOM_CSS_RULE_CHARSET_RULE">
+    <constant name="DOM_CSS_RULE_CHARSET_RULE" value="2" c:type="WEBKIT_DOM_CSS_RULE_CHARSET_RULE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_CSS_RULE_FONT_FACE_RULE" value="5" c:type="WEBKIT_DOM_CSS_RULE_FONT_FACE_RULE">
+    <constant name="DOM_CSS_RULE_FONT_FACE_RULE" value="5" c:type="WEBKIT_DOM_CSS_RULE_FONT_FACE_RULE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_CSS_RULE_IMPORT_RULE" value="3" c:type="WEBKIT_DOM_CSS_RULE_IMPORT_RULE">
+    <constant name="DOM_CSS_RULE_IMPORT_RULE" value="3" c:type="WEBKIT_DOM_CSS_RULE_IMPORT_RULE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_CSS_RULE_MEDIA_RULE" value="4" c:type="WEBKIT_DOM_CSS_RULE_MEDIA_RULE">
+    <constant name="DOM_CSS_RULE_MEDIA_RULE" value="4" c:type="WEBKIT_DOM_CSS_RULE_MEDIA_RULE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_CSS_RULE_PAGE_RULE" value="6" c:type="WEBKIT_DOM_CSS_RULE_PAGE_RULE">
+    <constant name="DOM_CSS_RULE_PAGE_RULE" value="6" c:type="WEBKIT_DOM_CSS_RULE_PAGE_RULE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_CSS_RULE_STYLE_RULE" value="1" c:type="WEBKIT_DOM_CSS_RULE_STYLE_RULE">
+    <constant name="DOM_CSS_RULE_STYLE_RULE" value="1" c:type="WEBKIT_DOM_CSS_RULE_STYLE_RULE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_CSS_RULE_UNKNOWN_RULE" value="0" c:type="WEBKIT_DOM_CSS_RULE_UNKNOWN_RULE">
+    <constant name="DOM_CSS_RULE_UNKNOWN_RULE" value="0" c:type="WEBKIT_DOM_CSS_RULE_UNKNOWN_RULE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_CSS_VALUE_CSS_CUSTOM" value="3" c:type="WEBKIT_DOM_CSS_VALUE_CSS_CUSTOM">
+    <constant name="DOM_CSS_VALUE_CSS_CUSTOM" value="3" c:type="WEBKIT_DOM_CSS_VALUE_CSS_CUSTOM" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_CSS_VALUE_CSS_INHERIT" value="0" c:type="WEBKIT_DOM_CSS_VALUE_CSS_INHERIT">
+    <constant name="DOM_CSS_VALUE_CSS_INHERIT" value="0" c:type="WEBKIT_DOM_CSS_VALUE_CSS_INHERIT" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_CSS_VALUE_CSS_PRIMITIVE_VALUE" value="1" c:type="WEBKIT_DOM_CSS_VALUE_CSS_PRIMITIVE_VALUE">
+    <constant name="DOM_CSS_VALUE_CSS_PRIMITIVE_VALUE" value="1" c:type="WEBKIT_DOM_CSS_VALUE_CSS_PRIMITIVE_VALUE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_CSS_VALUE_CSS_VALUE_LIST" value="2" c:type="WEBKIT_DOM_CSS_VALUE_CSS_VALUE_LIST">
+    <constant name="DOM_CSS_VALUE_CSS_VALUE_LIST" value="2" c:type="WEBKIT_DOM_CSS_VALUE_CSS_VALUE_LIST" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_ELEMENT_ALLOW_KEYBOARD_INPUT" value="1" c:type="WEBKIT_DOM_ELEMENT_ALLOW_KEYBOARD_INPUT">
+    <constant name="DOM_ELEMENT_ALLOW_KEYBOARD_INPUT" value="1" c:type="WEBKIT_DOM_ELEMENT_ALLOW_KEYBOARD_INPUT" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_AT_TARGET" value="2" c:type="WEBKIT_DOM_EVENT_AT_TARGET">
+    <constant name="DOM_EVENT_AT_TARGET" value="2" c:type="WEBKIT_DOM_EVENT_AT_TARGET" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_BLUR" value="8192" c:type="WEBKIT_DOM_EVENT_BLUR">
+    <constant name="DOM_EVENT_BLUR" value="8192" c:type="WEBKIT_DOM_EVENT_BLUR" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_BUBBLING_PHASE" value="3" c:type="WEBKIT_DOM_EVENT_BUBBLING_PHASE">
+    <constant name="DOM_EVENT_BUBBLING_PHASE" value="3" c:type="WEBKIT_DOM_EVENT_BUBBLING_PHASE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_CAPTURING_PHASE" value="1" c:type="WEBKIT_DOM_EVENT_CAPTURING_PHASE">
+    <constant name="DOM_EVENT_CAPTURING_PHASE" value="1" c:type="WEBKIT_DOM_EVENT_CAPTURING_PHASE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_CHANGE" value="32768" c:type="WEBKIT_DOM_EVENT_CHANGE">
+    <constant name="DOM_EVENT_CHANGE" value="32768" c:type="WEBKIT_DOM_EVENT_CHANGE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_CLICK" value="64" c:type="WEBKIT_DOM_EVENT_CLICK">
+    <constant name="DOM_EVENT_CLICK" value="64" c:type="WEBKIT_DOM_EVENT_CLICK" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_DBLCLICK" value="128" c:type="WEBKIT_DOM_EVENT_DBLCLICK">
+    <constant name="DOM_EVENT_DBLCLICK" value="128" c:type="WEBKIT_DOM_EVENT_DBLCLICK" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_DRAGDROP" value="2048" c:type="WEBKIT_DOM_EVENT_DRAGDROP">
+    <constant name="DOM_EVENT_DRAGDROP" value="2048" c:type="WEBKIT_DOM_EVENT_DRAGDROP" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_FOCUS" value="4096" c:type="WEBKIT_DOM_EVENT_FOCUS">
+    <constant name="DOM_EVENT_FOCUS" value="4096" c:type="WEBKIT_DOM_EVENT_FOCUS" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_KEYDOWN" value="256" c:type="WEBKIT_DOM_EVENT_KEYDOWN">
+    <constant name="DOM_EVENT_KEYDOWN" value="256" c:type="WEBKIT_DOM_EVENT_KEYDOWN" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_KEYPRESS" value="1024" c:type="WEBKIT_DOM_EVENT_KEYPRESS">
+    <constant name="DOM_EVENT_KEYPRESS" value="1024" c:type="WEBKIT_DOM_EVENT_KEYPRESS" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_KEYUP" value="512" c:type="WEBKIT_DOM_EVENT_KEYUP">
+    <constant name="DOM_EVENT_KEYUP" value="512" c:type="WEBKIT_DOM_EVENT_KEYUP" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_MOUSEDOWN" value="1" c:type="WEBKIT_DOM_EVENT_MOUSEDOWN">
+    <constant name="DOM_EVENT_MOUSEDOWN" value="1" c:type="WEBKIT_DOM_EVENT_MOUSEDOWN" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_MOUSEDRAG" value="32" c:type="WEBKIT_DOM_EVENT_MOUSEDRAG">
+    <constant name="DOM_EVENT_MOUSEDRAG" value="32" c:type="WEBKIT_DOM_EVENT_MOUSEDRAG" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_MOUSEMOVE" value="16" c:type="WEBKIT_DOM_EVENT_MOUSEMOVE">
+    <constant name="DOM_EVENT_MOUSEMOVE" value="16" c:type="WEBKIT_DOM_EVENT_MOUSEMOVE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_MOUSEOUT" value="8" c:type="WEBKIT_DOM_EVENT_MOUSEOUT">
+    <constant name="DOM_EVENT_MOUSEOUT" value="8" c:type="WEBKIT_DOM_EVENT_MOUSEOUT" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_MOUSEOVER" value="4" c:type="WEBKIT_DOM_EVENT_MOUSEOVER">
+    <constant name="DOM_EVENT_MOUSEOVER" value="4" c:type="WEBKIT_DOM_EVENT_MOUSEOVER" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_MOUSEUP" value="2" c:type="WEBKIT_DOM_EVENT_MOUSEUP">
+    <constant name="DOM_EVENT_MOUSEUP" value="2" c:type="WEBKIT_DOM_EVENT_MOUSEUP" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_NONE" value="0" c:type="WEBKIT_DOM_EVENT_NONE">
+    <constant name="DOM_EVENT_NONE" value="0" c:type="WEBKIT_DOM_EVENT_NONE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_EVENT_SELECT" value="16384" c:type="WEBKIT_DOM_EVENT_SELECT">
+    <constant name="DOM_EVENT_SELECT" value="16384" c:type="WEBKIT_DOM_EVENT_SELECT" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_KEYBOARD_EVENT_KEY_LOCATION_LEFT" value="1" c:type="WEBKIT_DOM_KEYBOARD_EVENT_KEY_LOCATION_LEFT">
+    <constant name="DOM_KEYBOARD_EVENT_KEY_LOCATION_LEFT" value="1" c:type="WEBKIT_DOM_KEYBOARD_EVENT_KEY_LOCATION_LEFT" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_KEYBOARD_EVENT_KEY_LOCATION_NUMPAD" value="3" c:type="WEBKIT_DOM_KEYBOARD_EVENT_KEY_LOCATION_NUMPAD">
+    <constant name="DOM_KEYBOARD_EVENT_KEY_LOCATION_NUMPAD" value="3" c:type="WEBKIT_DOM_KEYBOARD_EVENT_KEY_LOCATION_NUMPAD" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_KEYBOARD_EVENT_KEY_LOCATION_RIGHT" value="2" c:type="WEBKIT_DOM_KEYBOARD_EVENT_KEY_LOCATION_RIGHT">
+    <constant name="DOM_KEYBOARD_EVENT_KEY_LOCATION_RIGHT" value="2" c:type="WEBKIT_DOM_KEYBOARD_EVENT_KEY_LOCATION_RIGHT" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_KEYBOARD_EVENT_KEY_LOCATION_STANDARD" value="0" c:type="WEBKIT_DOM_KEYBOARD_EVENT_KEY_LOCATION_STANDARD">
+    <constant name="DOM_KEYBOARD_EVENT_KEY_LOCATION_STANDARD" value="0" c:type="WEBKIT_DOM_KEYBOARD_EVENT_KEY_LOCATION_STANDARD" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_ATTRIBUTE_NODE" value="2" c:type="WEBKIT_DOM_NODE_ATTRIBUTE_NODE">
+    <constant name="DOM_NODE_ATTRIBUTE_NODE" value="2" c:type="WEBKIT_DOM_NODE_ATTRIBUTE_NODE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_CDATA_SECTION_NODE" value="4" c:type="WEBKIT_DOM_NODE_CDATA_SECTION_NODE">
+    <constant name="DOM_NODE_CDATA_SECTION_NODE" value="4" c:type="WEBKIT_DOM_NODE_CDATA_SECTION_NODE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_COMMENT_NODE" value="8" c:type="WEBKIT_DOM_NODE_COMMENT_NODE">
+    <constant name="DOM_NODE_COMMENT_NODE" value="8" c:type="WEBKIT_DOM_NODE_COMMENT_NODE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_DOCUMENT_FRAGMENT_NODE" value="11" c:type="WEBKIT_DOM_NODE_DOCUMENT_FRAGMENT_NODE">
+    <constant name="DOM_NODE_DOCUMENT_FRAGMENT_NODE" value="11" c:type="WEBKIT_DOM_NODE_DOCUMENT_FRAGMENT_NODE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_DOCUMENT_NODE" value="9" c:type="WEBKIT_DOM_NODE_DOCUMENT_NODE">
+    <constant name="DOM_NODE_DOCUMENT_NODE" value="9" c:type="WEBKIT_DOM_NODE_DOCUMENT_NODE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_DOCUMENT_POSITION_CONTAINED_BY" value="16" c:type="WEBKIT_DOM_NODE_DOCUMENT_POSITION_CONTAINED_BY">
+    <constant name="DOM_NODE_DOCUMENT_POSITION_CONTAINED_BY" value="16" c:type="WEBKIT_DOM_NODE_DOCUMENT_POSITION_CONTAINED_BY" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_DOCUMENT_POSITION_CONTAINS" value="8" c:type="WEBKIT_DOM_NODE_DOCUMENT_POSITION_CONTAINS">
+    <constant name="DOM_NODE_DOCUMENT_POSITION_CONTAINS" value="8" c:type="WEBKIT_DOM_NODE_DOCUMENT_POSITION_CONTAINS" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_DOCUMENT_POSITION_DISCONNECTED" value="1" c:type="WEBKIT_DOM_NODE_DOCUMENT_POSITION_DISCONNECTED">
+    <constant name="DOM_NODE_DOCUMENT_POSITION_DISCONNECTED" value="1" c:type="WEBKIT_DOM_NODE_DOCUMENT_POSITION_DISCONNECTED" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_DOCUMENT_POSITION_FOLLOWING" value="4" c:type="WEBKIT_DOM_NODE_DOCUMENT_POSITION_FOLLOWING">
+    <constant name="DOM_NODE_DOCUMENT_POSITION_FOLLOWING" value="4" c:type="WEBKIT_DOM_NODE_DOCUMENT_POSITION_FOLLOWING" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC" value="32" c:type="WEBKIT_DOM_NODE_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC">
+    <constant name="DOM_NODE_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC" value="32" c:type="WEBKIT_DOM_NODE_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_DOCUMENT_POSITION_PRECEDING" value="2" c:type="WEBKIT_DOM_NODE_DOCUMENT_POSITION_PRECEDING">
+    <constant name="DOM_NODE_DOCUMENT_POSITION_PRECEDING" value="2" c:type="WEBKIT_DOM_NODE_DOCUMENT_POSITION_PRECEDING" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_DOCUMENT_TYPE_NODE" value="10" c:type="WEBKIT_DOM_NODE_DOCUMENT_TYPE_NODE">
+    <constant name="DOM_NODE_DOCUMENT_TYPE_NODE" value="10" c:type="WEBKIT_DOM_NODE_DOCUMENT_TYPE_NODE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_ELEMENT_NODE" value="1" c:type="WEBKIT_DOM_NODE_ELEMENT_NODE">
+    <constant name="DOM_NODE_ELEMENT_NODE" value="1" c:type="WEBKIT_DOM_NODE_ELEMENT_NODE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_ENTITY_NODE" value="6" c:type="WEBKIT_DOM_NODE_ENTITY_NODE">
+    <constant name="DOM_NODE_ENTITY_NODE" value="6" c:type="WEBKIT_DOM_NODE_ENTITY_NODE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_ENTITY_REFERENCE_NODE" value="5" c:type="WEBKIT_DOM_NODE_ENTITY_REFERENCE_NODE">
+    <constant name="DOM_NODE_ENTITY_REFERENCE_NODE" value="5" c:type="WEBKIT_DOM_NODE_ENTITY_REFERENCE_NODE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_ACCEPT" value="1" c:type="WEBKIT_DOM_NODE_FILTER_ACCEPT" version="2.6">
+    <constant name="DOM_NODE_FILTER_ACCEPT" value="1" c:type="WEBKIT_DOM_NODE_FILTER_ACCEPT" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Accept the node. Use this macro as return value of webkit_dom_node_filter_accept_node()
 implementation to accept the given #WebKitDOMNode</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_REJECT" value="2" c:type="WEBKIT_DOM_NODE_FILTER_REJECT" version="2.6">
+    <constant name="DOM_NODE_FILTER_REJECT" value="2" c:type="WEBKIT_DOM_NODE_FILTER_REJECT" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Reject the node. Use this macro as return value of webkit_dom_node_filter_accept_node()
 implementation to reject the given #WebKitDOMNode. The children of the given node will
 be rejected too.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_SHOW_ALL" value="4294967295" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_ALL" version="2.6">
+    <constant name="DOM_NODE_FILTER_SHOW_ALL" value="4294967295" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_ALL" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Show all nodes.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_SHOW_ATTRIBUTE" value="2" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_ATTRIBUTE" version="2.6">
+    <constant name="DOM_NODE_FILTER_SHOW_ATTRIBUTE" value="2" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_ATTRIBUTE" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Show #WebKitDOMAttr nodes.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_SHOW_CDATA_SECTION" value="8" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_CDATA_SECTION" version="2.6">
+    <constant name="DOM_NODE_FILTER_SHOW_CDATA_SECTION" value="8" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_CDATA_SECTION" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Show #WebKitDOMCDataSection nodes.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_SHOW_COMMENT" value="128" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_COMMENT" version="2.6">
+    <constant name="DOM_NODE_FILTER_SHOW_COMMENT" value="128" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_COMMENT" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Show #WebKitDOMComment nodes.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_SHOW_DOCUMENT" value="256" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_DOCUMENT" version="2.6">
+    <constant name="DOM_NODE_FILTER_SHOW_DOCUMENT" value="256" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_DOCUMENT" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Show #WebKitDOMDocument nodes.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_SHOW_DOCUMENT_FRAGMENT" value="1024" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_DOCUMENT_FRAGMENT" version="2.6">
+    <constant name="DOM_NODE_FILTER_SHOW_DOCUMENT_FRAGMENT" value="1024" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_DOCUMENT_FRAGMENT" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Show #WebKitDOMDocumentFragment nodes.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_SHOW_DOCUMENT_TYPE" value="512" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_DOCUMENT_TYPE" version="2.6">
+    <constant name="DOM_NODE_FILTER_SHOW_DOCUMENT_TYPE" value="512" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_DOCUMENT_TYPE" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Show #WebKitDOMDocumentType nodes.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_SHOW_ELEMENT" value="1" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_ELEMENT" version="2.6">
+    <constant name="DOM_NODE_FILTER_SHOW_ELEMENT" value="1" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_ELEMENT" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Show #WebKitDOMElement nodes.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_SHOW_ENTITY" value="32" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_ENTITY" version="2.6">
+    <constant name="DOM_NODE_FILTER_SHOW_ENTITY" value="32" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_ENTITY" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Show #WebKitDOMEntity nodes.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_SHOW_ENTITY_REFERENCE" value="16" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_ENTITY_REFERENCE" version="2.6">
+    <constant name="DOM_NODE_FILTER_SHOW_ENTITY_REFERENCE" value="16" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_ENTITY_REFERENCE" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Show #WebKitDOMEntityReference nodes.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_SHOW_NOTATION" value="2048" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_NOTATION" version="2.6">
+    <constant name="DOM_NODE_FILTER_SHOW_NOTATION" value="2048" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_NOTATION" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Show #WebKitDOMNotation nodes.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_SHOW_PROCESSING_INSTRUCTION" value="64" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_PROCESSING_INSTRUCTION" version="2.6">
+    <constant name="DOM_NODE_FILTER_SHOW_PROCESSING_INSTRUCTION" value="64" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_PROCESSING_INSTRUCTION" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Show #WebKitDOMProcessingInstruction nodes.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_SHOW_TEXT" value="4" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_TEXT" version="2.6">
+    <constant name="DOM_NODE_FILTER_SHOW_TEXT" value="4" c:type="WEBKIT_DOM_NODE_FILTER_SHOW_TEXT" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Show #WebKitDOMText nodes.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_FILTER_SKIP" value="3" c:type="WEBKIT_DOM_NODE_FILTER_SKIP" version="2.6">
+    <constant name="DOM_NODE_FILTER_SKIP" value="3" c:type="WEBKIT_DOM_NODE_FILTER_SKIP" version="2.6" deprecated="1" deprecated-version="2.22">
       <doc xml:space="preserve">Skip the node. Use this macro as return value of webkit_dom_node_filter_accept_node()
 implementation to skip the given #WebKitDOMNode. The children of the given node will
 not be skipped.</doc>
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_PROCESSING_INSTRUCTION_NODE" value="7" c:type="WEBKIT_DOM_NODE_PROCESSING_INSTRUCTION_NODE">
+    <constant name="DOM_NODE_PROCESSING_INSTRUCTION_NODE" value="7" c:type="WEBKIT_DOM_NODE_PROCESSING_INSTRUCTION_NODE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_NODE_TEXT_NODE" value="3" c:type="WEBKIT_DOM_NODE_TEXT_NODE">
+    <constant name="DOM_NODE_TEXT_NODE" value="3" c:type="WEBKIT_DOM_NODE_TEXT_NODE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_RANGE_END_TO_END" value="2" c:type="WEBKIT_DOM_RANGE_END_TO_END">
+    <constant name="DOM_RANGE_END_TO_END" value="2" c:type="WEBKIT_DOM_RANGE_END_TO_END" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_RANGE_END_TO_START" value="3" c:type="WEBKIT_DOM_RANGE_END_TO_START">
+    <constant name="DOM_RANGE_END_TO_START" value="3" c:type="WEBKIT_DOM_RANGE_END_TO_START" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_RANGE_NODE_AFTER" value="1" c:type="WEBKIT_DOM_RANGE_NODE_AFTER">
+    <constant name="DOM_RANGE_NODE_AFTER" value="1" c:type="WEBKIT_DOM_RANGE_NODE_AFTER" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_RANGE_NODE_BEFORE" value="0" c:type="WEBKIT_DOM_RANGE_NODE_BEFORE">
+    <constant name="DOM_RANGE_NODE_BEFORE" value="0" c:type="WEBKIT_DOM_RANGE_NODE_BEFORE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_RANGE_NODE_BEFORE_AND_AFTER" value="2" c:type="WEBKIT_DOM_RANGE_NODE_BEFORE_AND_AFTER">
+    <constant name="DOM_RANGE_NODE_BEFORE_AND_AFTER" value="2" c:type="WEBKIT_DOM_RANGE_NODE_BEFORE_AND_AFTER" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_RANGE_NODE_INSIDE" value="3" c:type="WEBKIT_DOM_RANGE_NODE_INSIDE">
+    <constant name="DOM_RANGE_NODE_INSIDE" value="3" c:type="WEBKIT_DOM_RANGE_NODE_INSIDE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_RANGE_START_TO_END" value="1" c:type="WEBKIT_DOM_RANGE_START_TO_END">
+    <constant name="DOM_RANGE_START_TO_END" value="1" c:type="WEBKIT_DOM_RANGE_START_TO_END" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_RANGE_START_TO_START" value="0" c:type="WEBKIT_DOM_RANGE_START_TO_START">
+    <constant name="DOM_RANGE_START_TO_START" value="0" c:type="WEBKIT_DOM_RANGE_START_TO_START" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_XPATH_RESULT_ANY_TYPE" value="0" c:type="WEBKIT_DOM_XPATH_RESULT_ANY_TYPE">
+    <constant name="DOM_XPATH_RESULT_ANY_TYPE" value="0" c:type="WEBKIT_DOM_XPATH_RESULT_ANY_TYPE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_XPATH_RESULT_ANY_UNORDERED_NODE_TYPE" value="8" c:type="WEBKIT_DOM_XPATH_RESULT_ANY_UNORDERED_NODE_TYPE">
+    <constant name="DOM_XPATH_RESULT_ANY_UNORDERED_NODE_TYPE" value="8" c:type="WEBKIT_DOM_XPATH_RESULT_ANY_UNORDERED_NODE_TYPE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_XPATH_RESULT_BOOLEAN_TYPE" value="3" c:type="WEBKIT_DOM_XPATH_RESULT_BOOLEAN_TYPE">
+    <constant name="DOM_XPATH_RESULT_BOOLEAN_TYPE" value="3" c:type="WEBKIT_DOM_XPATH_RESULT_BOOLEAN_TYPE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_XPATH_RESULT_FIRST_ORDERED_NODE_TYPE" value="9" c:type="WEBKIT_DOM_XPATH_RESULT_FIRST_ORDERED_NODE_TYPE">
+    <constant name="DOM_XPATH_RESULT_FIRST_ORDERED_NODE_TYPE" value="9" c:type="WEBKIT_DOM_XPATH_RESULT_FIRST_ORDERED_NODE_TYPE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_XPATH_RESULT_NUMBER_TYPE" value="1" c:type="WEBKIT_DOM_XPATH_RESULT_NUMBER_TYPE">
+    <constant name="DOM_XPATH_RESULT_NUMBER_TYPE" value="1" c:type="WEBKIT_DOM_XPATH_RESULT_NUMBER_TYPE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_XPATH_RESULT_ORDERED_NODE_ITERATOR_TYPE" value="5" c:type="WEBKIT_DOM_XPATH_RESULT_ORDERED_NODE_ITERATOR_TYPE">
+    <constant name="DOM_XPATH_RESULT_ORDERED_NODE_ITERATOR_TYPE" value="5" c:type="WEBKIT_DOM_XPATH_RESULT_ORDERED_NODE_ITERATOR_TYPE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_XPATH_RESULT_ORDERED_NODE_SNAPSHOT_TYPE" value="7" c:type="WEBKIT_DOM_XPATH_RESULT_ORDERED_NODE_SNAPSHOT_TYPE">
+    <constant name="DOM_XPATH_RESULT_ORDERED_NODE_SNAPSHOT_TYPE" value="7" c:type="WEBKIT_DOM_XPATH_RESULT_ORDERED_NODE_SNAPSHOT_TYPE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_XPATH_RESULT_STRING_TYPE" value="2" c:type="WEBKIT_DOM_XPATH_RESULT_STRING_TYPE">
+    <constant name="DOM_XPATH_RESULT_STRING_TYPE" value="2" c:type="WEBKIT_DOM_XPATH_RESULT_STRING_TYPE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_XPATH_RESULT_UNORDERED_NODE_ITERATOR_TYPE" value="4" c:type="WEBKIT_DOM_XPATH_RESULT_UNORDERED_NODE_ITERATOR_TYPE">
+    <constant name="DOM_XPATH_RESULT_UNORDERED_NODE_ITERATOR_TYPE" value="4" c:type="WEBKIT_DOM_XPATH_RESULT_UNORDERED_NODE_ITERATOR_TYPE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
-    <constant name="DOM_XPATH_RESULT_UNORDERED_NODE_SNAPSHOT_TYPE" value="6" c:type="WEBKIT_DOM_XPATH_RESULT_UNORDERED_NODE_SNAPSHOT_TYPE">
+    <constant name="DOM_XPATH_RESULT_UNORDERED_NODE_SNAPSHOT_TYPE" value="6" c:type="WEBKIT_DOM_XPATH_RESULT_UNORDERED_NODE_SNAPSHOT_TYPE" deprecated="1" deprecated-version="2.22">
+      <doc-deprecated xml:space="preserve">Use JavaScriptCore API instead</doc-deprecated>
       <type name="gint" c:type="gint"/>
     </constant>
     <enumeration name="FormSubmissionStep" version="2.20" glib:type-name="WebKitFormSubmissionStep" glib:get-type="webkit_form_submission_step_get_type" c:type="WebKitFormSubmissionStep">
@@ -20979,11 +22309,12 @@ to be submitted.</doc>
       </member>
     </enumeration>
     <class name="Frame" c:symbol-prefix="frame" c:type="WebKitFrame" parent="GObject.Object" glib:type-name="WebKitFrame" glib:get-type="webkit_frame_get_type" glib:type-struct="FrameClass">
-      <method name="get_javascript_context_for_script_world" c:identifier="webkit_frame_get_javascript_context_for_script_world" version="2.2">
+      <method name="get_javascript_context_for_script_world" c:identifier="webkit_frame_get_javascript_context_for_script_world" version="2.2" introspectable="0" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Gets the JavaScript execution context of @frame for the given #WebKitScriptWorld.</doc>
+        <doc-deprecated xml:space="preserve">Use webkit_frame_get_js_context_for_script_world() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the JavaScript context of @frame for @world</doc>
-          <type name="JavaScriptCore.GlobalContext" c:type="JSGlobalContextRef"/>
+          <type c:type="JSGlobalContextRef"/>
         </return-value>
         <parameters>
           <instance-parameter name="frame" transfer-ownership="none">
@@ -20996,18 +22327,90 @@ to be submitted.</doc>
           </parameter>
         </parameters>
       </method>
-      <method name="get_javascript_global_context" c:identifier="webkit_frame_get_javascript_global_context" version="2.2">
+      <method name="get_javascript_global_context" c:identifier="webkit_frame_get_javascript_global_context" version="2.2" introspectable="0" deprecated="1" deprecated-version="2.22">
         <doc xml:space="preserve">Gets the global JavaScript execution context. Use this function to bridge
 between the WebKit and JavaScriptCore APIs.</doc>
+        <doc-deprecated xml:space="preserve">Use webkit_frame_get_js_context() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the global JavaScript context of @frame</doc>
-          <type name="JavaScriptCore.GlobalContext" c:type="JSGlobalContextRef"/>
+          <type c:type="JSGlobalContextRef"/>
         </return-value>
         <parameters>
           <instance-parameter name="frame" transfer-ownership="none">
             <doc xml:space="preserve">a #WebKitFrame</doc>
             <type name="Frame" c:type="WebKitFrame*"/>
           </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_js_context" c:identifier="webkit_frame_get_js_context" version="2.22">
+        <doc xml:space="preserve">Get the JavaScript execution context of @frame. Use this function to bridge
+between the WebKit and JavaScriptCore APIs.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">the #JSCContext for the JavaScript execution context of @frame.</doc>
+          <type name="JavaScriptCore.Context" c:type="JSCContext*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="frame" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitFrame</doc>
+            <type name="Frame" c:type="WebKitFrame*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_js_context_for_script_world" c:identifier="webkit_frame_get_js_context_for_script_world" version="2.22">
+        <doc xml:space="preserve">Get the JavaScript execution context of @frame for the given #WebKitScriptWorld.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">the #JSCContext for the JavaScript execution context of @frame for @world.</doc>
+          <type name="JavaScriptCore.Context" c:type="JSCContext*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="frame" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitFrame</doc>
+            <type name="Frame" c:type="WebKitFrame*"/>
+          </instance-parameter>
+          <parameter name="world" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitScriptWorld</doc>
+            <type name="ScriptWorld" c:type="WebKitScriptWorld*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_js_value_for_dom_object" c:identifier="webkit_frame_get_js_value_for_dom_object" version="2.22">
+        <doc xml:space="preserve">Get a #JSCValue referencing the given DOM object. The value is created in the JavaScript execution
+context of @frame.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">the #JSCValue referencing @dom_object.</doc>
+          <type name="JavaScriptCore.Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="frame" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitFrame</doc>
+            <type name="Frame" c:type="WebKitFrame*"/>
+          </instance-parameter>
+          <parameter name="dom_object" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitDOMObject</doc>
+            <type name="DOMObject" c:type="WebKitDOMObject*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_js_value_for_dom_object_in_script_world" c:identifier="webkit_frame_get_js_value_for_dom_object_in_script_world" version="2.22">
+        <doc xml:space="preserve">Get a #JSCValue referencing the given DOM object. The value is created in the JavaScript execution
+context of @frame for the given #WebKitScriptWorld.</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">the #JSCValue referencing @dom_object</doc>
+          <type name="JavaScriptCore.Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="frame" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitFrame</doc>
+            <type name="Frame" c:type="WebKitFrame*"/>
+          </instance-parameter>
+          <parameter name="dom_object" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitDOMObject</doc>
+            <type name="DOMObject" c:type="WebKitDOMObject*"/>
+          </parameter>
+          <parameter name="world" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitScriptWorld</doc>
+            <type name="ScriptWorld" c:type="WebKitScriptWorld*"/>
+          </parameter>
         </parameters>
       </method>
       <method name="get_uri" c:identifier="webkit_frame_get_uri" version="2.2">
@@ -21328,12 +22731,32 @@ is present in #WebKitHitTestResult:context</doc>
         <doc xml:space="preserve">Creates a new isolated #WebKitScriptWorld. Scripts executed in
 isolated worlds have access to the DOM but not to other variable
 or functions created by the page.
+The #WebKitScriptWorld is created with a generated unique name. Use
+webkit_script_world_new_with_name() if you want to create it with a
+custom name.
 You can get the JavaScript execution context of a #WebKitScriptWorld
 for a given #WebKitFrame with webkit_frame_get_javascript_context_for_script_world().</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a new isolated #WebKitScriptWorld</doc>
           <type name="ScriptWorld" c:type="WebKitScriptWorld*"/>
         </return-value>
+      </constructor>
+      <constructor name="new_with_name" c:identifier="webkit_script_world_new_with_name" version="2.22">
+        <doc xml:space="preserve">Creates a new isolated #WebKitScriptWorld with a name. Scripts executed in
+isolated worlds have access to the DOM but not to other variable
+or functions created by the page.
+You can get the JavaScript execution context of a #WebKitScriptWorld
+for a given #WebKitFrame with webkit_frame_get_javascript_context_for_script_world().</doc>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve">a new isolated #WebKitScriptWorld</doc>
+          <type name="ScriptWorld" c:type="WebKitScriptWorld*"/>
+        </return-value>
+        <parameters>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve">a name for the script world</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
       </constructor>
       <function name="get_default" c:identifier="webkit_script_world_get_default" version="2.2">
         <doc xml:space="preserve">Get the default #WebKitScriptWorld. This is the normal script world
@@ -21345,6 +22768,19 @@ for a given #WebKitFrame with webkit_frame_get_javascript_context_for_script_wor
           <type name="ScriptWorld" c:type="WebKitScriptWorld*"/>
         </return-value>
       </function>
+      <method name="get_name" c:identifier="webkit_script_world_get_name" version="2.22">
+        <doc xml:space="preserve">Get the name of a #WebKitScriptWorld.</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve">the name of @world</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="world" transfer-ownership="none">
+            <doc xml:space="preserve">a #WebKitScriptWorld</doc>
+            <type name="ScriptWorld" c:type="WebKitScriptWorld*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
       <field name="parent">
         <type name="GObject.Object" c:type="GObject"/>
       </field>

--- a/dl.sh
+++ b/dl.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
 set -e
 
-VER="bionic"
+VER="disco"
 
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libatk1.0-dev/download
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libgirepository1.0-dev/download
-./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libpango1.0-dev/download security.ubuntu.com/ubuntu
+./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libpango1.0-dev/download
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libgdk-pixbuf2.0-dev/download
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libgtk-3-dev/download
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libgtksourceview-3.0-dev/download
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libsecret-1-dev/download
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libvte-2.91-dev/download
-./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libjavascriptcoregtk-4.0-dev/download security.ubuntu.com/ubuntu
+./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libjavascriptcoregtk-4.0-dev/download
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libsoup2.4-dev/download
-./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libwebkit2gtk-4.0-dev/download security.ubuntu.com/ubuntu
+./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libwebkit2gtk-4.0-dev/download
 
 
 ./reformat.sh

--- a/fix.sh
+++ b/fix.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -x -e
 
-# Remove all fields from FcFontMap. Its' parent_instance field is broken and we don't need the type anyway.
-xmlstarlet ed -P -L \
-	-d '//_:class[@name="FcFontMap"]/_:field' \
-	PangoCairo-1.0.gir
-
 # Remove Int32 alias because it misses c:type, it not like anyone actually cares about it.
 xmlstarlet ed -P -L \
 	-d '//_:alias[@name="Int32"]' \

--- a/gir-dl.sh
+++ b/gir-dl.sh
@@ -2,6 +2,7 @@
 set -e -u -o pipefail
 
 MIRRORS="$1"
+echo $MIRRORS
 if [ $# -lt 2 ]; then
   MIRROR="mirrors.kernel.org"
 else


### PR DESCRIPTION
This will need changes in manual code in glib, [gdk](https://github.com/gtk-rs/gdk/pull/259) for ToGlibContainerFromSlice<*const>.

FcFontMap was removed from pangocairo

Other affected crates: atk, sourceview, gio, pango, gtk

This is WIP as I don't want stall glibwrapper and closures updates.

cc @GuillaumeGomez, @sdroege 