### PR TITLE
webkit2gtk-webextension: change constant type to prevent overflow

### DIFF
--- a/fix.sh
+++ b/fix.sh
@@ -60,3 +60,9 @@ xmlstarlet ed -P -L \
 	-u '//_:parameter[@name="response_id"]/_:type[@name="gint"]/@c:type' -v "GtkResponseType" \
 	-u '//_:parameter[@name="response_id"]/_:type[@name="gint"]/@name' -v "ResponseType" \
 	Gtk-3.0.gir
+
+# change int to uint to prevent overflow
+xmlstarlet ed -P -L \
+	-u '//_:constant[@name="DOM_NODE_FILTER_SHOW_ALL"]/_:type[@name="gint"]/@c:type' -v "guint" \
+	-u '//_:constant[@name="DOM_NODE_FILTER_SHOW_ALL"]/_:type[@name="gint"]/@name' -v "guint" \
+	WebKit2WebExtension-4.0.gir


### PR DESCRIPTION
The constant ```4294967295``` is too large to fit into a signed int.