### PR TITLE
gdk4: replace external types by a gpointer

### DIFF
--- a/GdkWayland-4.0.gir
+++ b/GdkWayland-4.0.gir
@@ -211,7 +211,7 @@ This is most notably implemented for devices of type
         <doc xml:space="preserve">Returns the `xkb_keymap` of a `GdkDevice`.</doc>
         <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">a `struct xkb_keymap`</doc>
-          <type name="gpointer" c:type="xkb_keymap*"/>
+          <type name="gpointer" c:type="gpointer"/>
         </return-value>
         <parameters>
           <instance-parameter name="device" transfer-ownership="none">

--- a/GdkX11-4.0.gir
+++ b/GdkX11-4.0.gir
@@ -425,7 +425,7 @@ X servers that don't support the XCursor extension, all cursors
 may even fall back to a few default cursors.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">an Xlib Cursor.</doc>
-          <type name="xlib.Cursor" c:type="Cursor"/>
+          <type name="xlib.Cursor" c:type="gulong"/>
         </return-value>
         <parameters>
           <instance-parameter name="display" transfer-ownership="none">
@@ -442,7 +442,7 @@ may even fall back to a few default cursors.</doc>
         <doc xml:space="preserve">Returns the X display of a `GdkDisplay`.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">an X display</doc>
-          <type name="xlib.Display" c:type="Display*"/>
+          <type name="xlib.Display" c:type="gpointer"/>
         </return-value>
         <parameters>
           <instance-parameter name="display" transfer-ownership="none">
@@ -455,7 +455,7 @@ may even fall back to a few default cursors.</doc>
         <doc xml:space="preserve">Returns the root X window used by `GdkDisplay`.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">an X Window</doc>
-          <type name="xlib.Window" c:type="Window"/>
+          <type name="xlib.Window" c:type="gulong"/>
         </return-value>
         <parameters>
           <instance-parameter name="display" transfer-ownership="none">
@@ -468,7 +468,7 @@ may even fall back to a few default cursors.</doc>
         <doc xml:space="preserve">Returns the X Screen used by `GdkDisplay`.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">an X Screen</doc>
-          <type name="xlib.Screen" c:type="Screen*"/>
+          <type name="xlib.Screen" c:type="gpointer"/>
         </return-value>
         <parameters>
           <instance-parameter name="display" transfer-ownership="none">
@@ -738,7 +738,7 @@ XFreeEventData() will be called afterwards.</doc>
         <doc xml:space="preserve">Returns the XID of the Output corresponding to @monitor.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the XID of @monitor</doc>
-          <type name="xlib.XID" c:type="XID"/>
+          <type name="xlib.XID" c:type="gulong"/>
         </return-value>
         <parameters>
           <instance-parameter name="monitor" transfer-ownership="none">
@@ -792,7 +792,7 @@ If the X server does not support version 1.2 of the RANDR
 extension, 0 is returned.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the XID of the monitor</doc>
-          <type name="xlib.XID" c:type="XID"/>
+          <type name="xlib.XID" c:type="gulong"/>
         </return-value>
         <parameters>
           <instance-parameter name="screen" transfer-ownership="none">
@@ -854,7 +854,7 @@ and should not be freed.</doc>
         <doc xml:space="preserve">Returns the screen of a `GdkX11Screen`.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">an Xlib Screen*</doc>
-          <type name="xlib.Screen" c:type="Screen*"/>
+          <type name="xlib.Screen" c:type="gpointer"/>
         </return-value>
         <parameters>
           <instance-parameter name="screen" transfer-ownership="none">
@@ -914,7 +914,7 @@ a window manager change.</doc>
           </parameter>
           <parameter name="window" transfer-ownership="none">
             <doc xml:space="preserve">an Xlib Window</doc>
-            <type name="xlib.Window" c:type="Window"/>
+            <type name="xlib.Window" c:type="gulong"/>
           </parameter>
         </parameters>
       </function>
@@ -948,7 +948,7 @@ a window manager change.</doc>
         <doc xml:space="preserve">Returns the X resource (surface) belonging to a `GdkSurface`.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the ID of @drawable&#x2019;s X resource.</doc>
-          <type name="xlib.Window" c:type="Window"/>
+          <type name="xlib.Window" c:type="gulong"/>
         </return-value>
         <parameters>
           <instance-parameter name="surface" transfer-ownership="none">
