### PR TITLE
pango: manually fix Font::get_languages

### DIFF
--- a/Pango-1.0.gir
+++ b/Pango-1.0.gir
@@ -2795,7 +2795,9 @@ and its fontmap are valid.</doc>
         <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">a %NULL-terminated
   array of `PangoLanguage`*</doc>
-          <type name="Language" c:type="PangoLanguage**"/>
+          <array length="0" zero-terminated="1" c:type="const PangoLanguage*">
+            <type name="Language" c:type="PangoLanguage*"/>
+          </array>
         </return-value>
         <parameters>
           <instance-parameter name="font" transfer-ownership="none">


### PR DESCRIPTION
a proper fix is already included in the upstream gir, will be part of the next release

it required too much work to fix it in pango itself, so i ended up manually modifying the xml 

cc @sdroege 