### PR TITLE
Fix the VfsFileLookupFunc's return value so that it is nullable

### DIFF
--- a/fix.sh
+++ b/fix.sh
@@ -176,3 +176,8 @@ xmlstarlet ed -L \
 	-u '//_:class[@name="StackSwitcher"]/_:property[@name="icon-size"]/_:type/@c:type' -v "GtkIconSize" \
 	-u '//_:class[@name="StackSwitcher"]/_:property[@name="icon-size"]/_:type/@name' -v "IconSize" \
 	Gtk-3.0.gir
+
+# Fix return value of VfsFileLookupFunc that is nullable (according to the description of the function type)
+xmlstarlet ed -L \
+	-a '//_:callback[@name="VfsFileLookupFunc"]/_:return-value' -type attr -n "nullable" -v "1" \
+	Gio-2.0.gir


### PR DESCRIPTION
According to the VfsFileLookupFunc's description, the return value can be NULL. The current definition in Gio-2.0.gir does not specify that the return value is nullable. Therefore the generated code of [Vfs in gtk-rs](https://github.com/gtk-rs/gtk-rs-core/blob/main/gio/src/auto/vfs.rs#L90-L91) is incorrect:
```rust
        uri_func: Option<Box_<dyn Fn(&Vfs, &str) -> File + 'static>>,
        parse_name_func: Option<Box_<dyn Fn(&Vfs, &str) -> File + 'static>>,
```

This pull request fixes the definition of the VfsFileLookupFunc, in order to fix the generated code:
```rust
        uri_func: Option<Box_<dyn Fn(&Vfs, &str) -> Option<File> + 'static>>,
        parse_name_func: Option<Box_<dyn Fn(&Vfs, &str) -> Option<File> + 'static>>,
```
