### PR TITLE
Use upstream JavaScriptCore-4.0.gir file

### DIFF
--- a/JavaScriptCore-4.0-patch.gir
+++ b/JavaScriptCore-4.0-patch.gir
@@ -1,0 +1,355 @@
+<?xml version="1.0"?>
+<!-- This file was automatically generated from C sources - DO NOT EDIT!
+To affect the contents of this file, edit the original C definitions,
+and/or use gtk-doc annotations.  -->
+<repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0" version="1.2">
+  <include name="GObject" version="2.0"/>
+  <package name="javascriptcoregtk-4.0"/>
+  <c:include name="JavaScriptCore/JavaScript.h"/>
+  <namespace name="JavaScriptCore" version="4.0" shared-library="libjavascriptcoregtk-4.0.so.18" c:identifier-prefixes="JS" c:symbol-prefixes="JS">
+    <!-- Patches for incomplete type information in glib-compatible javascriptcore. -->
+    <callback name="Constructor" c:type="JSCConstructor">
+      <return-value transfer-ownership="full">
+        <type name="gpointer" c:type="gpointer"/>
+      </return-value>
+      <parameters>
+        <parameter name="args" transfer-ownership="none">
+          <type name="GLib.PtrArray" c:type="GPtrArray*"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="ClassVariadicFunction" c:type="JSCClassVariadicFunction">
+      <return-value transfer-ownership="full">
+        <type name="Value" c:type="JSCValue*"/>
+      </return-value>
+      <parameters>
+        <parameter name="instance" transfer-ownership="none">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="args" transfer-ownership="none">
+          <type name="GLib.PtrArray" c:type="GPtrArray*"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="PropertyGetter" c:type="JSCPropertyGetter">
+      <return-value transfer-ownership="full">
+        <type name="Value" c:type="JSCValue*"/>
+      </return-value>
+      <parameters>
+        <parameter name="instance" transfer-ownership="none">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="PropertySetter" c:type="JSCPropertySetter">
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="instance" transfer-ownership="none">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="value" transfer-ownership="none">
+          <type name="Value" c:type="JSCValue*"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="VariadicFunction" c:type="JSCVariadicFunction">
+      <return-value transfer-ownership="full">
+        <type name="Value" c:type="JSCValue*"/>
+      </return-value>
+      <parameters>
+        <parameter name="args" transfer-ownership="none">
+          <type name="GLib.PtrArray" c:type="GPtrArray*"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="Getter" c:type="JSCGetter">
+      <return-value transfer-ownership="full">
+        <type name="Value" c:type="JSCValue*"/>
+      </return-value>
+      <parameters>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="Setter" c:type="JSCSetter">
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="value" transfer-ownership="none">
+          <type name="Value" c:type="JSCValue*"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <!-- Patches for non-glib javascriptcore that deprecated webkitgtk functions still reference. -->
+    <record name="GlobalContextRef" c:type="JSGlobalContextRef" deprecated="1" deprecated-version="2.22" disguised="1" foreign="1">
+      <method name="ref" c:identifier="JSGlobalContextRetain">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="unref" c:identifier="JSGlobalContextRelease">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+    </record>
+    <record name="ValueRef" c:type="JSValueRef" deprecated="1" deprecated-version="2.22" disguised="1">
+      <function name="ValueIsArray" c:identifier="JSValueIsArray" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueProtect" c:type="JSValueProtect">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueUnprotect" c:type="JSValueUnprotect">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueIsBoolean" c:identifier="JSValueIsBoolean" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueIsDate" c:identifier="JSValueIsDate" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueIsObject" c:identifier="JSValueIsObject" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueIsNull" c:identifier="JSValueIsNull" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueIsNumber" c:identifier="JSValueIsNumber" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueIsString" c:identifier="JSValueIsString" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueIsUndefined" c:identifier="JSValueIsUndefined" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueToBoolean" c:identifier="JSValueToBoolean" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueToNumber" c:identifier="JSValueToNumber" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gdouble" c:type="gdouble"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+          <parameter name="exception" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
+            <doc xml:space="preserve">return location for a #JSCException, or %NULL to ignore</doc>
+            <type name="Exception" c:type="JSCException**"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueToStringCopy" c:identifier="JSValueToStringCopy">
+        <return-value transfer-ownership="none">
+          <type name="StringRef" c:type="JSStringRef"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+          <parameter name="exception" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
+            <type name="ValueRef" c:type="JSValueRef*"/>
+          </parameter>
+        </parameters>
+      </function>
+    </record>
+    <record name="StringRef" c:type="JSStringRef" deprecated="1" deprecated-version="2.22" disguised="1" foreign="1">
+      <method name="ref" c:identifier="JSStringRetain">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="string" transfer-ownership="none">
+            <type name="StringRef" c:type="JSStringRef"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="unref" c:identifier="JSStringRelease">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="string" transfer-ownership="none">
+            <type name="StringRef" c:type="JSStringRef"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="GetMaximumUTF8CStringSize" c:identifier="JSStringGetMaximumUTF8CStringSize">
+        <return-value transfer-ownership="none">
+          <type name="gsize" c:type="gsize"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="string" transfer-ownership="none">
+            <type name="StringRef" c:type="JSStringRef"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="GetUTF8CStringJSStringGetUTF8CString" c:identifier="JSStringGetUTF8CString">
+        <return-value transfer-ownership="none">
+          <type name="gsize" c:type="gsize"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="string" transfer-ownership="none">
+            <type name="StringRef" c:type="JSStringRef"/>
+          </instance-parameter>
+          <parameter name="buffer" direction="inout" caller-allocates="1" transfer-ownership="none">
+            <type name="utf8" c:type="char**"/>
+          </parameter>
+          <parameter name="buffer_size" transfer-ownership="none">
+            <type name="gsize" c:type="gsize"/>
+          </parameter>
+        </parameters>
+      </method>
+    </record>
+  </namespace>
+</repository>

--- a/JavaScriptCore-4.0.gir
+++ b/JavaScriptCore-4.0.gir
@@ -1,9 +1,3393 @@
 <?xml version="1.0"?>
