### PR TITLE
Revert "glib: fix guri error quark"

### DIFF
--- a/GLib-2.0.gir
+++ b/GLib-2.0.gir
@@ -31108,7 +31108,7 @@ should be freed when no longer needed.</doc>
         </parameters>
       </function>
     </record>
-    <enumeration name="UriError" version="2.66" c:type="GUriError" glib:error-domain="g-uri-error-quark">
+    <enumeration name="UriError" version="2.66" c:type="GUriError" glib:error-domain="g-uri-quark">
       <doc xml:space="preserve">Error codes returned by #GUri methods.</doc>
       
       <member name="failed" value="0" c:identifier="G_URI_ERROR_FAILED">

--- a/fix.sh
+++ b/fix.sh
@@ -10,7 +10,6 @@ xmlstarlet ed -P -L \
 # but in this case it happens to be named differently, i.e., as g_option_error_quark.
 xmlstarlet ed -P -L \
 	-u '//*[@glib:error-domain="g-option-context-error-quark"]/@glib:error-domain' -v g-option-error-quark \
-	-u '//*[@name="UriError"]/@glib:error-domain' -v g-uri-error-quark \
 	GLib-2.0.gir
 
 # GtkEntry icon signals incorrect assume GdkEventButton when other variants may be passed


### PR DESCRIPTION
This reverts commit 9f47916d2c3955b4d26a6a2987744fb7a6d24453.

It's not needed anymore since https://github.com/gtk-rs/gir/pull/972

----

CC @GuillaumeGomez @bilelmoussaoui 