### PR TITLE
gtk4: re-update with fixed introspection

### DIFF
--- a/Gdk-4.0.gir
+++ b/Gdk-4.0.gir
@@ -19535,7 +19535,8 @@ fullscreen, or %FALSE, if it should go unmaximized.</doc>
             <doc xml:space="preserve">a #GdkToplevelLayout</doc>
             <type name="ToplevelLayout" c:type="GdkToplevelLayout*"/>
           </instance-parameter>
-          <parameter name="maximize" transfer-ownership="none">
+          <parameter name="maximized" direction="out" caller-allocates="0" transfer-ownership="full">
+            <doc xml:space="preserve">set to %TRUE if the toplevel should be maximized</doc>
             <type name="gboolean" c:type="gboolean*"/>
           </parameter>
         </parameters>


### PR DESCRIPTION
this pulls a change from a more recent commit than gtk 4.0.0 itself
instead of adding a manual fix
mostly this change https://gitlab.gnome.org/GNOME/gtk/-/commit/df70dbbae4f7ce42ba3296d165363aa160a34113