-<repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" version="1.2">
-  <namespace name="JavaScriptCore" version="4.0" shared-library="javascriptcoregtk-4.0" c:identifier-prefixes="JS" c:symbol-prefixes="JS">
-    <record name="Context" c:type="JSCContext" foreign="1"/>
-    <record name="GlobalContextRef" c:type="JSGlobalContextRef" foreign="1"/>
-    <record name="ValueRef" c:type="JSValueRef" foreign="1"/>
-    <record name="Value" c:type="JSCValue" foreign="1"/>
+<!-- This file was automatically generated from C sources - DO NOT EDIT!
+To affect the contents of this file, edit the original C definitions,
+and/or use gtk-doc annotations.  -->
+<repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0" version="1.2">
+  <include name="GObject" version="2.0"/>
+  <package name="javascriptcoregtk-4.0"/>
+  <c:include name="jsc/jsc.h"/>
+  <namespace name="JavaScriptCore" version="4.0" shared-library="libjavascriptcoregtk-4.0.so.18" c:identifier-prefixes="JSC" c:symbol-prefixes="jsc">
+    <callback name="Constructor" c:type="JSCConstructor">
+      <return-value transfer-ownership="full">
+        <type name="gpointer" c:type="gpointer"/>
+      </return-value>
+      <parameters>
+        <parameter name="args" transfer-ownership="none">
+          <type name="GLib.PtrArray" c:type="GPtrArray*"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="ClassVariadicFunction" c:type="JSCClassVariadicFunction">
+      <return-value transfer-ownership="full">
+        <type name="Value" c:type="JSCValue*"/>
+      </return-value>
+      <parameters>
+        <parameter name="instance" transfer-ownership="none">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="args" transfer-ownership="none">
+          <type name="GLib.PtrArray" c:type="GPtrArray*"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="PropertyGetter" c:type="JSCPropertyGetter">
+      <return-value transfer-ownership="full">
+        <type name="Value" c:type="JSCValue*"/>
+      </return-value>
+      <parameters>
+        <parameter name="instance" transfer-ownership="none">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="PropertySetter" c:type="JSCPropertySetter">
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="instance" transfer-ownership="none">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="value" transfer-ownership="none">
+          <type name="Value" c:type="JSCValue*"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="VariadicFunction" c:type="JSCVariadicFunction">
+      <return-value transfer-ownership="full">
+        <type name="Value" c:type="JSCValue*"/>
+      </return-value>
+      <parameters>
+        <parameter name="args" transfer-ownership="none">
+          <type name="GLib.PtrArray" c:type="GPtrArray*"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="Getter" c:type="JSCGetter">
+      <return-value transfer-ownership="full">
+        <type name="Value" c:type="JSCValue*"/>
+      </return-value>
+      <parameters>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="Setter" c:type="JSCSetter">
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="value" transfer-ownership="none">
+          <type name="Value" c:type="JSCValue*"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="1">
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <record name="GlobalContextRef" c:type="JSGlobalContextRef" deprecated="1" deprecated-version="2.22" disguised="1" foreign="1">
+      <method name="ref" c:identifier="JSGlobalContextRetain">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="unref" c:identifier="JSGlobalContextRelease">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+    </record>
+    <record name="ValueRef" c:type="JSValueRef" deprecated="1" deprecated-version="2.22" disguised="1">
+      <function name="ValueIsArray" c:identifier="JSValueIsArray" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueProtect" c:type="JSValueProtect">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueUnprotect" c:type="JSValueUnprotect">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueIsBoolean" c:identifier="JSValueIsBoolean" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueIsDate" c:identifier="JSValueIsDate" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueIsObject" c:identifier="JSValueIsObject" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueIsNull" c:identifier="JSValueIsNull" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueIsNumber" c:identifier="JSValueIsNumber" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueIsString" c:identifier="JSValueIsString" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueIsUndefined" c:identifier="JSValueIsUndefined" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueToBoolean" c:identifier="JSValueToBoolean" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueToNumber" c:identifier="JSValueToNumber" deprecated="1" deprecated-version="2.22">
+        <return-value transfer-ownership="none">
+          <type name="gdouble" c:type="gdouble"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+          <parameter name="exception" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
+            <doc xml:space="preserve">return location for a #JSCException, or %NULL to ignore</doc>
+            <type name="Exception" c:type="JSCException**"/>
+          </parameter>
+        </parameters>
+      </function>
+      <function name="ValueToStringCopy" c:identifier="JSValueToStringCopy">
+        <return-value transfer-ownership="none">
+          <type name="StringRef" c:type="JSStringRef"/>
+        </return-value>
+        <parameters>
+          <parameter name="ctx" transfer-ownership="none">
+            <type name="GlobalContextRef" c:type="JSGlobalContextRef"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <type name="ValueRef" c:type="JSValueRef"/>
+          </parameter>
+          <parameter name="exception" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
+            <type name="ValueRef" c:type="JSValueRef*"/>
+          </parameter>
+        </parameters>
+      </function>
+    </record>
+    <record name="StringRef" c:type="JSStringRef" deprecated="1" deprecated-version="2.22" disguised="1" foreign="1">
+      <method name="ref" c:identifier="JSStringRetain">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="string" transfer-ownership="none">
+            <type name="StringRef" c:type="JSStringRef"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="unref" c:identifier="JSStringRelease">
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="string" transfer-ownership="none">
+            <type name="StringRef" c:type="JSStringRef"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="GetMaximumUTF8CStringSize" c:identifier="JSStringGetMaximumUTF8CStringSize">
+        <return-value transfer-ownership="none">
+          <type name="gsize" c:type="gsize"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="string" transfer-ownership="none">
+            <type name="StringRef" c:type="JSStringRef"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="GetUTF8CStringJSStringGetUTF8CString" c:identifier="JSStringGetUTF8CString">
+        <return-value transfer-ownership="none">
+          <type name="gsize" c:type="gsize"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="string" transfer-ownership="none">
+            <type name="StringRef" c:type="JSStringRef"/>
+          </instance-parameter>
+          <parameter name="buffer" direction="inout" caller-allocates="1" transfer-ownership="none">
+            <type name="utf8" c:type="char**"/>
+          </parameter>
+          <parameter name="buffer_size" transfer-ownership="none">
+            <type name="gsize" c:type="gsize"/>
+          </parameter>
+        </parameters>
+      </method>
+    </record>
+    <enumeration name="CheckSyntaxMode" c:type="JSCCheckSyntaxMode">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="896">Enum values to specify a mode to check for syntax errors in jsc_context_check_syntax().</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="54"/>
+      <member name="script" value="0" c:identifier="JSC_CHECK_SYNTAX_MODE_SCRIPT">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="898">mode to check syntax of a script</doc>
+      </member>
+      <member name="module" value="1" c:identifier="JSC_CHECK_SYNTAX_MODE_MODULE">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="899">mode to check syntax of a module</doc>
+      </member>
+    </enumeration>
+    <enumeration name="CheckSyntaxResult" c:type="JSCCheckSyntaxResult">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="904">Enum values to specify the result of jsc_context_check_syntax().</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="63"/>
+      <member name="success" value="0" c:identifier="JSC_CHECK_SYNTAX_RESULT_SUCCESS">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="906">no errors</doc>
+      </member>
+      <member name="recoverable_error" value="1" c:identifier="JSC_CHECK_SYNTAX_RESULT_RECOVERABLE_ERROR">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="907">recoverable syntax error</doc>
+      </member>
+      <member name="irrecoverable_error" value="2" c:identifier="JSC_CHECK_SYNTAX_RESULT_IRRECOVERABLE_ERROR">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="908">irrecoverable syntax error</doc>
+      </member>
+      <member name="unterminated_literal_error" value="3" c:identifier="JSC_CHECK_SYNTAX_RESULT_UNTERMINATED_LITERAL_ERROR">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="909">unterminated literal error</doc>
+      </member>
+      <member name="out_of_memory_error" value="4" c:identifier="JSC_CHECK_SYNTAX_RESULT_OUT_OF_MEMORY_ERROR">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="910">out of memory error</doc>
+      </member>
+      <member name="stack_overflow_error" value="5" c:identifier="JSC_CHECK_SYNTAX_RESULT_STACK_OVERFLOW_ERROR">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="911">stack overflow error</doc>
+      </member>
+    </enumeration>
+    <class name="Class" c:symbol-prefix="class" c:type="JSCClass" parent="GObject.Object" glib:type-name="JSCClass" glib:get-type="jsc_class_get_type" glib:type-struct="ClassClass">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="38"/>
+      <method name="add_constructor" c:identifier="jsc_class_add_constructor" shadowed-by="add_constructorv" introspectable="0">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="579">Add a constructor to @jsc_class. If @name is %NULL, the class name will be used. When &lt;function&gt;new&lt;/function&gt;
+is used with the constructor or jsc_value_constructor_call() is called, @callback is invoked receiving the
+parameters and @user_data as the last parameter. When the constructor object is cleared in the #JSCClass context,
+@destroy_notify is called with @user_data as parameter.
+
+This function creates the constructor, which needs to be added to an object as a property to be able to use it. Use
+jsc_context_set_value() to make the constructor available in the global object.
+
+Note that the value returned by @callback is adopted by @jsc_class, and the #GDestroyNotify passed to
+jsc_context_register_class() is responsible for disposing of it.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="88"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="601">a #JSCValue representing the class constructor.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="581">a #JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="582">the constructor name or %NULL</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="2" destroy="3">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="583">a #GCallback to be called to create an instance of @jsc_class</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="584">user data to pass to @callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="585">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="586">the #GType of the constructor return value</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="n_params" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="587">the number of parameter types to follow or 0 if constructor doesn't receive parameters.</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="588">a list of #GType&lt;!-- --&gt;s, one for each parameter.</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_constructor_variadic" c:identifier="jsc_class_add_constructor_variadic">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="674">Add a constructor to @jsc_class. If @name is %NULL, the class name will be used. When &lt;function&gt;new&lt;/function&gt;
+is used with the constructor or jsc_value_constructor_call() is called, @callback is invoked receiving
+a #GPtrArray of #JSCValue&lt;!-- --&gt;s as arguments and @user_data as the last parameter. When the constructor object
+is cleared in the #JSCClass context, @destroy_notify is called with @user_data as parameter.
+
+This function creates the constructor, which needs to be added to an object as a property to be able to use it. Use
+jsc_context_set_value() to make the constructor available in the global object.
+
+Note that the value returned by @callback is adopted by @jsc_class, and the #GDestroyNotify passed to
+jsc_context_register_class() is responsible for disposing of it.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="108"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="694">a #JSCValue representing the class constructor.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="676">a #JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="677">the constructor name or %NULL</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="2" destroy="3">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="678">a #GCallback to be called to create an instance of @jsc_class</doc>
+            <type name="Constructor" c:type="JSCConstructor"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="679">user data to pass to @callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="680">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="681">the #GType of the constructor return value</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_constructorv" c:identifier="jsc_class_add_constructorv" shadows="add_constructor">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="628">Add a constructor to @jsc_class. If @name is %NULL, the class name will be used. When &lt;function&gt;new&lt;/function&gt;
+is used with the constructor or jsc_value_constructor_call() is called, @callback is invoked receiving the
+parameters and @user_data as the last parameter. When the constructor object is cleared in the #JSCClass context,
+@destroy_notify is called with @user_data as parameter.
+
+This function creates the constructor, which needs to be added to an object as a property to be able to use it. Use
+jsc_context_set_value() to make the constructor available in the global object.
+
+Note that the value returned by @callback is adopted by @jsc_class, and the #GDestroyNotify passed to
+jsc_context_register_class() is responsible for disposing of it.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="98"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="650">a #JSCValue representing the class constructor.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="630">a #JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="631">the constructor name or %NULL</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="2" destroy="3">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="632">a #GCallback to be called to create an instance of @jsc_class</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="633">user data to pass to @callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="634">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="635">the #GType of the constructor return value</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="n_parameters" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="636">the number of parameters</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="parameter_types" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="637">a list of #GType&lt;!-- --&gt;s, one for each parameter, or %NULL</doc>
+            <array length="5" zero-terminated="0" c:type="GType*">
+              <type name="GType"/>
+            </array>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_method" c:identifier="jsc_class_add_method" shadowed-by="add_methodv" introspectable="0">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="725">Add method with @name to @jsc_class. When the method is called by JavaScript or jsc_value_object_invoke_method(),
+@callback is called receiving the class instance as first parameter, followed by the method parameters and then
+@user_data as last parameter. When the method is cleared in the #JSCClass context, @destroy_notify is called with
+@user_data as parameter.
+
+Note that the value returned by @callback must be transfer full. In case of non-refcounted boxed types, you should use
+%G_TYPE_POINTER instead of the actual boxed #GType to ensure that the instance owned by #JSCClass is used.
+If you really want to return a new copy of the boxed type, use #JSC_TYPE_VALUE and return a #JSCValue created
+with jsc_value_new_object() that receives the copy as the instance parameter.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="116"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="727">a #JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="728">the method name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="2" destroy="3">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="729">a #GCallback to be called to invoke method @name of @jsc_class</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="730">user data to pass to @callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="731">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="732">the #GType of the method return value, or %G_TYPE_NONE if the method is void.</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="n_params" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="733">the number of parameter types to follow or 0 if the method doesn't receive parameters.</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="734">a list of #GType&lt;!-- --&gt;s, one for each parameter.</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_method_variadic" c:identifier="jsc_class_add_method_variadic">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="805">Add method with @name to @jsc_class. When the method is called by JavaScript or jsc_value_object_invoke_method(),
+@callback is called receiving the class instance as first parameter, followed by a #GPtrArray of #JSCValue&lt;!-- --&gt;s
+with the method arguments and then @user_data as last parameter. When the method is cleared in the #JSCClass context,
+@destroy_notify is called with @user_data as parameter.
+
+Note that the value returned by @callback must be transfer full. In case of non-refcounted boxed types, you should use
+%G_TYPE_POINTER instead of the actual boxed #GType to ensure that the instance owned by #JSCClass is used.
+If you really want to return a new copy of the boxed type, use #JSC_TYPE_VALUE and return a #JSCValue created
+with jsc_value_new_object() that receives the copy as the instance parameter.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="136"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="807">a #JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="808">the method name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="2" destroy="3">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="809">a #GCallback to be called to invoke method @name of @jsc_class</doc>
+            <type name="ClassVariadicFunction" c:type="JSCClassVariadicFunction"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="810">user data to pass to @callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="811">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="812">the #GType of the method return value, or %G_TYPE_NONE if the method is void.</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_methodv" c:identifier="jsc_class_add_methodv" shadows="add_method">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="766">Add method with @name to @jsc_class. When the method is called by JavaScript or jsc_value_object_invoke_method(),
+@callback is called receiving the class instance as first parameter, followed by the method parameters and then
+@user_data as last parameter. When the method is cleared in the #JSCClass context, @destroy_notify is called with
+@user_data as parameter.
+
+Note that the value returned by @callback must be transfer full. In case of non-refcounted boxed types, you should use
+%G_TYPE_POINTER instead of the actual boxed #GType to ensure that the instance owned by #JSCClass is used.
+If you really want to return a new copy of the boxed type, use #JSC_TYPE_VALUE and return a #JSCValue created
+with jsc_value_new_object() that receives the copy as the instance parameter.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="126"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="768">a #JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="769">the method name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="2" destroy="3">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="770">a #GCallback to be called to invoke method @name of @jsc_class</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="771">user data to pass to @callback</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="772">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="773">the #GType of the method return value, or %G_TYPE_NONE if the method is void.</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="n_parameters" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="774">the number of parameter types to follow or 0 if the method doesn't receive parameters.</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="parameter_types" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="775">a list of #GType&lt;!-- --&gt;s, one for each parameter, or %NULL</doc>
+            <array length="5" zero-terminated="0" c:type="GType*">
+              <type name="GType"/>
+            </array>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_property" c:identifier="jsc_class_add_property">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="834">Add a property with @name to @jsc_class. When the property value needs to be getted, @getter is called
+receiving the the class instance as first parameter and @user_data as last parameter. When the property
+value needs to be set, @setter is called receiving the the class instance as first parameter, followed
+by the value to be set and then @user_data as the last parameter. When the property is cleared in the
+#JSCClass context, @destroy_notify is called with @user_data as parameter.
+
+Note that the value returned by @getter must be transfer full. In case of non-refcounted boxed types, you should use
+%G_TYPE_POINTER instead of the actual boxed #GType to ensure that the instance owned by #JSCClass is used.
+If you really want to return a new copy of the boxed type, use #JSC_TYPE_VALUE and return a #JSCValue created
+with jsc_value_new_object() that receives the copy as the instance parameter.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="144"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="836">a #JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="837">the property name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="property_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="838">the #GType of the property value</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="getter" transfer-ownership="none" nullable="1" allow-none="1" scope="notified" closure="4" destroy="5">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="839">a #GCallback to be called to get the property value</doc>
+            <type name="PropertyGetter" c:type="JSCPropertyGetter"/>
+          </parameter>
+          <parameter name="setter" transfer-ownership="none" nullable="1" allow-none="1" scope="notified" closure="4" destroy="5">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="840">a #GCallback to be called to set the property value</doc>
+            <type name="PropertySetter" c:type="JSCPropertySetter"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="841">user data to pass to @getter and @setter</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="842">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_name" c:identifier="jsc_class_get_name">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="525">Get the class name of @jsc_class</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="82"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="531">the name of @jsc_class</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="527">a @JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_parent" c:identifier="jsc_class_get_parent">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="540">Get the parent class of @jsc_class</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="85"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="546">the parent class of @jsc_class</doc>
+          <type name="Class" c:type="JSCClass*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="jsc_class" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="542">a @JSCClass</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <property name="context" writable="1" construct-only="1" transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="338">The #JSCContext in which the class was registered.</doc>
+        <type name="Context"/>
+      </property>
+      <property name="name" writable="1" construct-only="1" transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="352">The name of the class.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="parent" writable="1" construct-only="1" transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="366">The parent class or %NULL in case of final classes.</doc>
+        <type name="Class"/>
+      </property>
+    </class>
+    <record name="ClassClass" c:type="JSCClassClass" disguised="1" glib:is-gtype-struct-for="Class">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="38"/>
+    </record>
+    <callback name="ClassDeletePropertyFunction" c:type="JSCClassDeletePropertyFunction">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="423">The type of delete_property in #JSCClassVTable. This is only required when you need to handle
+external properties not added to the prototype.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="55"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="433">%TRUE if handled or %FALSE to to forward the request to the parent class or prototype chain.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="jsc_class" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="425">a #JSCClass</doc>
+          <type name="Class" c:type="JSCClass*"/>
+        </parameter>
+        <parameter name="context" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="426">a #JSCContext</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </parameter>
+        <parameter name="instance" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="427">the @jsc_class instance</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="name" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="428">the property name</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="ClassEnumeratePropertiesFunction" c:type="JSCClassEnumeratePropertiesFunction">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="436">The type of enumerate_properties in #JSCClassVTable. This is only required when you need to handle
+external properties not added to the prototype.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="59"/>
+      <return-value transfer-ownership="full" nullable="1">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="445">a %NULL-terminated array of strings
+   containing the property names, or %NULL if @instance doesn't have enumerable properties.</doc>
+        <array c:type="gchar**">
+          <type name="utf8"/>
+        </array>
+      </return-value>
+      <parameters>
+        <parameter name="jsc_class" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="438">a #JSCClass</doc>
+          <type name="Class" c:type="JSCClass*"/>
+        </parameter>
+        <parameter name="context" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="439">a #JSCContext</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </parameter>
+        <parameter name="instance" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="440">the @jsc_class instance</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="ClassGetPropertyFunction" c:type="JSCClassGetPropertyFunction">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="381">The type of get_property in #JSCClassVTable. This is only required when you need to handle
+external properties not added to the prototype.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="42"/>
+      <return-value transfer-ownership="full" nullable="1">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="391">a #JSCValue or %NULL to forward the request to
+   the parent class or prototype chain</doc>
+        <type name="Value" c:type="JSCValue*"/>
+      </return-value>
+      <parameters>
+        <parameter name="jsc_class" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="383">a #JSCClass</doc>
+          <type name="Class" c:type="JSCClass*"/>
+        </parameter>
+        <parameter name="context" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="384">a #JSCContext</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </parameter>
+        <parameter name="instance" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="385">the @jsc_class instance</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="name" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="386">the property name</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="ClassHasPropertyFunction" c:type="JSCClassHasPropertyFunction">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="409">The type of has_property in #JSCClassVTable. This is only required when you need to handle
+external properties not added to the prototype.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="51"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="419">%TRUE if @instance has a property with @name or %FALSE to forward the request
+   to the parent class or prototype chain.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="jsc_class" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="411">a #JSCClass</doc>
+          <type name="Class" c:type="JSCClass*"/>
+        </parameter>
+        <parameter name="context" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="412">a #JSCContext</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </parameter>
+        <parameter name="instance" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="413">the @jsc_class instance</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="name" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="414">the property name</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <callback name="ClassSetPropertyFunction" c:type="JSCClassSetPropertyFunction">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="395">The type of set_property in #JSCClassVTable. This is only required when you need to handle
+external properties not added to the prototype.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="46"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="406">%TRUE if handled or %FALSE to forward the request to the parent class or prototype chain.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="jsc_class" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="397">a #JSCClass</doc>
+          <type name="Class" c:type="JSCClass*"/>
+        </parameter>
+        <parameter name="context" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="398">a #JSCContext</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </parameter>
+        <parameter name="instance" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="399">the @jsc_class instance</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+        <parameter name="name" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="400">the property name</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="401">the #JSCValue to set</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <record name="ClassVTable" c:type="JSCClassVTable">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="449">Virtual table for a JSCClass. This can be optionally used when registering a #JSCClass in a #JSCContext
+to provide a custom implementation for the class. All virtual functions are optional and can be set to
+%NULL to fallback to the default implementation.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="76"/>
+      <field name="get_property" writable="1">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="451">a #JSCClassGetPropertyFunction for getting a property.</doc>
+        <type name="ClassGetPropertyFunction" c:type="JSCClassGetPropertyFunction"/>
+      </field>
+      <field name="set_property" writable="1">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="452">a #JSCClassSetPropertyFunction for setting a property.</doc>
+        <type name="ClassSetPropertyFunction" c:type="JSCClassSetPropertyFunction"/>
+      </field>
+      <field name="has_property" writable="1">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="453">a #JSCClassHasPropertyFunction for querying a property.</doc>
+        <type name="ClassHasPropertyFunction" c:type="JSCClassHasPropertyFunction"/>
+      </field>
+      <field name="delete_property" writable="1">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="454">a #JSCClassDeletePropertyFunction for deleting a property.</doc>
+        <type name="ClassDeletePropertyFunction" c:type="JSCClassDeletePropertyFunction"/>
+      </field>
+      <field name="enumerate_properties" writable="1">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCClass.cpp" line="455">a #JSCClassEnumeratePropertiesFunction for enumerating properties.</doc>
+        <type name="ClassEnumeratePropertiesFunction" c:type="JSCClassEnumeratePropertiesFunction"/>
+      </field>
+      <field name="_jsc_reserved0" introspectable="0">
+        <callback name="_jsc_reserved0">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="72"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved1" introspectable="0">
+        <callback name="_jsc_reserved1">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="73"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved2" introspectable="0">
+        <callback name="_jsc_reserved2">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="74"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved3" introspectable="0">
+        <callback name="_jsc_reserved3">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCClass.h" line="75"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <class name="Context" c:symbol-prefix="context" c:type="JSCContext" parent="GObject.Object" glib:type-name="JSCContext" glib:get-type="jsc_context_get_type" glib:type-struct="ContextClass">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="79"/>
+      <constructor name="new" c:identifier="jsc_context_new">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="572">Create a new #JSCContext. The context is created in a new #JSCVirtualMachine.
+Use jsc_context_new_with_virtual_machine() to create a new #JSCContext in an
+existing #JSCVirtualMachine.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="85"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="579">the newly created #JSCContext.</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </return-value>
+      </constructor>
+      <constructor name="new_with_virtual_machine" c:identifier="jsc_context_new_with_virtual_machine">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="586">Create a new #JSCContext in @virtual_machine.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="88"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="592">the newly created #JSCContext.</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </return-value>
+        <parameters>
+          <parameter name="vm" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="588">a #JSCVirtualMachine</doc>
+            <type name="VirtualMachine" c:type="JSCVirtualMachine*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <function name="get_current" c:identifier="jsc_context_get_current">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="791">Get the #JSCContext that is currently executing a function. This should only be
+called within a function or method callback, otherwise %NULL will be returned.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="133"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="797">the #JSCContext that is currently executing.</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </return-value>
+      </function>
+      <method name="check_syntax" c:identifier="jsc_context_check_syntax">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="916">Check the given @code in @context for syntax errors. The @line_number is the starting line number in @uri;
+the value is one-based so the first line is 1. @uri and @line_number are only used to fill the @exception.
+In case of errors @exception will be set to a new #JSCException with the details. You can pass %NULL to
+@exception to ignore the error details.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="158"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="931">a #JSCCheckSyntaxResult</doc>
+          <type name="CheckSyntaxResult" c:type="JSCCheckSyntaxResult"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="918">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="code" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="919">a JavaScript script to check</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="length" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="920">length of @code, or -1 if @code is a nul-terminated string</doc>
+            <type name="gssize" c:type="gssize"/>
+          </parameter>
+          <parameter name="mode" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="921">a #JSCCheckSyntaxMode</doc>
+            <type name="CheckSyntaxMode" c:type="JSCCheckSyntaxMode"/>
+          </parameter>
+          <parameter name="uri" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="922">the source URI</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="line_number" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="923">the starting line number</doc>
+            <type name="guint" c:type="unsigned"/>
+          </parameter>
+          <parameter name="exception" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="924">return location for a #JSCException, or %NULL to ignore</doc>
+            <type name="Exception" c:type="JSCException**"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="clear_exception" c:identifier="jsc_context_clear_exception">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="717">Clear the uncaught exception in @context if any.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="121"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="719">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="evaluate" c:identifier="jsc_context_evaluate">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="805">Evaluate @code in @context.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="136"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="813">a #JSCValue representing the last value generated by the script.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="807">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="code" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="808">a JavaScript script to evaluate</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="length" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="809">length of @code, or -1 if @code is a nul-terminated string</doc>
+            <type name="gssize" c:type="gssize"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="evaluate_in_object" c:identifier="jsc_context_evaluate_in_object">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="854">Evaluate @code and create an new object where symbols defined in @code will be added as properties,
+instead of being added to @context global object. The new object is returned as @object parameter.
+Similar to how jsc_value_new_object() works, if @object_instance is not %NULL @object_class must be provided too.
+The @line_number is the starting line number in @uri; the value is one-based so the first line is 1.
+@uri and @line_number will be shown in exceptions and they don't affect the behavior of the script.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="148"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="871">a #JSCValue representing the last value generated by the script.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="856">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="code" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="857">a JavaScript script to evaluate</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="length" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="858">length of @code, or -1 if @code is a nul-terminated string</doc>
+            <type name="gssize" c:type="gssize"/>
+          </parameter>
+          <parameter name="object_instance" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="859">an object instance</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="object_class" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="860">a #JSCClass or %NULL to use the default</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </parameter>
+          <parameter name="uri" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="861">the source URI</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="line_number" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="862">the starting line number</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="object" direction="out" caller-allocates="0" transfer-ownership="full">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="863">return location for a #JSCValue.</doc>
+            <type name="Value" c:type="JSCValue**"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="evaluate_with_source_uri" c:identifier="jsc_context_evaluate_with_source_uri">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="827">Evaluate @code in @context using @uri as the source URI. The @line_number is the starting line number
+in @uri; the value is one-based so the first line is 1. @uri and @line_number will be shown in exceptions and
+they don't affect the behavior of the script.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="141"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="839">a #JSCValue representing the last value generated by the script.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="829">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="code" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="830">a JavaScript script to evaluate</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="length" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="831">length of @code, or -1 if @code is a nul-terminated string</doc>
+            <type name="gssize" c:type="gssize"/>
+          </parameter>
+          <parameter name="uri" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="832">the source URI</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="line_number" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="833">the starting line number</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_exception" c:identifier="jsc_context_get_exception">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="615">Get the last unhandled exception thrown in @context by API functions calls.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="94"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="621">a #JSCException or %NULL if there isn't any
+   unhandled exception in the #JSCContext.</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="617">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_global_object" c:identifier="jsc_context_get_global_object">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1004">Get a #JSCValue referencing the @context global object</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="167"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1010">a #JSCValue</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1006">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_value" c:identifier="jsc_context_get_value">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1037">Get a property of @context global object with @name.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="175"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1044">a #JSCValue</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1039">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1040">the value name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_virtual_machine" c:identifier="jsc_context_get_virtual_machine">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="600">Get the #JSCVirtualMachine where @context was created.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="91"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="606">the #JSCVirtualMachine where the #JSCContext was created.</doc>
+          <type name="VirtualMachine" c:type="JSCVirtualMachine*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="602">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="pop_exception_handler" c:identifier="jsc_context_pop_exception_handler">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="763">Remove the last #JSCExceptionHandler previously pushed to @context with
+jsc_context_push_exception_handler().</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="130"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="765">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="push_exception_handler" c:identifier="jsc_context_push_exception_handler">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="739">Push an exception handler in @context. Whenever a JavaScript exception happens in
+the #JSCContext, the given @handler will be called. The default #JSCExceptionHandler
+simply calls jsc_context_throw_exception() to throw the exception to the #JSCContext.
+If you don't want to catch the exception, but only get notified about it, call
+jsc_context_throw_exception() in @handler like the default one does.
+The last exception handler pushed is the only one used by the #JSCContext, use
+jsc_context_pop_exception_handler() to remove it and set the previous one. When @handler
+is removed from the context, @destroy_notify i called with @user_data as parameter.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="124"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="741">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="handler" transfer-ownership="none" scope="notified" closure="1" destroy="2">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="742">a #JSCExceptionHandler</doc>
+            <type name="ExceptionHandler" c:type="JSCExceptionHandler"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="743">user data to pass to @handler</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="744">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="register_class" c:identifier="jsc_context_register_class">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1055">Register a custom class in @context using the given @name. If the new class inherits from
+another #JSCClass, the parent should be passed as @parent_class, otherwise %NULL should be
+used. The optional @vtable parameter allows to provide a custom implementation for handling
+the class, for example, to handle external properties not added to the prototype.
+When an instance of the #JSCClass is cleared in the context, @destroy_notify is called with
+the instance as parameter.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="179"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1070">a #JSCClass</doc>
+          <type name="Class" c:type="JSCClass*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1057">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1058">the class name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="parent_class" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1059">a #JSCClass or %NULL</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </parameter>
+          <parameter name="vtable" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1060">an optional #JSCClassVTable or %NULL</doc>
+            <type name="ClassVTable" c:type="JSCClassVTable*"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1061">a destroy notifier for class instances</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_value" c:identifier="jsc_context_set_value">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1019">Set a property of @context global object with @name and @value.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="170"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1021">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1022">the value name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="1023">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="throw" c:identifier="jsc_context_throw">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="631">Throw an exception to @context using the given error message. The created #JSCException
+can be retrieved with jsc_context_get_exception().</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="97"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="633">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="error_message" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="634">an error message</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="throw_exception" c:identifier="jsc_context_throw_exception">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="702">Throw @exception to @context.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="117"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="704">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="705">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="throw_printf" c:identifier="jsc_context_throw_printf" introspectable="0">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="646">Throw an exception to @context using the given formatted string as error message.
+The created #JSCException can be retrieved with jsc_context_get_exception().</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="101"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="648">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="format" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="649">the string format</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="650">the parameters to insert into the format string</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="throw_with_name" c:identifier="jsc_context_throw_with_name">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="665">Throw an exception to @context using the given error name and message. The created #JSCException
+can be retrieved with jsc_context_get_exception().</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="106"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="667">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="error_name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="668">the error name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="error_message" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="669">an error message</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="throw_with_name_printf" c:identifier="jsc_context_throw_with_name_printf" introspectable="0">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="682">Throw an exception to @context using the given error name and the formatted string as error message.
+The created #JSCException can be retrieved with jsc_context_get_exception().</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="111"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="684">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </instance-parameter>
+          <parameter name="error_name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="685">the error name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="format" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="686">the string format</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="687">the parameters to insert into the format string</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="virtual-machine" writable="1" construct-only="1" transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="176">The #JSCVirtualMachine in which the context was created.</doc>
+        <type name="VirtualMachine"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv" readable="0" private="1">
+        <type name="ContextPrivate" c:type="JSCContextPrivate*"/>
+      </field>
+    </class>
+    <record name="ContextClass" c:type="JSCContextClass" glib:is-gtype-struct-for="Context">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="79"/>
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_jsc_reserved0" introspectable="0">
+        <callback name="_jsc_reserved0">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="75"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved1" introspectable="0">
+        <callback name="_jsc_reserved1">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="76"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved2" introspectable="0">
+        <callback name="_jsc_reserved2">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="77"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved3" introspectable="0">
+        <callback name="_jsc_reserved3">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="78"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <record name="ContextPrivate" c:type="JSCContextPrivate" disguised="1">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="45"/>
+    </record>
+    <class name="Exception" c:symbol-prefix="exception" c:type="JSCException" parent="GObject.Object" glib:type-name="JSCException" glib:get-type="jsc_exception_get_type" glib:type-struct="ExceptionClass">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="59"/>
+      <constructor name="new" c:identifier="jsc_exception_new">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="122">Create a new #JSCException in @context with @message.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="65"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="129">a new #JSCException.</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="124">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="message" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="125">the error message</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_printf" c:identifier="jsc_exception_new_printf" introspectable="0">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="136">Create a new #JSCException in @context using a formatted string
+for the message.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="69"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="145">a new #JSCException.</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="138">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="format" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="139">the string format</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="140">the parameters to insert into the format string</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_vprintf" c:identifier="jsc_exception_new_vprintf" introspectable="0">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="157">Create a new #JSCException in @context using a formatted string
+for the message. This is similar to jsc_exception_new_printf()
+except that the arguments to the format string are passed as a va_list.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="74"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="167">a new #JSCException.</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="159">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="format" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="160">the string format</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="args" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="161">the parameters to insert into the format string</doc>
+            <type name="va_list" c:type="va_list"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_with_name" c:identifier="jsc_exception_new_with_name">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="178">Create a new #JSCException in @context with @name and @message.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="79"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="186">a new #JSCException.</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="180">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="181">the error name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="message" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="182">the error message</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_with_name_printf" c:identifier="jsc_exception_new_with_name_printf" introspectable="0">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="209">Create a new #JSCException in @context with @name and using a formatted string
+for the message.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="84"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="219">a new #JSCException.</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="211">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="212">the error name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="format" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="213">the string format</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="214">the parameters to insert into the format string</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_with_name_vprintf" c:identifier="jsc_exception_new_with_name_vprintf" introspectable="0">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="231">Create a new #JSCException in @context with @name and using a formatted string
+for the message. This is similar to jsc_exception_new_with_name_printf()
+except that the arguments to the format string are passed as a va_list.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="90"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="242">a new #JSCException.</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="233">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="234">the error name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="format" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="235">the string format</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="args" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="236">the parameters to insert into the format string</doc>
+            <type name="va_list" c:type="va_list"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="get_backtrace_string" c:identifier="jsc_exception_get_backtrace_string">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="348">Get a string with the exception backtrace.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="111"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="354">the exception backtrace string or %NULL.</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="350">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_column_number" c:identifier="jsc_exception_get_column_number">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="310">Get the column number at which @exception happened.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="105"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="316">the column number of @exception.</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="312">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_line_number" c:identifier="jsc_exception_get_line_number">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="291">Get the line number at which @exception happened.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="102"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="297">the line number of @exception.</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="293">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_message" c:identifier="jsc_exception_get_message">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="272">Get the error message of @exception.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="99"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="278">the @exception error message.</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="274">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_name" c:identifier="jsc_exception_get_name">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="253">Get the error name of @exception</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="96"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="259">the @exception error name.</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="255">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_source_uri" c:identifier="jsc_exception_get_source_uri">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="329">Get the source URI of @exception.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="108"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="335">the the source URI of @exception, or %NULL.</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="331">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="report" c:identifier="jsc_exception_report">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="386">Return a report message of @exception, containing all the possible details such us
+source URI, line, column and backtrace, and formatted to be printed.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="117"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="393">a new string with the exception report</doc>
+          <type name="utf8" c:type="char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="388">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="to_string" c:identifier="jsc_exception_to_string">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="367">Get the string representation of @exception error.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="114"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="373">the string representation of @exception.</doc>
+          <type name="utf8" c:type="char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="exception" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCException.cpp" line="369">a #JSCException</doc>
+            <type name="Exception" c:type="JSCException*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv" readable="0" private="1">
+        <type name="ExceptionPrivate" c:type="JSCExceptionPrivate*"/>
+      </field>
+    </class>
+    <record name="ExceptionClass" c:type="JSCExceptionClass" glib:is-gtype-struct-for="Exception">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="59"/>
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_jsc_reserved0" introspectable="0">
+        <callback name="_jsc_reserved0">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="55"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved1" introspectable="0">
+        <callback name="_jsc_reserved1">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="56"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved2" introspectable="0">
+        <callback name="_jsc_reserved2">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="57"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved3" introspectable="0">
+        <callback name="_jsc_reserved3">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="58"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <callback name="ExceptionHandler" c:type="JSCExceptionHandler">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="730">Function used to handle JavaScript exceptions in a #JSCContext.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCContext.h" line="47"/>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="context" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="732">a #JSCContext</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </parameter>
+        <parameter name="exception" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="733">a #JSCException</doc>
+          <type name="Exception" c:type="JSCException*"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="2">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCContext.cpp" line="734">user data</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <record name="ExceptionPrivate" c:type="JSCExceptionPrivate" disguised="1">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCException.h" line="41"/>
+    </record>
+    <constant name="MAJOR_VERSION" value="2" c:type="JSC_MAJOR_VERSION">
+      <doc xml:space="preserve" filename="obj-x86_64-linux-gnu/DerivedSources/JavaScriptCore/javascriptcoregtk/jsc/JSCVersion.h" line="31">Like jsc_get_major_version(), but from the headers used at
+application compile time, rather than from the library linked
+against at application run time.</doc>
+      <source-position filename="obj-x86_64-linux-gnu/DerivedSources/JavaScriptCore/javascriptcoregtk/jsc/JSCVersion.h" line="38"/>
+      <type name="gint" c:type="gint"/>
+    </constant>
+    <constant name="MICRO_VERSION" value="2" c:type="JSC_MICRO_VERSION">
+      <doc xml:space="preserve" filename="obj-x86_64-linux-gnu/DerivedSources/JavaScriptCore/javascriptcoregtk/jsc/JSCVersion.h" line="49">Like jsc_get_micro_version(), but from the headers used at
+application compile time, rather than from the library linked
+against at application run time.</doc>
+      <source-position filename="obj-x86_64-linux-gnu/DerivedSources/JavaScriptCore/javascriptcoregtk/jsc/JSCVersion.h" line="56"/>
+      <type name="gint" c:type="gint"/>
+    </constant>
+    <constant name="MINOR_VERSION" value="24" c:type="JSC_MINOR_VERSION">
+      <doc xml:space="preserve" filename="obj-x86_64-linux-gnu/DerivedSources/JavaScriptCore/javascriptcoregtk/jsc/JSCVersion.h" line="40">Like jsc_get_minor_version(), but from the headers used at
+application compile time, rather than from the library linked
+against at application run time.</doc>
+      <source-position filename="obj-x86_64-linux-gnu/DerivedSources/JavaScriptCore/javascriptcoregtk/jsc/JSCVersion.h" line="47"/>
+      <type name="gint" c:type="gint"/>
+    </constant>
+    <constant name="OPTIONS_USE_DFG" value="useDFGJIT" c:type="JSC_OPTIONS_USE_DFG" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="698">Allows the DFG JIT to be used if %TRUE.
+Option type: %JSC_OPTION_BOOLEAN
+Default value: %TRUE.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="33"/>
+      <type name="utf8" c:type="gchar*"/>
+    </constant>
+    <constant name="OPTIONS_USE_FTL" value="useFTLJIT" c:type="JSC_OPTIONS_USE_FTL" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="708">Allows the FTL JIT to be used if %TRUE.
+Option type: %JSC_OPTION_BOOLEAN
+Default value: %TRUE.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="34"/>
+      <type name="utf8" c:type="gchar*"/>
+    </constant>
+    <constant name="OPTIONS_USE_JIT" value="useJIT" c:type="JSC_OPTIONS_USE_JIT" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="688">Allows the executable pages to be allocated for JIT and thunks if %TRUE.
+Option type: %JSC_OPTION_BOOLEAN
+Default value: %TRUE.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="32"/>
+      <type name="utf8" c:type="gchar*"/>
+    </constant>
+    <constant name="OPTIONS_USE_LLINT" value="useLLInt" c:type="JSC_OPTIONS_USE_LLINT" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="718">Allows the LLINT to be used if %TRUE.
+Option type: %JSC_OPTION_BOOLEAN
+Default value: %TRUE.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="35"/>
+      <type name="utf8" c:type="gchar*"/>
+    </constant>
+    <enumeration name="OptionType" version="2.24" c:type="JSCOptionType">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="572">Enum values for options types.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="94"/>
+      <member name="boolean" value="0" c:identifier="JSC_OPTION_BOOLEAN">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="574">A #gboolean option type.</doc>
+      </member>
+      <member name="int" value="1" c:identifier="JSC_OPTION_INT">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="575">A #gint option type.</doc>
+      </member>
+      <member name="uint" value="2" c:identifier="JSC_OPTION_UINT">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="576">A #guint option type.</doc>
+      </member>
+      <member name="size" value="3" c:identifier="JSC_OPTION_SIZE">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="577">A #gsize options type.</doc>
+      </member>
+      <member name="double" value="4" c:identifier="JSC_OPTION_DOUBLE">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="578">A #gdouble options type.</doc>
+      </member>
+      <member name="string" value="5" c:identifier="JSC_OPTION_STRING">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="579">A string option type.</doc>
+      </member>
+      <member name="range_string" value="6" c:identifier="JSC_OPTION_RANGE_STRING">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="580">A range string option type.</doc>
+      </member>
+    </enumeration>
+    <callback name="OptionsFunc" c:type="JSCOptionsFunc" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="587">Function used to iterate options.
+
+Not that @description string is not localized.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="96"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="598">%TRUE to stop the iteration, or %FALSE otherwise</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="589">the option name</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="type" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="590">the option #JSCOptionType</doc>
+          <type name="OptionType" c:type="JSCOptionType"/>
+        </parameter>
+        <parameter name="description" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="591">the option description, or %NULL</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1" closure="3">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="592">user data</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </callback>
+    <class name="Value" c:symbol-prefix="value" c:type="JSCValue" parent="GObject.Object" glib:type-name="JSCValue" glib:get-type="jsc_value_get_type" glib:type-struct="ValueClass">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="66"/>
+      <constructor name="new_array" c:identifier="jsc_value_new_array" introspectable="0">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="460">Create a new #JSCValue referencing an array with the given items. If @first_item_type
+is %G_TYPE_NONE an empty array is created.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="125"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="469">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="462">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="first_item_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="463">#GType of first item, or %G_TYPE_NONE</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="464">value of the first item, followed optionally by more type/value pairs, followed by %G_TYPE_NONE.</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_array_from_garray" c:identifier="jsc_value_new_array_from_garray">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="521">Create a new #JSCValue referencing an array with the items from @array. If @array
+is %NULL or empty a new empty array will be created. Elements of @array should be
+pointers to a #JSCValue.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="130"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="530">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="523">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="array" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="524">a #GPtrArray</doc>
+            <array name="GLib.PtrArray" c:type="GPtrArray*">
+              <type name="Value"/>
+            </array>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_array_from_strv" c:identifier="jsc_value_new_array_from_strv">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="547">Create a new #JSCValue referencing an array of strings with the items from @strv. If @array
+is %NULL or empty a new empty array will be created.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="134"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="555">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="549">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="strv" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="550">a %NULL-terminated array of strings</doc>
+            <array c:type="const char* const*">
+              <type name="utf8"/>
+            </array>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_boolean" c:identifier="jsc_value_new_boolean">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="281">Create a new #JSCValue from @value</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="99"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="288">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="283">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="284">a #gboolean</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_function" c:identifier="jsc_value_new_function" shadowed-by="new_functionv" introspectable="0">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1158">Create a function in @context. If @name is %NULL an anonymous function will be created.
+When the function is called by JavaScript or jsc_value_function_call(), @callback is called
+receiving the function parameters and then @user_data as last parameter. When the function is
+cleared in @context, @destroy_notify is called with @user_data as parameter.
+
+Note that the value returned by @callback must be fully transferred. In case of boxed types, you could use
+%G_TYPE_POINTER instead of the actual boxed #GType to ensure that the instance owned by #JSCClass is used.
+If you really want to return a new copy of the boxed type, use #JSC_TYPE_VALUE and return a #JSCValue created
+with jsc_value_new_object() that receives the copy as instance parameter.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="210"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1179">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1160">a #JSCContext:</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="name" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1161">the function name or %NULL</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="3" destroy="4">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1162">a #GCallback.</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1163">user data to pass to @callback.</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1164">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1165">the #GType of the function return value, or %G_TYPE_NONE if the function is void.</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="n_params" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1166">the number of parameter types to follow or 0 if the function doesn't receive parameters.</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1167">a list of #GType&lt;!-- --&gt;s, one for each parameter.</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_function_variadic" c:identifier="jsc_value_new_function_variadic">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1238">Create a function in @context. If @name is %NULL an anonymous function will be created.
+When the function is called by JavaScript or jsc_value_function_call(), @callback is called
+receiving an #GPtrArray of #JSCValue&lt;!-- --&gt;s with the arguments and then @user_data as last parameter.
+When the function is cleared in @context, @destroy_notify is called with @user_data as parameter.
+
+Note that the value returned by @callback must be fully transferred. In case of boxed types, you could use
+%G_TYPE_POINTER instead of the actual boxed #GType to ensure that the instance owned by #JSCClass is used.
+If you really want to return a new copy of the boxed type, use #JSC_TYPE_VALUE and return a #JSCValue created
+with jsc_value_new_object() that receives the copy as instance parameter.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="230"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1257">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1240">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="name" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1241">the function name or %NULL</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="3" destroy="4">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1242">a #GCallback.</doc>
+            <type name="VariadicFunction" c:type="JSCVariadicFunction"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1243">user data to pass to @callback.</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1244">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1245">the #GType of the function return value, or %G_TYPE_NONE if the function is void.</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_functionv" c:identifier="jsc_value_new_functionv" shadows="new_function">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1199">Create a function in @context. If @name is %NULL an anonymous function will be created.
+When the function is called by JavaScript or jsc_value_function_call(), @callback is called
+receiving the function parameters and then @user_data as last parameter. When the function is
+cleared in @context, @destroy_notify is called with @user_data as parameter.
+
+Note that the value returned by @callback must be fully transferred. In case of boxed types, you could use
+%G_TYPE_POINTER instead of the actual boxed #GType to ensure that the instance owned by #JSCClass is used.
+If you really want to return a new copy of the boxed type, use #JSC_TYPE_VALUE and return a #JSCValue created
+with jsc_value_new_object() that receives the copy as instance parameter.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="220"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1220">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1201">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="name" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1202">the function name or %NULL</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="callback" transfer-ownership="none" scope="notified" closure="3" destroy="4">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1203">a #GCallback.</doc>
+            <type name="GObject.Callback" c:type="GCallback"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1204">user data to pass to @callback.</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1205">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+          <parameter name="return_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1206">the #GType of the function return value, or %G_TYPE_NONE if the function is void.</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="n_parameters" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1207">the number of parameters</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="parameter_types" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1208">a list of #GType&lt;!-- --&gt;s, one for each parameter, or %NULL</doc>
+            <array length="6" zero-terminated="0" c:type="GType*">
+              <type name="GType"/>
+            </array>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_null" c:identifier="jsc_value_new_null">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="184">Create a new #JSCValue referencing &lt;function&gt;null&lt;/function&gt; in @context.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="81"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="190">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="186">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_number" c:identifier="jsc_value_new_number">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="215">Create a new #JSCValue from @number.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="87"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="222">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="217">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="number" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="218">a number</doc>
+            <type name="gdouble" c:type="double"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_object" c:identifier="jsc_value_new_object">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="588">Create a new #JSCValue from @instance. If @instance is %NULL a new empty object is created.
+When @instance is provided, @jsc_class must be provided too. @jsc_class takes ownership of
+@instance that will be freed by the #GDestroyNotify passed to jsc_context_register_class().</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="141"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="598">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="590">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="instance" transfer-ownership="full" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="591">an object instance or %NULL</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="jsc_class" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="592">the #JSCClass of @instance</doc>
+            <type name="Class" c:type="JSCClass*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_string" c:identifier="jsc_value_new_string">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="329">Create a new #JSCValue from @string. If you need to create a #JSCValue from a
+string containing null characters, use jsc_value_new_string_from_bytes() instead.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="108"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="337">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="331">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="string" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="332">a null-terminated string</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_string_from_bytes" c:identifier="jsc_value_new_string_from_bytes">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="352">Create a new #JSCValue from @bytes.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="112"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="359">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="354">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+          <parameter name="bytes" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="355">a #GBytes</doc>
+            <type name="GLib.Bytes" c:type="GBytes*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <constructor name="new_undefined" c:identifier="jsc_value_new_undefined">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="153">Create a new #JSCValue referencing &lt;function&gt;undefined&lt;/function&gt; in @context.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="75"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="159">a #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="context" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="155">a #JSCContext</doc>
+            <type name="Context" c:type="JSCContext*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="constructor_call" c:identifier="jsc_value_constructor_call" shadowed-by="constructor_callv" introspectable="0">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1378">Invoke &lt;function&gt;new&lt;/function&gt; with constructor referenced by @value. If @first_parameter_type
+is %G_TYPE_NONE no parameters will be passed to the constructor.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="254"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1387">a #JSCValue referencing the newly created object instance.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1380">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="first_parameter_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1381">#GType of first parameter, or %G_TYPE_NONE</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1382">value of the first parameter, followed optionally by more type/value pairs, followed by %G_TYPE_NONE</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="constructor_callv" c:identifier="jsc_value_constructor_callv" shadows="constructor_call">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1408">Invoke &lt;function&gt;new&lt;/function&gt; with constructor referenced by @value. If @n_parameters
+is 0 no parameters will be passed to the constructor.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="259"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1417">a #JSCValue referencing the newly created object instance.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1410">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="n_parameters" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1411">the number of parameters</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="parameters" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1412">the #JSCValue&lt;!-- --&gt;s to pass as parameters to the constructor, or %NULL</doc>
+            <array length="0" zero-terminated="0" c:type="JSCValue**">
+              <type name="Value"/>
+            </array>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="function_call" c:identifier="jsc_value_function_call" shadowed-by="function_callv" introspectable="0">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1286">Call function referenced by @value, passing the given parameters. If @first_parameter_type
+is %G_TYPE_NONE no parameters will be passed to the function.
+
+This function always returns a #JSCValue, in case of void functions a #JSCValue referencing
+&lt;function&gt;undefined&lt;/function&gt; is returned</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="241"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1298">a #JSCValue with the return value of the function.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1288">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="first_parameter_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1289">#GType of first parameter, or %G_TYPE_NONE</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1290">value of the first parameter, followed optionally by more type/value pairs, followed by %G_TYPE_NONE</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="function_callv" c:identifier="jsc_value_function_callv" shadows="function_call">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1319">Call function referenced by @value, passing the given @parameters. If @n_parameters
+is 0 no parameters will be passed to the function.
+
+This function always returns a #JSCValue, in case of void functions a #JSCValue referencing
+&lt;function&gt;undefined&lt;/function&gt; is returned</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="246"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1331">a #JSCValue with the return value of the function.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1321">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="n_parameters" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1322">the number of parameters</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="parameters" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1323">the #JSCValue&lt;!-- --&gt;s to pass as parameters to the function, or %NULL</doc>
+            <array length="0" zero-terminated="0" c:type="JSCValue**">
+              <type name="Value"/>
+            </array>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_context" c:identifier="jsc_value_get_context">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="138">Get the #JSCContext in which @value was created.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="72"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="144">the #JSCValue context.</doc>
+          <type name="Context" c:type="JSCContext*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="140">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_array" c:identifier="jsc_value_is_array">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="572">Get whether the value referenced by @value is an array.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="138"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="578">whether the value is an array.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="574">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_boolean" c:identifier="jsc_value_is_boolean">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="297">Get whether the value referenced by @value is a boolean.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="102"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="303">whether the value is a boolean.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="299">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_constructor" c:identifier="jsc_value_is_constructor">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1359">Get whether the value referenced by @value is a constructor.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="251"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1365">whether the value is a constructor.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1361">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_function" c:identifier="jsc_value_is_function">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1267">Get whether the value referenced by @value is a function</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="238"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1273">whether the value is a function.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1269">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_null" c:identifier="jsc_value_is_null">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="199">Get whether the value referenced by @value is &lt;function&gt;null&lt;/function&gt;.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="84"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="205">whether the value is null.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="201">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_number" c:identifier="jsc_value_is_number">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="231">Get whether the value referenced by @value is a number.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="90"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="237">whether the value is a number.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="233">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_object" c:identifier="jsc_value_is_object">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="608">Get whether the value referenced by @value is an object.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="146"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="614">whether the value is an object.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="610">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_string" c:identifier="jsc_value_is_string">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="375">Get whether the value referenced by @value is a string</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="116"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="381">whether the value is a string</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="377">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="is_undefined" c:identifier="jsc_value_is_undefined">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="168">Get whether the value referenced by @value is &lt;function&gt;undefined&lt;/function&gt;.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="78"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="174">whether the value is undefined.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="170">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="object_define_property_accessor" c:identifier="jsc_value_object_define_property_accessor">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1071">Define or modify a property with @property_name in object referenced by @value. When the
+property value needs to be getted or set, @getter and @setter callbacks will be called.
+When the property is cleared in the #JSCClass context, @destroy_notify is called with
+@user_data as parameter. This is equivalent to JavaScript &lt;function&gt;Object.defineProperty()&lt;/function&gt;
+when used with an accessor descriptor.
+
+Note that the value returned by @getter must be fully transferred. In case of boxed types, you could use
+%G_TYPE_POINTER instead of the actual boxed #GType to ensure that the instance owned by #JSCClass is used.
+If you really want to return a new copy of the boxed type, use #JSC_TYPE_VALUE and return a #JSCValue created
+with jsc_value_new_object() that receives the copy as instance parameter.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="200"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1073">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="property_name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1074">the name of the property to define</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="flags" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1075">#JSCValuePropertyFlags</doc>
+            <type name="ValuePropertyFlags" c:type="JSCValuePropertyFlags"/>
+          </parameter>
+          <parameter name="property_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1076">the #GType of the property</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="getter" transfer-ownership="none" nullable="1" allow-none="1" scope="notified" closure="5" destroy="6">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1077">a #GCallback to be called to get the property value</doc>
+            <type name="Getter" c:type="JSCGetter"/>
+          </parameter>
+          <parameter name="setter" transfer-ownership="none" nullable="1" allow-none="1" scope="notified" closure="5" destroy="6">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1078">a #GCallback to be called to set the property value</doc>
+            <type name="Setter" c:type="JSCSetter"/>
+          </parameter>
+          <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1079">user data to pass to @getter and @setter</doc>
+            <type name="gpointer" c:type="gpointer"/>
+          </parameter>
+          <parameter name="destroy_notify" transfer-ownership="none" nullable="1" allow-none="1" scope="async">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1080">destroy notifier for @user_data</doc>
+            <type name="GLib.DestroyNotify" c:type="GDestroyNotify"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_define_property_data" c:identifier="jsc_value_object_define_property_data">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1025">Define or modify a property with @property_name in object referenced by @value. This is equivalent to
+JavaScript &lt;function&gt;Object.defineProperty()&lt;/function&gt; when used with a data descriptor.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="194"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1027">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="property_name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1028">the name of the property to define</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="flags" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1029">#JSCValuePropertyFlags</doc>
+            <type name="ValuePropertyFlags" c:type="JSCValuePropertyFlags"/>
+          </parameter>
+          <parameter name="property_value" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1030">the default property value</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_delete_property" c:identifier="jsc_value_object_delete_property">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="787">Try to delete property with @name from @value. This function will return %FALSE if
+the property was defined without %JSC_VALUE_PROPERTY_CONFIGURABLE flag.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="175"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="795">%TRUE if the property was deleted, or %FALSE otherwise.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="789">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="790">the property name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_enumerate_properties" c:identifier="jsc_value_object_enumerate_properties">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="817">Get the list of property names of @value. Only properties defined with %JSC_VALUE_PROPERTY_ENUMERABLE
+flag will be collected.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="179"/>
+        <return-value transfer-ownership="full" nullable="1">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="824">a %NULL-terminated array of strings containing the
+   property names, or %NULL if @value doesn't have enumerable properties.  Use g_strfreev() to free.</doc>
+          <array c:type="gchar**">
+            <type name="utf8"/>
+          </array>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="819">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="object_get_property" c:identifier="jsc_value_object_get_property">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="682">Get property with @name from @value.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="158"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="689">the property #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="684">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="685">the property name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_get_property_at_index" c:identifier="jsc_value_object_get_property_at_index">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="735">Get property at @index from @value.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="167"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="742">the property #JSCValue.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="737">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="index" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="738">the property index</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_has_property" c:identifier="jsc_value_object_has_property">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="762">Get whether @value has property with @name.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="171"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="769">%TRUE if @value has a property with @name, or %FALSE otherwise</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="764">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="765">the property name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_invoke_method" c:identifier="jsc_value_object_invoke_method" shadowed-by="object_invoke_methodv" introspectable="0">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="911">Invoke method with @name on object referenced by @value, passing the given parameters. If
+@first_parameter_type is %G_TYPE_NONE no parameters will be passed to the method.
+The object instance will be handled automatically even when the method is a custom one
+registered with jsc_class_add_method(), so it should never be passed explicitly as parameter
+of this function.
+
+This function always returns a #JSCValue, in case of void methods a #JSCValue referencing
+&lt;function&gt;undefined&lt;/function&gt; is returned.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="182"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="927">a #JSCValue with the return value of the method.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="913">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="914">the method name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="first_parameter_type" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="915">#GType of first parameter, or %G_TYPE_NONE</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+          <parameter name="..." transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="916">value of the first parameter, followed optionally by more type/value pairs, followed by %G_TYPE_NONE</doc>
+            <varargs/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_invoke_methodv" c:identifier="jsc_value_object_invoke_methodv" shadows="object_invoke_method">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="958">Invoke method with @name on object referenced by @value, passing the given @parameters. If
+@n_parameters is 0 no parameters will be passed to the method.
+The object instance will be handled automatically even when the method is a custom one
+registered with jsc_class_add_method(), so it should never be passed explicitly as parameter
+of this function.
+
+This function always returns a #JSCValue, in case of void methods a #JSCValue referencing
+&lt;function&gt;undefined&lt;/function&gt; is returned.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="188"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="974">a #JSCValue with the return value of the method.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="960">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="961">the method name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="n_parameters" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="962">the number of parameters</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="parameters" transfer-ownership="none" nullable="1" allow-none="1">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="963">the #JSCValue&lt;!-- --&gt;s to pass as parameters to the method, or %NULL</doc>
+            <array length="1" zero-terminated="0" c:type="JSCValue**">
+              <type name="Value"/>
+            </array>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_is_instance_of" c:identifier="jsc_value_object_is_instance_of">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="624">Get whether the value referenced by @value is an instance of class @name.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="149"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="631">whether the value is an object instance of class @name.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="626">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="627">a class name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_set_property" c:identifier="jsc_value_object_set_property">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="656">Set @property with @name on @value.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="153"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="658">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="659">the property name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="property" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="660">the #JSCValue to set</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="object_set_property_at_index" c:identifier="jsc_value_object_set_property_at_index">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="711">Set @property at @index on @value.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="162"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="713">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+          <parameter name="index" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="714">the property index</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+          <parameter name="property" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="715">the #JSCValue to set</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="to_boolean" c:identifier="jsc_value_to_boolean">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="313">Convert @value to a boolean.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="105"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="319">a #gboolean result of the conversion.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="315">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="to_double" c:identifier="jsc_value_to_double">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="247">Convert @value to a double.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="93"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="253">a #gdouble result of the conversion.</doc>
+          <type name="gdouble" c:type="double"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="249">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="to_int32" c:identifier="jsc_value_to_int32">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="268">Convert @value to a #gint32.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="96"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="274">a #gint32 result of the conversion.</doc>
+          <type name="gint32" c:type="gint32"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="270">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="to_string" c:identifier="jsc_value_to_string">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="391">Convert @value to a string. Use jsc_value_to_string_as_bytes() instead, if you need to
+handle strings containing null characters.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="119"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="398">a null-terminated string result of the conversion.</doc>
+          <type name="utf8" c:type="char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="393">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="to_string_as_bytes" c:identifier="jsc_value_to_string_as_bytes">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="423">Convert @value to a string and return the results as #GBytes. This is needed
+to handle strings with null characters.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="122"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="430">a #GBytes with the result of the conversion.</doc>
+          <type name="GLib.Bytes" c:type="GBytes*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="425">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <property name="context" writable="1" construct-only="1" transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="110">The #JSCContext in which the value was created.</doc>
+        <type name="Context"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv" readable="0" private="1">
+        <type name="ValuePrivate" c:type="JSCValuePrivate*"/>
+      </field>
+    </class>
+    <record name="ValueClass" c:type="JSCValueClass" glib:is-gtype-struct-for="Value">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="66"/>
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_jsc_reserved0" introspectable="0">
+        <callback name="_jsc_reserved0">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="62"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved1" introspectable="0">
+        <callback name="_jsc_reserved1">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="63"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved2" introspectable="0">
+        <callback name="_jsc_reserved2">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="64"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved3" introspectable="0">
+        <callback name="_jsc_reserved3">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="65"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <record name="ValuePrivate" c:type="JSCValuePrivate" disguised="1">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="41"/>
+    </record>
+    <bitfield name="ValuePropertyFlags" c:type="JSCValuePropertyFlags">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1012">Flags used when defining properties with jsc_value_object_define_property_data() and
+jsc_value_object_define_property_accessor().</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCValue.h" line="50"/>
+      <member name="configurable" value="1" c:identifier="JSC_VALUE_PROPERTY_CONFIGURABLE">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1014">the type of the property descriptor may be changed and the
+ property may be deleted from the corresponding object.</doc>
+      </member>
+      <member name="enumerable" value="2" c:identifier="JSC_VALUE_PROPERTY_ENUMERABLE">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1016">the property shows up during enumeration of the properties on
+ the corresponding object.</doc>
+      </member>
+      <member name="writable" value="4" c:identifier="JSC_VALUE_PROPERTY_WRITABLE">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCValue.cpp" line="1018">the value associated with the property may be changed with an
+ assignment operator. This doesn't have any effect when passed to jsc_value_object_define_property_accessor().</doc>
+      </member>
+    </bitfield>
+    <class name="VirtualMachine" c:symbol-prefix="virtual_machine" c:type="JSCVirtualMachine" parent="GObject.Object" glib:type-name="JSCVirtualMachine" glib:get-type="jsc_virtual_machine_get_type" glib:type-struct="VirtualMachineClass">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCVirtualMachine.h" line="58"/>
+      <constructor name="new" c:identifier="jsc_virtual_machine_new">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCVirtualMachine.cpp" line="149">Create a new #JSCVirtualMachine.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCVirtualMachine.h" line="64"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCVirtualMachine.cpp" line="154">the newly created #JSCVirtualMachine.</doc>
+          <type name="VirtualMachine" c:type="JSCVirtualMachine*"/>
+        </return-value>
+      </constructor>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv" readable="0" private="1">
+        <type name="VirtualMachinePrivate" c:type="JSCVirtualMachinePrivate*"/>
+      </field>
+    </class>
+    <record name="VirtualMachineClass" c:type="JSCVirtualMachineClass" glib:is-gtype-struct-for="VirtualMachine">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCVirtualMachine.h" line="58"/>
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_jsc_reserved0" introspectable="0">
+        <callback name="_jsc_reserved0">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCVirtualMachine.h" line="54"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved1" introspectable="0">
+        <callback name="_jsc_reserved1">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCVirtualMachine.h" line="55"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved2" introspectable="0">
+        <callback name="_jsc_reserved2">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCVirtualMachine.h" line="56"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved3" introspectable="0">
+        <callback name="_jsc_reserved3">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCVirtualMachine.h" line="57"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <record name="VirtualMachinePrivate" c:type="JSCVirtualMachinePrivate" disguised="1">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCVirtualMachine.h" line="42"/>
+    </record>
+    <class name="WeakValue" c:symbol-prefix="weak_value" c:type="JSCWeakValue" parent="GObject.Object" glib:type-name="JSCWeakValue" glib:get-type="jsc_weak_value_get_type" glib:type-struct="WeakValueClass">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCWeakValue.h" line="58"/>
+      <constructor name="new" c:identifier="jsc_weak_value_new">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCWeakValue.cpp" line="164">Create a new #JSCWeakValue for the JavaScript value referenced by @value.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCWeakValue.h" line="64"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCWeakValue.cpp" line="170">a new #JSCWeakValue</doc>
+          <type name="WeakValue" c:type="JSCWeakValue*"/>
+        </return-value>
+        <parameters>
+          <parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCWeakValue.cpp" line="166">a #JSCValue</doc>
+            <type name="Value" c:type="JSCValue*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="get_value" c:identifier="jsc_weak_value_get_value">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCWeakValue.cpp" line="179">Get a #JSCValue referencing the JavaScript value of @weak_value.</doc>
+        <source-position filename="Source/JavaScriptCore/API/glib/JSCWeakValue.h" line="67"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCWeakValue.cpp" line="185">a new #JSCValue or %NULL if @weak_value was cleared.</doc>
+          <type name="Value" c:type="JSCValue*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="weak_value" transfer-ownership="none">
+            <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCWeakValue.cpp" line="181">a #JSCWeakValue</doc>
+            <type name="WeakValue" c:type="JSCWeakValue*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <property name="value" readable="0" writable="1" construct-only="1" transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCWeakValue.cpp" line="134">The #JSCValue referencing the JavaScript value.</doc>
+        <type name="Value"/>
+      </property>
+      <field name="parent">
+        <type name="GObject.Object" c:type="GObject"/>
+      </field>
+      <field name="priv" readable="0" private="1">
+        <type name="WeakValuePrivate" c:type="JSCWeakValuePrivate*"/>
+      </field>
+      <glib:signal name="cleared" when="last">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCWeakValue.cpp" line="148">This signal is emitted when the JavaScript value is destroyed.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+    </class>
+    <record name="WeakValueClass" c:type="JSCWeakValueClass" glib:is-gtype-struct-for="WeakValue">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCWeakValue.h" line="58"/>
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+      <field name="_jsc_reserved0" introspectable="0">
+        <callback name="_jsc_reserved0">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCWeakValue.h" line="54"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved1" introspectable="0">
+        <callback name="_jsc_reserved1">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCWeakValue.h" line="55"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved2" introspectable="0">
+        <callback name="_jsc_reserved2">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCWeakValue.h" line="56"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+      <field name="_jsc_reserved3" introspectable="0">
+        <callback name="_jsc_reserved3">
+          <source-position filename="Source/JavaScriptCore/API/glib/JSCWeakValue.h" line="57"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+        </callback>
+      </field>
+    </record>
+    <record name="WeakValuePrivate" c:type="JSCWeakValuePrivate" disguised="1">
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCWeakValue.h" line="42"/>
+    </record>
+    <function name="get_major_version" c:identifier="jsc_get_major_version">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCVersion.cpp" line="37">Returns the major version number of the JavaScriptCore library.
+(e.g. in JavaScriptCore version 1.8.3 this is 1.)
+
+This function is in the library, so it represents the JavaScriptCore library
+your code is running against. Contrast with the #JSC_MAJOR_VERSION
+macro, which represents the major version of the JavaScriptCore headers you
+have included when compiling your code.</doc>
+      <source-position filename="obj-x86_64-linux-gnu/DerivedSources/JavaScriptCore/javascriptcoregtk/jsc/JSCVersion.h" line="74"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCVersion.cpp" line="48">the major version number of the JavaScriptCore library</doc>
+        <type name="guint" c:type="guint"/>
+      </return-value>
+    </function>
+    <function name="get_micro_version" c:identifier="jsc_get_micro_version">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCVersion.cpp" line="73">Returns the micro version number of the JavaScriptCore library.
+(e.g. in JavaScriptCore version 1.8.3 this is 3.)
+
+This function is in the library, so it represents the JavaScriptCore library
+your code is running against. Contrast with the #JSC_MICRO_VERSION
+macro, which represents the micro version of the JavaScriptCore headers you
+have included when compiling your code.</doc>
+      <source-position filename="obj-x86_64-linux-gnu/DerivedSources/JavaScriptCore/javascriptcoregtk/jsc/JSCVersion.h" line="80"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCVersion.cpp" line="84">the micro version number of the JavaScriptCore library</doc>
+        <type name="guint" c:type="guint"/>
+      </return-value>
+    </function>
+    <function name="get_minor_version" c:identifier="jsc_get_minor_version">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCVersion.cpp" line="55">Returns the minor version number of the JavaScriptCore library.
+(e.g. in JavaScriptCore version 1.8.3 this is 8.)
+
+This function is in the library, so it represents the JavaScriptCore library
+your code is running against. Contrast with the #JSC_MINOR_VERSION
+macro, which represents the minor version of the JavaScriptCore headers you
+have included when compiling your code.</doc>
+      <source-position filename="obj-x86_64-linux-gnu/DerivedSources/JavaScriptCore/javascriptcoregtk/jsc/JSCVersion.h" line="77"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCVersion.cpp" line="66">the minor version number of the JavaScriptCore library</doc>
+        <type name="guint" c:type="guint"/>
+      </return-value>
+    </function>
+    <function name="options_foreach" c:identifier="jsc_options_foreach" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="603">Iterates all available options calling @function for each one. Iteration can
+stop early if @function returns %FALSE.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="102"/>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+      <parameters>
+        <parameter name="function" transfer-ownership="none" scope="call" closure="1">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="605">a #JSCOptionsFunc callback</doc>
+          <type name="OptionsFunc" c:type="JSCOptionsFunc"/>
+        </parameter>
+        <parameter name="user_data" transfer-ownership="none" nullable="1" allow-none="1">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="606">callback user data</doc>
+          <type name="gpointer" c:type="gpointer"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="options_get_boolean" c:identifier="jsc_options_get_boolean" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="222">Get @option as a #gboolean value.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="41"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="229">%TRUE if @value has been set or %FALSE if the option doesn't exist</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="224">the option identifier</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" direction="out" caller-allocates="0" transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="225">return location for the option value</doc>
+          <type name="gboolean" c:type="gboolean*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="options_get_double" c:identifier="jsc_options_get_double" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="406">Get @option as a #gdouble value.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="69"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="413">%TRUE if @value has been set or %FALSE if the option doesn't exist</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="408">the option identifier</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" direction="out" caller-allocates="0" transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="409">return location for the option value</doc>
+          <type name="gdouble" c:type="gdouble*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="options_get_int" c:identifier="jsc_options_get_int" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="268">Get @option as a #gint value.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="48"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="275">%TRUE if @value has been set or %FALSE if the option doesn't exist</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="270">the option identifier</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" direction="out" caller-allocates="0" transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="271">return location for the option value</doc>
+          <type name="gint" c:type="gint*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="options_get_option_group" c:identifier="jsc_options_get_option_group" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="642">Create a #GOptionGroup to handle JSCOptions as command line arguments.
+The options will be exposed as command line arguments with the form
+&lt;emphasis&gt;--jsc-&amp;lt;option&amp;gt;=&amp;lt;value&amp;gt;&lt;/emphasis&gt;.
+Each entry in the returned #GOptionGroup is configured to apply the
+corresponding option during command line parsing. Applications only need to
+pass the returned group to g_option_context_add_group(), and the rest will
+be taken care for automatically.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="106"/>
+      <return-value transfer-ownership="full">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="653">a #GOptionGroup for the JSCOptions</doc>
+        <type name="GLib.OptionGroup" c:type="GOptionGroup*"/>
+      </return-value>
+    </function>
+    <function name="options_get_range_string" c:identifier="jsc_options_get_range_string" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="506">Get @option as a range string. The string must be in the
+format &lt;emphasis&gt;[!]&amp;lt;low&amp;gt;[:&amp;lt;high&amp;gt;]&lt;/emphasis&gt; where low and high are #guint values.
+Values between low and high (both included) will be considered in
+the range, unless &lt;emphasis&gt;!&lt;/emphasis&gt; is used to invert the range.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="83"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="516">%TRUE if @value has been set or %FALSE if the option doesn't exist</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="508">the option identifier</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" direction="out" caller-allocates="0" transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="509">return location for the option value</doc>
+          <type name="utf8" c:type="char**"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="options_get_size" c:identifier="jsc_options_get_size" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="360">Get @option as a #gsize value.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="62"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="367">%TRUE if @value has been set or %FALSE if the option doesn't exist</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="362">the option identifier</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" direction="out" caller-allocates="0" transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="363">return location for the option value</doc>
+          <type name="gsize" c:type="gsize*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="options_get_string" c:identifier="jsc_options_get_string" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="454">Get @option as a string.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="76"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="461">%TRUE if @value has been set or %FALSE if the option doesn't exist</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="456">the option identifier</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" direction="out" caller-allocates="0" transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="457">return location for the option value</doc>
+          <type name="utf8" c:type="char**"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="options_get_uint" c:identifier="jsc_options_get_uint" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="314">Get @option as a #guint value.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="55"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="321">%TRUE if @value has been set or %FALSE if the option doesn't exist</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="316">the option identifier</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" direction="out" caller-allocates="0" transfer-ownership="full">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="317">return location for the option value</doc>
+          <type name="guint" c:type="guint*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="options_set_boolean" c:identifier="jsc_options_set_boolean" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="201">Set @option as a #gboolean value.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="38"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="208">%TRUE if option was correctly set or %FALSE otherwise.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="203">the option identifier</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="204">the value to set</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="options_set_double" c:identifier="jsc_options_set_double" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="385">Set @option as a #gdouble value.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="66"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="392">%TRUE if option was correctly set or %FALSE otherwise.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="387">the option identifier</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="388">the value to set</doc>
+          <type name="gdouble" c:type="gdouble"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="options_set_int" c:identifier="jsc_options_set_int" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="247">Set @option as a #gint value.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="45"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="254">%TRUE if option was correctly set or %FALSE otherwise.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="249">the option identifier</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="250">the value to set</doc>
+          <type name="gint" c:type="gint"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="options_set_range_string" c:identifier="jsc_options_set_range_string" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="480">Set @option as a range string. The string must be in the
+format &lt;emphasis&gt;[!]&amp;lt;low&amp;gt;[:&amp;lt;high&amp;gt;]&lt;/emphasis&gt; where low and high are #guint values.
+Values between low and high (both included) will be considered in
+the range, unless &lt;emphasis&gt;!&lt;/emphasis&gt; is used to invert the range.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="80"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="490">%TRUE if option was correctly set or %FALSE otherwise.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="482">the option identifier</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="483">the value to set</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="options_set_size" c:identifier="jsc_options_set_size" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="339">Set @option as a #gsize value.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="59"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="346">%TRUE if option was correctly set or %FALSE otherwise.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="341">the option identifier</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="342">the value to set</doc>
+          <type name="gsize" c:type="gsize"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="options_set_string" c:identifier="jsc_options_set_string" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="431">Set @option as a string.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="73"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="438">%TRUE if option was correctly set or %FALSE otherwise.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="433">the option identifier</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="434">the value to set</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="options_set_uint" c:identifier="jsc_options_set_uint" version="2.24">
+      <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="293">Set @option as a #guint value.</doc>
+      <source-position filename="Source/JavaScriptCore/API/glib/JSCOptions.h" line="52"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="300">%TRUE if option was correctly set or %FALSE otherwise.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="option" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="295">the option identifier</doc>
+          <type name="utf8" c:type="const char*"/>
+        </parameter>
+        <parameter name="value" transfer-ownership="none">
+          <doc xml:space="preserve" filename="Source/JavaScriptCore/API/glib/JSCOptions.cpp" line="296">the value to set</doc>
+          <type name="guint" c:type="guint"/>
+        </parameter>
+      </parameters>
+    </function>
   </namespace>
 </repository>

