### PR TITLE
glib: fix ABI issues with macros/constants

### DIFF
--- a/GLib-2.0.gir
+++ b/GLib-2.0.gir
@@ -12890,32 +12890,6 @@ module.</doc>
       <doc xml:space="preserve">Multiplying the base 2 exponent by this number yields the base 10 exponent.</doc>
       <type name="gdouble" c:type="gdouble"/>
     </constant>
-    <constant name="LOG_DOMAIN" value="0" c:type="G_LOG_DOMAIN">
-      <doc xml:space="preserve">Defines the log domain. See [Log Domains](#log-domains).
-
-Libraries should define this so that any messages
-which they log can be differentiated from messages from other
-libraries and application code. But be careful not to define
-it in any public header files.
-
-Log domains must be unique, and it is recommended that they are the
-application or library name, optionally followed by a hyphen and a sub-domain
-name. For example, `bloatpad` or `bloatpad-io`.
-
-If undefined, it defaults to the default %NULL (or `""`) log domain; this is
-not advisable, as it cannot be filtered against using the `G_MESSAGES_DEBUG`
-environment variable.
-
-For example, GTK+ uses this in its `Makefile.am`:
-|[
-AM_CPPFLAGS = -DG_LOG_DOMAIN=\"Gtk\"
-]|
-
-Applications can choose to leave it as the default %NULL (or `""`)
-domain. However, defining the domain offers the same advantages as
-above.</doc>
-      <type name="gchar" c:type="gchar"/>
-    </constant>
     <constant name="LOG_FATAL_MASK" value="5" c:type="G_LOG_FATAL_MASK">
       <doc xml:space="preserve">GLib log levels that are considered fatal by default.
 
@@ -13884,7 +13858,7 @@ levels using g_log_set_handler() and g_log_set_fatal_mask().</doc>
       <member name="level_debug" value="128" c:identifier="G_LOG_LEVEL_DEBUG">
         <doc xml:space="preserve">log level for debug messages, see g_debug()</doc>
       </member>
-      <member name="level_mask" value="-4" c:identifier="G_LOG_LEVEL_MASK">
+      <member name="level_mask" value="4294967292" c:identifier="G_LOG_LEVEL_MASK">
         <doc xml:space="preserve">a mask including all log levels</doc>
       </member>
     </bitfield>
@@ -45766,9 +45740,6 @@ application domain</doc>
         </parameter>
       </parameters>
     </function-macro>
-    <constant name="macro__has_attribute___noreturn__" value="0" c:type="g_macro__has_attribute___noreturn__">
-      <type name="gint" c:type="gint"/>
-    </constant>
     <function-macro name="macro__has_builtin" c:identifier="g_macro__has_builtin" introspectable="0">
       <parameters>
         <parameter name="x">

--- a/fix.sh
+++ b/fix.sh
@@ -12,6 +12,13 @@ xmlstarlet ed -L \
 	-u '//*[@glib:error-domain="g-option-context-error-quark"]/@glib:error-domain' -v g-option-error-quark \
 	GLib-2.0.gir
 
+# fix layout checks
+xmlstarlet ed -L \
+	-d '//_:constant[@name="LOG_DOMAIN"]' \
+	-d '//_:constant[@name="macro__has_attribute___noreturn__"]' \
+	-u '//_:member[@c:identifier="G_LOG_LEVEL_MASK"]/@value' -v "4294967292" \
+	GLib-2.0.gir
+
 # GtkEntry icon signals incorrect assume GdkEventButton when other variants may be passed
 xmlstarlet ed -L \
 	-u '//_:class[@name="Entry"]/glib:signal[@name="icon-press"]//_:parameter[@name="event"]/_:type[@name="Gdk.EventButton"]/@name' -v "Gdk.Event" \


### PR DESCRIPTION
Part of https://github.com/gtk-rs/gtk-rs-core/issues/64

- `g_macro__has_attribute___noreturn__` and `G_LOG_DOMAIN` are used for C macros, should not be in ffi at all
- `G_LOG_LEVEL_MASK` is considered unsigned by rust but C defines it as signed