### PR TITLE
CI: allow to update the gir files manually

### DIFF
--- a/.github/workflows/regenerate_scheduled.yml
+++ b/.github/workflows/regenerate_scheduled.yml
@@ -2,6 +2,8 @@ name: Redownload & regenerate (weekly)
 on:
   schedule:
     - cron: '0 0 * * 0'
+  workflow_dispatch:
+
 jobs:
   regenerate:
     name: Regenerate GIR files


### PR DESCRIPTION
This will allow us to trigger the CI manually to get newer gir-files before the end of a week