--- a/JavaScriptCore-4.0.xsl
+++ b/JavaScriptCore-4.0.xsl
@@ -1,0 +1,84 @@
+<xsl:stylesheet xmlns="http://www.gtk.org/introspection/core/1.0"
+		xmlns:gir="http://www.gtk.org/introspection/core/1.0"
+		xmlns:c="http://www.gtk.org/introspection/c/1.0"
+		xmlns:glib="http://www.gtk.org/introspection/glib/1.0"
+		xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+		version="1.0">
+  <xsl:output method="xml" indent="yes"/>
+
+  <!-- Insert non-glib types and additional callback types. -->
+  <xsl:template match="/gir:repository/gir:namespace[@name='JavaScriptCore' and not(./gir:record[@name='GlobalContextRef'])]">
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:text>&#xa;</xsl:text>
+      <xsl:apply-templates select="document('JavaScriptCore-4.0-patch.gir')/gir:repository/gir:namespace/*"/>
+      <xsl:apply-templates/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Patch up class callback types. -->
+  <xsl:template match="//gir:class[@name='Class']/gir:method[@name='add_constructor_variadic']//gir:parameter[@name='callback']/gir:type">
+    <xsl:copy>
+      <xsl:attribute name="name">Constructor</xsl:attribute>
+      <xsl:attribute name="c:type">JSCConstructor</xsl:attribute>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="//gir:class[@name='Class']/gir:method[@name='add_method_variadic']//gir:parameter[@name='callback']/gir:type">
+    <xsl:copy>
+      <xsl:attribute name="name">ClassVariadicFunction</xsl:attribute>
+      <xsl:attribute name="c:type">JSCClassVariadicFunction</xsl:attribute>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="//gir:class[@name='Class']/gir:method[@name='add_property']//gir:parameter[@name='getter']">
+    <xsl:copy>
+      <xsl:apply-templates select="@*[not(name()='scope') and not(name()='closure')]"/>
+      <xsl:attribute name="scope">notified</xsl:attribute>
+      <xsl:attribute name="closure">4</xsl:attribute>
+      <xsl:attribute name="destroy">5</xsl:attribute>
+      <xsl:text>&#xa;</xsl:text>
+      <xsl:apply-templates select="*[not(name()='type')]"/>
+      <xsl:text>&#xa;</xsl:text>
+      <type name="PropertyGetter" c:type="JSCPropertyGetter"/>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="//gir:class[@name='Class']/gir:method[@name='add_property']//gir:parameter[@name='setter']/gir:type">
+    <xsl:copy>
+      <xsl:attribute name="name">PropertySetter</xsl:attribute>
+      <xsl:attribute name="c:type">JSCPropertySetter</xsl:attribute>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Patch up value callback types. -->
+  <xsl:template match="//gir:class[@name='Value']/gir:constructor[@name='new_function_variadic']//gir:parameter[@name='callback']/gir:type">
+    <xsl:copy>
+      <xsl:attribute name="name">VariadicFunction</xsl:attribute>
+      <xsl:attribute name="c:type">JSCVariadicFunction</xsl:attribute>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="//gir:class[@name='Value']/gir:method[@name='object_define_property_accessor']//gir:parameter[@name='getter']">
+    <xsl:copy>
+      <xsl:apply-templates select="@*[not(name()='scope') and not(name()='closure')]"/>
+      <xsl:attribute name="scope">notified</xsl:attribute>
+      <xsl:attribute name="closure">5</xsl:attribute>
+      <xsl:attribute name="destroy">6</xsl:attribute>
+      <xsl:text>&#xa;</xsl:text>
+      <xsl:apply-templates select="*[not(name()='type')]"/>
+      <xsl:text>&#xa;</xsl:text>
+      <type name="Getter" c:type="JSCGetter"/>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="//gir:class[@name='Value']/gir:method[@name='object_define_property_accessor']//gir:parameter[@name='setter']/gir:type">
+    <xsl:copy>
+      <xsl:attribute name="name">Setter</xsl:attribute>
+      <xsl:attribute name="c:type">JSCSetter</xsl:attribute>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Identity template. -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/dl.sh
+++ b/dl.sh
@@ -11,7 +11,7 @@ VER="eoan"
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libgtksourceview-3.0-dev/download
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libsecret-1-dev/download
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libvte-2.91-dev/download
-#./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libjavascriptcoregtk-4.0-dev/download
+./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libjavascriptcoregtk-4.0-dev/download
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libsoup2.4-dev/download
 ./gir-dl.sh https://packages.ubuntu.com/$VER/amd64/libwebkit2gtk-4.0-dev/download
 

