### PR TITLE
Add Adw-1.gir

### DIFF
--- a/dl.py
+++ b/dl.py
@@ -3,6 +3,7 @@ import os
 import shutil
 
 GIR_FILES = [
+    "Adw-1",
     "Atk-1.0",
     "cairo-1.0",
     "fontconfig-2.0",


### PR DESCRIPTION
This repository seems to be missing Adw-1.gir ( https://gitlab.gnome.org/World/Rust/libadwaita-rs/-/blob/master/Adw-1.gir ).