@@ -1388,7 +1388,7 @@ This function caches the result, so if called repeatedly it is much
 faster than XInternAtom(), which is a round trip to the server each time.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">a X atom for a `GdkDisplay`</doc>
-        <type name="xlib.Atom" c:type="Atom"/>
+        <type name="xlib.Atom" c:type="gulong"/>
       </return-value>
       <parameters>
         <parameter name="display" transfer-ownership="none">
@@ -1418,7 +1418,7 @@ be freed.</doc>
         </parameter>
         <parameter name="xatom" transfer-ownership="none">
           <doc xml:space="preserve">an X atom</doc>
-          <type name="xlib.Atom" c:type="Atom"/>
+          <type name="xlib.Atom" c:type="gulong"/>
         </parameter>
       </parameters>
     </function>
@@ -1431,7 +1431,7 @@ be freed.</doc>
       <parameters>
         <parameter name="xdisplay" transfer-ownership="none">
           <doc xml:space="preserve">a pointer to an X Display</doc>
-          <type name="xlib.Display" c:type="Display*"/>
+          <type name="xlib.Display" c:type="gpointer"/>
         </parameter>
       </parameters>
     </function>

--- a/fix.sh
+++ b/fix.sh
@@ -132,7 +132,25 @@ xmlstarlet ed -L \
 	-u '//_:class[@name="WaylandMonitor"]/_:method[@name="get_wl_output"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
 	-u '//_:class[@name="WaylandSeat"]/_:method[@name="get_wl_seat"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
 	-u '//_:class[@name="WaylandSurface"]/_:method[@name="get_wl_surface"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
+	-u '//_:class[@name="WaylandDevice"]/_:method[@name="get_xkb_keymap"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
 	GdkWayland-4.0.gir
+
+# avoid always depending on x11 crate
+xmlstarlet ed -L \
+	-u '//_:class[@name="X11Display"]/_:method[@name="get_xcursor"]//_:type[@name="xlib.Cursor"]/@c:type' -v "gulong" \
+	-u '//_:class[@name="X11Display"]/_:method[@name="get_xdisplay"]//_:type[@name="xlib.Display"]/@c:type' -v "gpointer" \
+	-u '//_:class[@name="X11Display"]/_:method[@name="get_xrootwindow"]//_:type[@name="xlib.Window"]/@c:type' -v "gulong" \
+	-u '//_:class[@name="X11Display"]/_:method[@name="get_xscreen"]//_:type[@name="xlib.Screen"]/@c:type' -v "gpointer" \
+	-u '//_:class[@name="X11Monitor"]/_:method[@name="get_output"]//_:type[@name="xlib.XID"]/@c:type' -v "gulong" \
+	-u '//_:class[@name="X11Screen"]/_:method[@name="get_monitor_output"]//_:type[@name="xlib.XID"]/@c:type' -v "gulong" \
+	-u '//_:class[@name="X11Screen"]/_:method[@name="get_xscreen"]//_:type[@name="xlib.Screen"]/@c:type' -v "gpointer" \
+	-u '//_:class[@name="X11Surface"]/_:method[@name="get_xid"]//_:type[@name="xlib.Window"]/@c:type' -v "gulong" \
+	-u '//_:class[@name="X11Surface"]/_:function[@name="lookup_for_display"]//_:type[@name="xlib.Window"]/@c:type' -v "gulong" \
+	-u '//_:class[@name="get_xid"]/_:method[@name="lookup_for_display"]//_:type[@name="xlib.Window"]/@c:type' -v "gulong" \
+	-u '//_:function[@name="x11_get_xatom_by_name_for_display"]//_:type[@name="xlib.Atom"]/@c:type' -v "gulong" \
+	-u '//_:function[@name="x11_get_xatom_name_for_display"]//_:type[@name="xlib.Atom"]/@c:type' -v "gulong" \
+	-u '//_:function[@name="x11_lookup_xdisplay"]//_:type[@name="xlib.Display"]/@c:type' -v "gpointer" \
+	GdkX11-4.0.gir
 
 # Fix invalid type for GtkImage and GtkStackSwitcher "icon-size" property
 xmlstarlet ed -L \


### PR DESCRIPTION
with this  -sys crates don't have to depend on external dependencies

Needed for https://github.com/gtk-rs/gtk4-rs/issues/676

I have the required changes for gdk4-x11 already locally. Once the same work is done for gdk3-x11 we can drop the specific code to handle x11 in gir tiself.

