### PR TITLE
add missing attributes for TypePlugin and TypePluginClass (GObject-2.0.gir)

### DIFF
--- a/GObject-2.0.gir
+++ b/GObject-2.0.gir
@@ -10760,7 +10760,7 @@ the @load and @unload functions in #GTypeModuleClass must be implemented.</doc>
         </callback>
       </field>
     </record>
-    <interface name="TypePlugin" c:symbol-prefix="type_plugin" c:type="GTypePlugin" glib:type-name="GTypePlugin" glib:get-type="g_type_plugin_get_type">
+    <interface name="TypePlugin" c:symbol-prefix="type_plugin" c:type="GTypePlugin" glib:type-name="GTypePlugin" glib:get-type="g_type_plugin_get_type" glib:type-struct="TypePluginClass">
       <doc xml:space="preserve">An interface that handles the lifecycle of dynamically loaded types.
 
 The GObject type system supports dynamic loading of types.
@@ -10891,7 +10891,7 @@ the GObject type system itself.</doc>
         </parameters>
       </method>
     </interface>
-    <record name="TypePluginClass" c:type="GTypePluginClass">
+    <record name="TypePluginClass" c:type="GTypePluginClass" glib:is-gtype-struct-for="TypePlugin">
       <doc xml:space="preserve">The #GTypePlugin interface is used by the type system in order to handle
 the lifecycle of dynamically loaded types.</doc>
       <field name="base_iface" readable="0" private="1">

--- a/fix.sh
+++ b/fix.sh
@@ -50,6 +50,12 @@ xmlstarlet ed -L \
 	-u '//_:class[@name="Object"]/_:constructor[@name="new_with_properties"]//_:parameter[@name="values"]/_:array/@c:type' -v "const GValue*" \
 	GObject-2.0.gir
 
+# add missing attributes to resolve type struct for TypePlugin
+xmlstarlet ed -L \
+	-i '//_:interface[@name="TypePlugin" and not(@glib:type-struct)]' -t 'attr' -n 'glib:type-struct' -v 'TypePluginClass' \
+	-i '//_:record[@name="TypePluginClass" and not(@glib:is-gtype-struct-for)]' -t 'attr' -n 'glib:is-gtype-struct-for' -v 'TypePlugin' \
+	GObject-2.0.gir
+
 # fix wrong "full" transfer ownership
 xmlstarlet ed -L \
 	-u '//_:method[@c:identifier="gdk_frame_clock_get_current_timings"]/_:return-value/@transfer-ownership' -v "none" \


### PR DESCRIPTION
in GObject-2.0.gir:
- add attribute `glib:type-struct` to `TypePlugin` 
- add attribute `glib:is-gtype-struct-for` in `TypePluginClass`

modify fix.sh accordingly
