### PR TITLE
Add travis check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+dist: xenial
+language: rust
+addons:
+  apt:
+    packages:
+    - libgtk-3-dev
+    - libssh2-1-dev
+script:
+  - git clone https://github.com/gtk-rs/gir
+  - git clone https://github.com/gtk-rs/sys
+  - cd gir && cargo build --release && cd ..
+  - ./gir/target/release/gir -c sys/conf/gir-gtk.toml -m sys -o sys/gtk-sys/ -d .
+  - ./gir/target/release/gir -c sys/conf/gir-gtk4.toml -m sys -o sys/gtk4-sys/ -d .


### PR DESCRIPTION
I just thought that it'd allow us to detect more quickly to just check if we can build with the new gir files by checking their build with the latest `gir` version.

What do you think @sdroege @EPashkin ?