### PR TITLE
Don't mark g_binding_unbind() as transfer-full

### DIFF
--- a/GObject-2.0.gir
+++ b/GObject-2.0.gir
@@ -318,7 +318,7 @@ to it.</doc>
           <type name="none" c:type="void"/>
         </return-value>
         <parameters>
-          <instance-parameter name="binding" transfer-ownership="full">
+          <instance-parameter name="binding" transfer-ownership="none">
             <doc xml:space="preserve">a #GBinding</doc>
             <type name="Binding" c:type="GBinding*"/>
           </instance-parameter>

--- a/fix.sh
+++ b/fix.sh
@@ -50,11 +50,6 @@ xmlstarlet ed -P -L \
 	-u '//_:class[@name="Object"]/_:constructor[@name="new_with_properties"]//_:parameter[@name="values"]/_:array/@c:type' -v "const GValue*" \
 	GObject-2.0.gir
 
-# incorrectly marked as transfer-none GitLab issue #197
-xmlstarlet ed -P -L \
-	-u '//_:class[@name="Binding"]/_:method[@name="unbind"]//_:instance-parameter[@name="binding"]/@transfer-ownership' -v "full" \
-	GObject-2.0.gir
-
 # fix wrong "full" transfer ownership
 xmlstarlet ed -P -L \
 	-u '//_:method[@c:identifier="gdk_frame_clock_get_current_timings"]/_:return-value/@transfer-ownership' -v "none" \


### PR DESCRIPTION
It actually is not, GBinding just has very confusing ownership semantics.

----

This reverts https://github.com/gtk-rs/gir-files/pull/24 which was actually wrong. I'll update gtk-rs once this is in.