### PR TITLE
Trigger auto update dispatch event

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,6 +1,7 @@
 name: Trigger Repository Dispatch
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,20 @@
+name: Trigger Repository Dispatch
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  dispatch:
+    strategy:
+      matrix:
+        repo: ['gtk-rs/gtk4-rs', 'gtk-rs/gtk-rs-core']
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Repository Dispatch Event
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.TOKEN_PAT }}
+          repository: ${{ matrix.repo }}
+          event-type: internal-merge-event


### PR DESCRIPTION
when a commit lands on main, the CI will trigger an event on gtk4-rs/gtk-rs-core repositories triggering a CI job to regenerate the bindings. One can push on top of it to the finish line if needed but it would at least ensure up to date development docs.