### PR TITLE
regenrate_scheduled: Do not redirect apt output to /dev/null

### DIFF
--- a/.github/workflows/regenerate_scheduled.yml
+++ b/.github/workflows/regenerate_scheduled.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Redownload, regenerate, reformat
         id: changes
         run: |
-          sudo apt-get update > /dev/null
-          sudo apt-get -qq upgrade > /dev/null
-          sudo apt-get -qq install binutils wget tar xmlstarlet flatpak > /dev/null
+          sudo apt-get -q update
+          sudo apt-get -q upgrade
+          sudo apt-get -q install binutils wget tar xmlstarlet flatpak
           flatpak remote-add --user --if-not-exists gnome-nightly https://nightly.gnome.org/gnome-nightly.flatpakrepo 
           flatpak install org.gnome.Sdk//master -y --noninteractive
           flatpak info org.gnome.Sdk//master


### PR DESCRIPTION
Instead use apt-get -q to silence most information.

Additionally drop the use of second level -qq as per manpage:

> Note that quiet level 2 implies -y; you should never use -qq
> without a no-action modifier such as -d, --print-uris or -s as
> APT may decide to do something you did not expect.