--- a/fix.sh
+++ b/fix.sh
@@ -61,11 +61,13 @@ xmlstarlet ed -P -L \
 	-u '//_:parameter[@name="response_id"]/_:type[@name="gint"]/@name' -v "ResponseType" \
 	Gtk-3.0.gir
 
+xmlstarlet tr JavaScriptCore-4.0.xsl JavaScriptCore-4.0.gir | xmlstarlet fo > JavaScriptCore-4.0.gir.tmp
+mv JavaScriptCore-4.0.gir.tmp JavaScriptCore-4.0.gir
+
 # fill in types from JavaScriptCore
 xmlstarlet ed -P -L \
 	-i '//_:type[not(@name) and @c:type="JSGlobalContextRef"]' -t 'attr' -n 'name' -v "JavaScriptCore.GlobalContextRef" \
 	-i '//_:type[not(@name) and @c:type="JSValueRef"]' -t 'attr' -n 'name' -v "JavaScriptCore.ValueRef" \
-    -i '//_:type[not(@name) and @c:type="JSCValue*"]' -t 'attr' -n 'name' -v "JavaScriptCore.Value" \
 	WebKit2WebExtension-4.0.gir WebKit2-4.0.gir
 
 xmlstarlet ed -P -L \


### PR DESCRIPTION
The complexity in this change comes from:
1.) Adding in types from the non-glib version of javascriptcore that deprecated webkitgtk methods still reference.
2.) Defining some callback types that are just "GCallback" upstream