### PR TITLE
reformat: Encode gir files as utf-8

### DIFF
--- a/Atk-1.0.gir
+++ b/Atk-1.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -9094,12 +9094,12 @@ neither checked nor unchecked.</doc>
         <doc xml:space="preserve">Indicates that the object has encountered an error condition due to failure of input validation. For instance, a form control may acquire this state in response to invalid or malformed user input.</doc>
       </member>
       <member name="supports_autocompletion" value="34" c:identifier="ATK_STATE_SUPPORTS_AUTOCOMPLETION" glib:nick="supports-autocompletion" glib:name="ATK_STATE_SUPPORTS_AUTOCOMPLETION">
-        <doc xml:space="preserve">Indicates that the object in question implements some form of &#xA8;typeahead&#xA8; or
+        <doc xml:space="preserve">Indicates that the object in question implements some form of ¨typeahead¨ or
 pre-selection behavior whereby entering the first character of one or more sub-elements
 causes those elements to scroll into view or become selected.  Subsequent character input
 may narrow the selection further as long as one or more sub-elements match the string.
 This state is normally only useful and encountered on objects that implement Selection.
-In some cases the typeahead behavior may result in full or partial &#xA8;completion&#xA8; of
+In some cases the typeahead behavior may result in full or partial ¨completion¨ of
 the data in the input field, in which case these input events may trigger text-changed
 events from the AtkText interface.  This state supplants @ATK_ROLE_AUTOCOMPLETE.</doc>
       </member>

--- a/GL-1.0.gir
+++ b/GL-1.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" version="1.2">
   <namespace name="GL" version="1.0" c:identifier-prefixes="GL" c:symbol-prefixes="gl">
     <record name="bitfield" c:type="GLbitfield"/>

--- a/GLib-2.0.gir
+++ b/GLib-2.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -133,7 +133,7 @@ type. The address of a variable or struct member of the given type must always b
 a multiple of this alignment. For example, most platforms require int variables
 to be aligned at a 4-byte boundary, so `G_ALIGNOF (int)` is 4 on most platforms.
 
-Note this is not necessarily the same as the value returned by GCC&#x2019;s
+Note this is not necessarily the same as the value returned by GCC’s
 `__alignof__` operator, which returns the preferred alignment for a type.
 The preferred alignment may be a stricter alignment than the minimal
 alignment.</doc>
@@ -305,7 +305,7 @@ function is a no-op.</doc>
         <doc xml:space="preserve">Checks whether @target exists in @array by performing a binary
 search based on the given comparison function @compare_func which
 gets pointers to items as arguments. If the element is found, true
-is returned and the element&#x2019;s index is returned in @out_match_index
+is returned and the element’s index is returned in @out_match_index
 (if non-`NULL`). Otherwise, false is returned and @out_match_index
 is undefined. This search is using a binary search, so the @array must
 absolutely be sorted to return a correct result (if not, the function may
@@ -423,12 +423,12 @@ threads, use only the atomic [func@GLib.Array.ref] and
       <function name="insert_vals" c:identifier="g_array_insert_vals" introspectable="0">
         <doc xml:space="preserve">Inserts @len elements into a `GArray` at the given index.
 
-If @index_ is greater than the array&#x2019;s current length, the array is expanded.
+If @index_ is greater than the array’s current length, the array is expanded.
 The elements between the old end of the array and the newly inserted elements
 will be initialised to zero if the array was configured to clear elements;
 otherwise their values will be undefined.
 
-If @index_ is less than the array&#x2019;s current length, new entries will be
+If @index_ is less than the array’s current length, new entries will be
 inserted into the array, and the existing entries above @index_ will be moved
 upwards.
 
@@ -3491,7 +3491,7 @@ the returned pointer will be equal to the base pointer of the data of
 @bytes, plus @offset.  This will be non-`NULL` except for the case
 where @bytes itself was a zero-sized region.  Since it is unlikely
 that you will be using this function to check for a zero-sized region
-in a zero-sized @bytes, `NULL` effectively always means &#x2018;error&#x2019;.</doc>
+in a zero-sized @bytes, `NULL` effectively always means ‘error’.</doc>
         <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">the requested region, or `NULL` in case of an error</doc>
           <type name="gpointer" c:type="gconstpointer"/>
@@ -3941,7 +3941,7 @@ value corresponding to the key.</doc>
       </parameters>
     </callback>
     <record name="Checksum" c:type="GChecksum" opaque="1" version="2.16" glib:type-name="GChecksum" glib:get-type="g_checksum_get_type" c:symbol-prefix="checksum">
-      <doc xml:space="preserve">GLib provides a generic API for computing checksums (or &#x2018;digests&#x2019;)
+      <doc xml:space="preserve">GLib provides a generic API for computing checksums (or ‘digests’)
 for a sequence of arbitrary bytes, using various hashing algorithms
 like MD5, SHA-1 and SHA-256. Checksums are commonly used in various
 environments and specifications.
@@ -3950,7 +3950,7 @@ To create a new `GChecksum`, use [ctor@GLib.Checksum.new]. To free
 a `GChecksum`, use [method@GLib.Checksum.free].
 
 GLib supports incremental checksums using the `GChecksum` data
-structure, by calling [method@GLib.Checksum.update] as long as there&#x2019;s data
+structure, by calling [method@GLib.Checksum.update] as long as there’s data
 available and then using [method@GLib.Checksum.get_string] or
 [method@GLib.Checksum.get_digest] to compute the checksum and return it
 either as a string in hexadecimal form, or as a raw sequence of bytes. To
@@ -4235,7 +4235,7 @@ When no longer needed, the `GCompletion` is freed with
 Items in the completion can be simple strings (e.g. filenames), or
 pointers to arbitrary data structures. If data structures are used
 you must provide a [type@GLib.CompletionFunc] in [func@GLib.Completion.new],
-which retrieves the item&#x2019;s string from the data structure. You can change
+which retrieves the item’s string from the data structure. You can change
 the way in which strings are compared by setting a different
 [type@GLib.CompletionStrncmpFunc] in [method@GLib.Completion.set_compare].
 
@@ -6654,7 +6654,7 @@ The result depends on which day is considered the first day of the week,
 which varies by locale. `first_day_of_week` must be valid.
 
 The result will be either 52 or 53. Years always have 52 seven-day periods,
-plus one or two extra days depending on whether it&#x2019;s a leap year. This
+plus one or two extra days depending on whether it’s a leap year. This
 function effectively calculates how many @first_day_of_week days there are in
 the year.</doc>
         <return-value transfer-ownership="none">
@@ -7598,11 +7598,11 @@ The following format specifiers are supported:
 - `%m`: the month as a decimal number (range 01 to 12)
 - `%M`: the minute as a decimal number (range 00 to 59)
 - `%f`: the microsecond as a decimal number (range 000000 to 999999)
-- `%p`: either &#x2018;AM&#x2019; or &#x2018;PM&#x2019; according to the given time value, or the
+- `%p`: either ‘AM’ or ‘PM’ according to the given time value, or the
   corresponding  strings for the current locale.  Noon is treated as
-  &#x2018;PM&#x2019; and midnight as &#x2018;AM&#x2019;. Use of this format specifier is discouraged, as
+  ‘PM’ and midnight as ‘AM’. Use of this format specifier is discouraged, as
   many locales have no concept of AM/PM formatting. Use `%c` or `%X` instead.
-- `%P`: like `%p` but lowercase: &#x2018;am&#x2019; or &#x2018;pm&#x2019; or a corresponding string for
+- `%P`: like `%p` but lowercase: ‘am’ or ‘pm’ or a corresponding string for
   the current locale. Use of this format specifier is discouraged, as
   many locales have no concept of AM/PM formatting. Use `%c` or `%X` instead.
 - `%r`: the time in a.m. or p.m. notation. Use of this format specifier is
@@ -7621,7 +7621,7 @@ The following format specifiers are supported:
   least 4 days in the new year. See g_date_time_get_week_of_year().
   This works well with `%G` and `%u`.
 - `%w`: the day of the week as a decimal, range 0 to 6, Sunday being 0.
-  This is not the ISO 8601 standard format &#x2014; use `%u` instead.
+  This is not the ISO 8601 standard format — use `%u` instead.
 - `%x`: the preferred date representation for the current locale without
   the time
 - `%X`: the preferred time representation for the current locale without
@@ -8955,7 +8955,7 @@ performance.</doc>
       <member name="only_existing" value="4" c:identifier="G_FILE_SET_CONTENTS_ONLY_EXISTING">
         <doc xml:space="preserve">Only apply consistency and durability
   guarantees if the file already exists. This may speed up file operations
-  if the file doesn&#x2019;t currently exist, but may result in a corrupted version
+  if the file doesn’t currently exist, but may result in a corrupted version
   of the new file if the system crashes while writing it.</doc>
       </member>
     </bitfield>
@@ -9018,7 +9018,7 @@ as appropriate for a given platform. IEEE floats and doubles are supported
       </member>
       <member name="bits" value="4" c:identifier="G_FORMAT_SIZE_BITS">
         <doc xml:space="preserve">set the size as a quantity in bits, rather than
-    bytes, and return units in bits. For example, &#x2018;Mbit&#x2019; rather than &#x2018;MB&#x2019;.</doc>
+    bytes, and return units in bits. For example, ‘Mbit’ rather than ‘MB’.</doc>
       </member>
       <member name="only_value" value="8" c:identifier="G_FORMAT_SIZE_ONLY_VALUE">
         <doc xml:space="preserve">return only value, without unit; this should
@@ -11432,9 +11432,9 @@ whenever these events occur.
 [method@GLib.IOChannel.ref] and [method@GLib.IOChannel.unref] can be used to
 increment or decrement the reference count respectively. When the
 reference count falls to 0, the `GIOChannel` is freed. (Though it
-isn&#x2019;t closed automatically, unless it was created using
+isn’t closed automatically, unless it was created using
 [ctor@GLib.IOChannel.new_file].) Using [func@GLib.io_add_watch] or
-[func@GLib.io_add_watch_full] increments a channel&#x2019;s reference count.
+[func@GLib.io_add_watch_full] increments a channel’s reference count.
 
 The new functions [method@GLib.IOChannel.read_chars],
 [method@GLib.IOChannel.read_line], [method@GLib.IOChannel.read_line_string],
@@ -12737,7 +12737,7 @@ entries representing links to documents.</doc>
       <doc xml:space="preserve">`GKeyFile` parses .ini-like config files.
 
 `GKeyFile` lets you parse, edit or create files containing groups of
-key-value pairs, which we call &#x2018;key files&#x2019; for lack of a better name.
+key-value pairs, which we call ‘key files’ for lack of a better name.
 Several freedesktop.org specifications use key files. For example, the
 [Desktop Entry Specification](https://specifications.freedesktop.org/desktop-entry-spec/latest/)
 and the [Icon Theme Specification](https://specifications.freedesktop.org/icon-theme-spec/latest/).
@@ -12803,7 +12803,7 @@ on Windows, but there are some important differences:
 - Key and Group names are case-sensitive. For example, a group called
   `[GROUP]` is a different from `[group]`.
 
-- .ini files don&#x2019;t have a strongly typed boolean entry type,
+- .ini files don’t have a strongly typed boolean entry type,
    they only have `GetProfileInt()`. In key files, only
    `true` and `false` (in lower case) are allowed.
 
@@ -12845,7 +12845,7 @@ Here is an example of creating and saving a key file:
 
 ```c
 g_autoptr(GKeyFile) key_file = g_key_file_new ();
-const gchar *val = &#x2026;;
+const gchar *val = …;
 g_autoptr(GError) error = NULL;
 
 g_key_file_set_string (key_file, "Group Name", "SomeKey", val);
@@ -13287,7 +13287,7 @@ be `NULL`.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">
    a newly allocated `NULL`-terminated string array or `NULL` if the key
-   isn&#x2019;t found. The string array should be freed with [func@GLib.strfreev].</doc>
+   isn’t found. The string array should be freed with [func@GLib.strfreev].</doc>
           <array length="3" zero-terminated="1" c:type="gchar**">
             <type name="utf8"/>
           </array>
@@ -13550,7 +13550,7 @@ If the object cannot be created then a [error@GLib.KeyFileError is returned.</do
 [func@GLib.get_user_data_dir] and [func@GLib.get_system_data_dirs].
 
 The search algorithm from [method@GLib.KeyFile.load_from_dirs] is used. If
-@file is found, it&#x2019;s loaded into @key_file and its full path is returned in
+@file is found, it’s loaded into @key_file and its full path is returned in
 @full_path.
 
 If the file could not be loaded then either a [error@GLib.FileError] or
@@ -13581,11 +13581,11 @@ If the file could not be loaded then either a [error@GLib.FileError] or
       </method>
       <method name="load_from_dirs" c:identifier="g_key_file_load_from_dirs" version="2.14" throws="1">
         <doc xml:space="preserve">Looks for a key file named @file in the paths specified in @search_dirs,
-loads the file into @key_file and returns the file&#x2019;s full path in @full_path.
+loads the file into @key_file and returns the file’s full path in @full_path.
 
 @search_dirs are checked in the order listed in the array, with the highest
 priority directory listed first. Within each directory, @file is looked for.
-If it&#x2019;s not found, `-` characters in @file are progressively replaced with
+If it’s not found, `-` characters in @file are progressively replaced with
 directory separators to search subdirectories of the search directory. If the
 file has not been found after all `-` characters have been replaced, the next
 search directory in @search_dirs is checked.
@@ -14557,7 +14557,7 @@ container itself.
 @func, as a #GCopyFunc, takes two arguments, the data to be copied
 and a @user_data pointer. On common processor architectures, it's safe to
 pass %NULL as @user_data if the copy function takes only one argument. You
-may get compiler warnings from this though if compiling with GCC&#x2019;s
+may get compiler warnings from this though if compiling with GCC’s
 `-Wcast-function-type` warning.
 
 For instance, if @list holds a list of GObjects, you can do:
@@ -14723,7 +14723,7 @@ either use g_list_free_full() or free them manually first.
 It can be combined with g_steal_pointer() to ensure the list head pointer
 is not left dangling:
 |[&lt;!-- language="C" --&gt;
-GList *list_of_borrowed_things = &#x2026;;  /&lt;!-- --&gt;* (transfer container) *&lt;!-- --&gt;/
+GList *list_of_borrowed_things = …;  /&lt;!-- --&gt;* (transfer container) *&lt;!-- --&gt;/
 g_list_free (g_steal_pointer (&amp;list_of_borrowed_things));
 ]|</doc>
         <return-value transfer-ownership="none">
@@ -14764,11 +14764,11 @@ and calls @free_func on every element's data.
 element from it).
 
 It can be combined with g_steal_pointer() to ensure the list head pointer
-is not left dangling &#xAD;&#x2014; this also has the nice property that the head pointer
+is not left dangling ­— this also has the nice property that the head pointer
 is cleared before any of the list elements are freed, to prevent double frees
 from @free_func:
 |[&lt;!-- language="C" --&gt;
-GList *list_of_owned_things = &#x2026;;  /&lt;!-- --&gt;* (transfer full) (element-type GObject) *&lt;!-- --&gt;/
+GList *list_of_owned_things = …;  /&lt;!-- --&gt;* (transfer full) (element-type GObject) *&lt;!-- --&gt;/
 g_list_free_full (g_steal_pointer (&amp;list_of_owned_things), g_object_unref);
 ]|</doc>
         <return-value transfer-ownership="none">
@@ -15795,8 +15795,8 @@ one found will be returned.</doc>
         <doc xml:space="preserve">Invokes a function in such a way that @context is owned during the
 invocation of @function.
 
-If @context is `NULL` then the global-default main context &#x2014; as
-returned by [func@GLib.MainContext.default] &#x2014; is used.
+If @context is `NULL` then the global-default main context — as
+returned by [func@GLib.MainContext.default] — is used.
 
 If @context is owned by the current thread, @function is called
 directly.  Otherwise, if @context is the thread-default main context
@@ -15992,8 +15992,8 @@ ever call [method@GLib.MainContext.pop_thread_default], assuming you want
 the new [struct@GLib.MainContext] to be the default for the whole lifecycle
 of the thread.
 
-If you don&#x2019;t have control over how the new thread was created (e.g.
-in the new thread isn&#x2019;t newly created, or if the thread life
+If you don’t have control over how the new thread was created (e.g.
+in the new thread isn’t newly created, or if the thread life
 cycle is managed by a #GThreadPool), it is always suggested to wrap
 the logic that needs to use the new [struct@GLib.MainContext] inside a
 [method@GLib.MainContext.push_thread_default] /
@@ -16173,8 +16173,8 @@ polled for a particular context.</doc>
         <doc xml:space="preserve">Sets the function to use to handle polling of file descriptors.
 
 It will be used instead of the [`poll()`](man:poll(2)) system call
-(or GLib&#x2019;s replacement function, which is used where
-`poll()` isn&#x2019;t available).
+(or GLib’s replacement function, which is used where
+`poll()` isn’t available).
 
 This function could possibly be used to integrate the GLib event
 loop with an external event loop.</doc>
@@ -16238,7 +16238,7 @@ try again (once) to become the owner.</doc>
         </parameters>
       </method>
       <method name="wakeup" c:identifier="g_main_context_wakeup">
-        <doc xml:space="preserve">Wake up @context if it&#x2019;s currently blocking in
+        <doc xml:space="preserve">Wake up @context if it’s currently blocking in
 [method@GLib.MainContext.iteration], causing it to stop blocking.
 
 The @context could be blocking waiting for a source to become ready.
@@ -16285,7 +16285,7 @@ Then in a thread:
 
 This is the main context
 used for main loop functions when a main loop is not explicitly
-specified, and corresponds to the &#x2018;main&#x2019; main loop. See also
+specified, and corresponds to the ‘main’ main loop. See also
 [func@GLib.MainContext.get_thread_default].</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the global-default main context.</doc>
@@ -16312,7 +16312,7 @@ If you need to hold a reference on the context, use
         </return-value>
       </function>
       <function name="pusher_free" c:identifier="g_main_context_pusher_free" version="2.64" introspectable="0">
-        <doc xml:space="preserve">Pop @pusher&#x2019;s main context as the thread default main context.
+        <doc xml:space="preserve">Pop @pusher’s main context as the thread default main context.
 See g_main_context_pusher_new() for details.
 
 This will pop the [struct@GLib.MainContext] as the current thread-default
@@ -16439,7 +16439,7 @@ Note that sources that have already been dispatched when
       <method name="run" c:identifier="g_main_loop_run">
         <doc xml:space="preserve">Runs a main loop until [method@GLib.MainLoop.quit] is called on the loop.
 
-If this is called from the thread of the loop&#x2019;s [struct@GLib.MainContext],
+If this is called from the thread of the loop’s [struct@GLib.MainContext],
 it will process events from the loop, otherwise it will
 simply wait.</doc>
         <return-value transfer-ownership="none">
@@ -17542,7 +17542,7 @@ returns true and sets @start_pos and @end_pos to `-1` when called with
 
 For an expanded example, a regex pattern is `(a)?(.*?)the (.*)`,
 and a candidate string is `glib regexes are the best`. In this scenario
-there are four capture parentheses numbered 0&#x2013;3: an implicit one
+there are four capture parentheses numbered 0–3: an implicit one
 for the entire string, and three explicitly declared in the regex pattern.
 
 Given this example, the following table describes the return values
@@ -17810,7 +17810,7 @@ Consider, for example, an application where a human is required to
 type in data for a field with specific formatting requirements. An
 example might be a date in the form ddmmmyy, defined by the pattern
 "^\d?\d(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\d\d$".
-If the application sees the user&#x2019;s keystrokes one by one, and can
+If the application sees the user’s keystrokes one by one, and can
 check that what has been typed so far is potentially valid, it is
 able to raise an error as soon as a mistake is made.
 
@@ -19822,9 +19822,9 @@ the application can then add to its #GOptionContext.</doc>
         <doc xml:space="preserve">Creates a new #GOptionGroup.
 
 @description is typically used to provide a title for the group. If so, it
-is recommended that it&#x2019;s written in title case, and has a trailing colon so
+is recommended that it’s written in title case, and has a trailing colon so
 that it matches the style of built-in GLib group titles such as
-&#x2018;Application Options:&#x2019;.</doc>
+‘Application Options:’.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a newly created option group. It should be added
   to a #GOptionContext or freed with g_option_group_unref().</doc>
@@ -20539,7 +20539,7 @@ This function can be passed to g_hash_table_new() as the
       </function>
     </record>
     <record name="PatternSpec" c:type="GPatternSpec" opaque="1" glib:type-name="GPatternSpec" glib:get-type="g_pattern_spec_get_type" c:symbol-prefix="pattern_spec">
-      <doc xml:space="preserve">A `GPatternSpec` struct is the &#x2018;compiled&#x2019; form of a glob-style pattern.
+      <doc xml:space="preserve">A `GPatternSpec` struct is the ‘compiled’ form of a glob-style pattern.
 
 The [func@GLib.pattern_match_simple] and [method@GLib.PatternSpec.match] functions
 match a string against a pattern containing `*` and `?` wildcards with similar
@@ -20547,7 +20547,7 @@ semantics as the standard `glob()` function: `*` matches an arbitrary,
 possibly empty, string, `?` matches an arbitrary character.
 
 Note that in contrast to [`glob()`](man:glob(3)), the `/` character can be
-matched by the wildcards, there are no `[&#x2026;]` character ranges and `*` and `?`
+matched by the wildcards, there are no `[…]` character ranges and `*` and `?`
 can not be escaped to include them literally in a pattern.
 
 When multiple strings must be matched against the same pattern, it is better
@@ -20623,7 +20623,7 @@ requires reverse matches.
 
 Note that, if the user code will (possibly) match a string against a
 multitude of patterns containing wildcards, chances are high that
-some patterns will require a reversed string. In this case, it&#x2019;s
+some patterns will require a reversed string. In this case, it’s
 more efficient to provide the reversed string to avoid multiple
 constructions thereof in the various calls to [method@GLib.PatternSpec.match].
 
@@ -20872,9 +20872,9 @@ in size automatically if necessary.</doc>
 
 @func, as a [callback@GLib.CopyFunc], takes two arguments, the data to be
 copied
-and a @user_data pointer. On common processor architectures, it&#x2019;s safe to
+and a @user_data pointer. On common processor architectures, it’s safe to
 pass `NULL` as @user_data if the copy function takes only one argument. You
-may get compiler warnings from this though if compiling with GCC&#x2019;s
+may get compiler warnings from this though if compiling with GCC’s
 `-Wcast-function-type` warning.
 
 If @func is `NULL`, then only the pointers (and not what they are
@@ -20914,9 +20914,9 @@ modified in-place.
 
 @func, as a [callback@GLib.CopyFunc], takes two arguments, the data to be
 copied
-and a @user_data pointer. On common processor architectures, it&#x2019;s safe to
+and a @user_data pointer. On common processor architectures, it’s safe to
 pass `NULL` as @user_data if the copy function takes only one argument. You
-may get compiler warnings from this though if compiling with GCC&#x2019;s
+may get compiler warnings from this though if compiling with GCC’s
 `-Wcast-function-type` warning.
 
 If @func is `NULL`, then only the pointers (and not what they are
@@ -20978,7 +20978,7 @@ length of @array set to zero.</doc>
       </function>
       <function name="find" c:identifier="g_ptr_array_find" version="2.54" introspectable="0">
         <doc xml:space="preserve">Checks whether @needle exists in @haystack. If the element is found, true
-is returned and the element&#x2019;s index is returned in @index_ (if non-`NULL`).
+is returned and the element’s index is returned in @index_ (if non-`NULL`).
 Otherwise, false is returned and @index_ is undefined. If @needle exists
 multiple times in @haystack, the index of the first instance is returned.
 
@@ -21009,7 +21009,7 @@ checks, such as string comparisons, use
       </function>
       <function name="find_with_equal_func" c:identifier="g_ptr_array_find_with_equal_func" version="2.54" introspectable="0">
         <doc xml:space="preserve">Checks whether @needle exists in @haystack, using the given @equal_func.
-If the element is found, true is returned and the element&#x2019;s index is
+If the element is found, true is returned and the element’s index is
 returned in @index_ (if non-`NULL`). Otherwise, false is returned and @index_
 is undefined. If @needle exists multiple times in @haystack, the index of
 the first instance is returned.
@@ -21161,7 +21161,7 @@ appended to them.</doc>
       </function>
       <function name="new_from_array" c:identifier="g_ptr_array_new_from_array" version="2.76" introspectable="0">
         <doc xml:space="preserve">Creates a new `GPtrArray`, copying @len pointers from @data, and setting
-the array&#x2019;s reference count to 1.
+the array’s reference count to 1.
 
 This avoids having to manually add each element one by one.
 
@@ -21289,7 +21289,7 @@ current length.
 `GPtrArray` created by other constructors are not automatically `NULL`
 terminated.
 
-Note that if the @array&#x2019;s length is zero and currently no
+Note that if the @array’s length is zero and currently no
 data array is allocated, then `pdata` will still be `NULL`.
 `GPtrArray` will only `NULL` terminate `pdata`, if an actual
 array is allocated. It does not guarantee that an array
@@ -21636,7 +21636,7 @@ comparison function (returns less than zero for first arg is less
 than second arg, zero for equal, greater than zero if first arg is
 greater than second arg).
 
-Note that the comparison function for [func@GLib.PtrArray.sort] doesn&#x2019;t
+Note that the comparison function for [func@GLib.PtrArray.sort] doesn’t
 take the pointers from the array as arguments, it takes pointers to
 the pointers in the array.
 
@@ -21660,7 +21660,7 @@ sort_filelist (gconstpointer a, gconstpointer b)
   return g_ascii_strcasecmp (entry1-&gt;name, entry2-&gt;name);
 }
 
-&#x2026;
+…
 g_autoptr (GPtrArray) file_list = NULL;
 
 // initialize file_list array and load with many FileListEntry entries
@@ -21739,7 +21739,7 @@ This is guaranteed to be a stable sort.</doc>
 user data argument.
 
 Note that the comparison function for [func@GLib.PtrArray.sort_with_data]
-doesn&#x2019;t take the pointers from the array as arguments, it takes
+doesn’t take the pointers from the array as arguments, it takes
 pointers to the pointers in the array.
 
 Use [func@GLib.PtrArray.sort_values_with_data] if you want to use normal
@@ -21833,7 +21833,7 @@ g_autoptr(GPtrArray) chunk_buffer = g_ptr_array_new_with_free_func (g_bytes_unre
 g_ptr_array_add (chunk_buffer, g_bytes_new_static ("hello", 5));
 g_ptr_array_add (chunk_buffer, g_bytes_new_static ("world", 5));
 
-&#x2026;
+…
 
 // Periodically, the chunks need to be sent as an array-and-length to some
 // other part of the program.
@@ -21846,7 +21846,7 @@ for (gsize i = 0; i &lt; n_chunks; i++)
     // Do something with each chunk here, and then free them, since
     // g_ptr_array_steal() transfers ownership of all the elements and the
     // array to the caller.
-    &#x2026;
+    …
 
     g_bytes_unref (chunks[i]);
   }
@@ -21859,7 +21859,7 @@ g_assert (chunk_buffer-&gt;len == 0);
 ```</doc>
         <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">The allocated element data.
-  This may be `NULL`if the array doesn&#x2019;t have any elements (i.e. if `*len` is zero).</doc>
+  This may be `NULL`if the array doesn’t have any elements (i.e. if `*len` is zero).</doc>
           <array length="1" zero-terminated="0" c:type="gpointer*">
             <type name="gpointer" c:type="gpointer"/>
           </array>
@@ -23470,18 +23470,18 @@ else
 
 The constructor for `GRegex` includes two sets of bitmapped flags:
 
-* [flags@GLib.RegexCompileFlags]&#x2014;These flags
+* [flags@GLib.RegexCompileFlags]—These flags
 control how GLib compiles the regex. There are options for case
 sensitivity, multiline, ignoring whitespace, etc.
-* [flags@GLib.RegexMatchFlags]&#x2014;These flags control
-`GRegex`&#x2019;s matching behavior, such as anchoring and customizing definitions
+* [flags@GLib.RegexMatchFlags]—These flags control
+`GRegex`’s matching behavior, such as anchoring and customizing definitions
 for newline characters.
 
 Some regex patterns include backslash assertions, such as `\d` (digit) or
 `\D` (non-digit). The regex pattern must escape those backslashes. For
 example, the pattern `"\\d\\D"` matches a digit followed by a non-digit.
 
-GLib&#x2019;s implementation of pattern matching includes a `start_position`
+GLib’s implementation of pattern matching includes a `start_position`
 argument for some of the match, replace, and split methods. Specifying
 a start position provides flexibility when you want to ignore the first
 _n_ characters of a string, but want to incorporate backslash assertions
@@ -23529,7 +23529,7 @@ the previous character satisfies an assertion.
 Unless you set the [flags@GLib.RegexCompileFlags.RAW] as one of
 the `GRegexCompileFlags`, all the strings passed to `GRegex` methods must
 be encoded in UTF-8. The lengths and the positions inside the strings are
-in bytes and not in characters, so, for instance, `\xc3\xa0` (i.e., `&#xE0;`)
+in bytes and not in characters, so, for instance, `\xc3\xa0` (i.e., `à`)
 is two bytes long but it is treated as a single character. If you set
 `G_REGEX_RAW`, the strings can be non-valid UTF-8 strings and a byte is
 treated as a character, so `\xc3\xa0` is two bytes and two characters long.
@@ -24441,12 +24441,12 @@ it using g_strfreev()</doc>
       <member name="multiline" value="2" c:identifier="G_REGEX_MULTILINE">
         <doc xml:space="preserve">By default, [type@GLib.Regex] treats the strings as consisting
   of a single line of characters (even if it actually contains
-  newlines). The &#x2018;start of line&#x2019; metacharacter (`^`) matches only
-  at the start of the string, while the &#x2018;end of line&#x2019; metacharacter
+  newlines). The ‘start of line’ metacharacter (`^`) matches only
+  at the start of the string, while the ‘end of line’ metacharacter
   (`$`) matches only at the end of the string, or before a terminating
   newline (unless [flags@GLib.RegexCompileFlags.DOLLAR_ENDONLY] is set). When
-  [flags@GLib.RegexCompileFlags.MULTILINE] is set, the &#x2018;start of line&#x2019; and
-  &#x2018;end of line&#x2019; constructs match immediately following or immediately before
+  [flags@GLib.RegexCompileFlags.MULTILINE] is set, the ‘start of line’ and
+  ‘end of line’ constructs match immediately following or immediately before
   any newline in the string, respectively, as well as at the very start
   and end. This can be changed within a pattern by a `(?m)` option
   setting.</doc>
@@ -24465,7 +24465,7 @@ it using g_strfreev()</doc>
   be changed within a pattern by a `(?x)` option setting.</doc>
       </member>
       <member name="anchored" value="16" c:identifier="G_REGEX_ANCHORED">
-        <doc xml:space="preserve">The pattern is forced to be &#x2018;anchored&#x2019;, that is,
+        <doc xml:space="preserve">The pattern is forced to be ‘anchored’, that is,
   it is constrained to match only at the first matching point in the
   string that is being searched. This effect can also be achieved by
   appropriate constructs in the pattern itself such as the `^`
@@ -24479,7 +24479,7 @@ it using g_strfreev()</doc>
   is ignored if [flags@GLib.RegexCompileFlags.MULTILINE] is set.</doc>
       </member>
       <member name="ungreedy" value="512" c:identifier="G_REGEX_UNGREEDY">
-        <doc xml:space="preserve">Inverts the &#x2018;greediness&#x2019; of the quantifiers so that
+        <doc xml:space="preserve">Inverts the ‘greediness’ of the quantifiers so that
   they are not greedy by default, but become greedy if followed by `?`.
   It can also be set by a `(?U)` option setting within the pattern.</doc>
       </member>
@@ -24778,7 +24778,7 @@ if you need the regex object itself, or the matched string.</doc>
         <doc xml:space="preserve">No special options set. Since: 2.74</doc>
       </member>
       <member name="anchored" value="16" c:identifier="G_REGEX_MATCH_ANCHORED">
-        <doc xml:space="preserve">The pattern is forced to be &#x2018;anchored&#x2019;, that is,
+        <doc xml:space="preserve">The pattern is forced to be ‘anchored’, that is,
   it is constrained to match only at the first matching point in the
   string that is being searched. This effect can also be achieved by
   appropriate constructs in the pattern itself such as the `^`
@@ -25254,7 +25254,7 @@ each list element, in addition to copying the list container itself.
 @func, as a #GCopyFunc, takes two arguments, the data to be copied
 and a @user_data pointer. On common processor architectures, it's safe to
 pass %NULL as @user_data if the copy function takes only one argument. You
-may get compiler warnings from this though if compiling with GCC&#x2019;s
+may get compiler warnings from this though if compiling with GCC’s
 `-Wcast-function-type` warning.
 
 For instance, if @list holds a list of GObjects, you can do:
@@ -25410,7 +25410,7 @@ first.
 It can be combined with g_steal_pointer() to ensure the list head pointer
 is not left dangling:
 |[&lt;!-- language="C" --&gt;
-GSList *list_of_borrowed_things = &#x2026;;  /&lt;!-- --&gt;* (transfer container) *&lt;!-- --&gt;/
+GSList *list_of_borrowed_things = …;  /&lt;!-- --&gt;* (transfer container) *&lt;!-- --&gt;/
 g_slist_free (g_steal_pointer (&amp;list_of_borrowed_things));
 ]|</doc>
         <return-value transfer-ownership="none">
@@ -25448,11 +25448,11 @@ calls the specified destroy function on every element's data.
 element from it).
 
 It can be combined with g_steal_pointer() to ensure the list head pointer
-is not left dangling &#xAD;&#x2014; this also has the nice property that the head pointer
+is not left dangling ­— this also has the nice property that the head pointer
 is cleared before any of the list elements are freed, to prevent double frees
 from @free_func:
 |[&lt;!-- language="C" --&gt;
-GSList *list_of_owned_things = &#x2026;;  /&lt;!-- --&gt;* (transfer full) (element-type GObject) *&lt;!-- --&gt;/
+GSList *list_of_owned_things = …;  /&lt;!-- --&gt;* (transfer full) (element-type GObject) *&lt;!-- --&gt;/
 g_slist_free_full (g_steal_pointer (&amp;list_of_owned_things), g_object_unref);
 ]|</doc>
         <return-value transfer-ownership="none">
@@ -27682,7 +27682,7 @@ executed.</doc>
         <parameters>
           <parameter name="source_funcs" transfer-ownership="none">
             <doc xml:space="preserve">structure containing functions that implement
-  the source&#x2018;s behavior</doc>
+  the source‘s behavior</doc>
             <type name="SourceFuncs" c:type="GSourceFuncs*"/>
           </parameter>
           <parameter name="struct_size" transfer-ownership="none">
@@ -27692,7 +27692,7 @@ executed.</doc>
         </parameters>
       </constructor>
       <method name="add_child_source" c:identifier="g_source_add_child_source" version="2.28">
-        <doc xml:space="preserve">Adds @child_source to @source as a &#x2018;polled&#x2019; source.
+        <doc xml:space="preserve">Adds @child_source to @source as a ‘polled’ source.
 
 When @source is added to a [struct@GLib.MainContext], @child_source will be
 automatically added with the same priority. When @child_source is triggered,
@@ -27702,7 +27702,7 @@ and when @source is destroyed, it will destroy @child_source as well.
 The @source will also still be dispatched if its own prepare/check functions
 indicate that it is ready.
 
-If you don&#x2019;t need @child_source to do anything on its own when it
+If you don’t need @child_source to do anything on its own when it
 triggers, you can call `g_source_set_dummy_callback()` on it to set a
 callback that does nothing (except return true if appropriate).
 
@@ -27720,7 +27720,7 @@ Do not call this API on a [struct@GLib.Source] that you did not create.</doc>
             <type name="Source" c:type="GSource*"/>
           </instance-parameter>
           <parameter name="child_source" transfer-ownership="none">
-            <doc xml:space="preserve">a second source that @source should &#x2018;poll&#x2019;</doc>
+            <doc xml:space="preserve">a second source that @source should ‘poll’</doc>
             <type name="Source" c:type="GSource*"/>
           </parameter>
         </parameters>
@@ -27730,7 +27730,7 @@ Do not call this API on a [struct@GLib.Source] that you did not create.</doc>
 this source.
 
 This is usually combined with [ctor@GLib.Source.new] to add an
-event source. The event source&#x2019;s check function will typically test
+event source. The event source’s check function will typically test
 the @revents field in the [struct@GLib.PollFD] struct and return true if
 events need to be processed.
 
@@ -27829,7 +27829,7 @@ the [struct@GLib.MainContext] is running in.
 
 If the source is currently attached to a [struct@GLib.MainContext],
 destroying it will effectively unset the callback similar to calling
-[method@GLib.Source.set_callback]. This can mean, that the data&#x2019;s
+[method@GLib.Source.set_callback]. This can mean, that the data’s
 [callback@GLib.DestroyNotify] gets called right away.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -27974,13 +27974,13 @@ name may be `NULL` if it has never been set with [method@GLib.Source.set_name].<
         </parameters>
       </method>
       <method name="get_ready_time" c:identifier="g_source_get_ready_time">
-        <doc xml:space="preserve">Gets the &#x2018;ready time&#x2019; of @source, as set by
+        <doc xml:space="preserve">Gets the ‘ready time’ of @source, as set by
 [method@GLib.Source.set_ready_time].
 
 Any time before or equal to the current monotonic time (including zero)
 is an indication that the source will fire immediately.</doc>
         <return-value transfer-ownership="none">
-          <doc xml:space="preserve">the monotonic ready time, `-1` for &#x2018;never&#x2019;</doc>
+          <doc xml:space="preserve">the monotonic ready time, `-1` for ‘never’</doc>
           <type name="gint64" c:type="gint64"/>
         </return-value>
         <parameters>
@@ -28106,7 +28106,7 @@ this function can be used for opportunistic checks from any thread.</doc>
 
 The @tag is the tag returned from [method@GLib.Source.add_unix_fd].
 
-If you want to remove a file descriptor, don&#x2019;t set its event mask to zero.
+If you want to remove a file descriptor, don’t set its event mask to zero.
 Instead, call [method@GLib.Source.remove_unix_fd].
 
 This API is only intended to be used by implementations of [struct@GLib.Source].
@@ -28238,7 +28238,7 @@ As the name suggests, this function is not available on Windows.</doc>
       </method>
       <method name="set_callback" c:identifier="g_source_set_callback">
         <doc xml:space="preserve">Sets the callback function for a source. The callback for a source is
-called from the source&#x2019;s dispatch function.
+called from the source’s dispatch function.
 
 The exact type of @func depends on the type of source; ie. you
 should not count on @func being called with @data as its first
@@ -28248,7 +28248,7 @@ incompatible function types.
 See [main loop memory management](main-loop.html#memory-management-of-sources) for details
 on how to handle memory management of @data.
 
-Typically, you won&#x2019;t use this function. Instead use functions specific
+Typically, you won’t use this function. Instead use functions specific
 to the type of source you are using, such as [func@GLib.idle_add] or
 [func@GLib.timeout_add].
 
@@ -28282,7 +28282,7 @@ of also unsetting the callback.</doc>
       </method>
       <method name="set_callback_indirect" c:identifier="g_source_set_callback_indirect">
         <doc xml:space="preserve">Sets the callback function storing the data as a reference counted callback
-&#x2018;object&#x2019;.
+‘object’.
 
 This is used internally. Note that calling
 [method@GLib.Source.set_callback_indirect] assumes
@@ -28302,7 +28302,7 @@ the source is dispatched after this call returns.</doc>
             <type name="Source" c:type="GSource*"/>
           </instance-parameter>
           <parameter name="callback_data" transfer-ownership="none" nullable="1" allow-none="1">
-            <doc xml:space="preserve">pointer to callback data &#x2018;object&#x2019;</doc>
+            <doc xml:space="preserve">pointer to callback data ‘object’</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
           <parameter name="callback_funcs" transfer-ownership="none">
@@ -28344,7 +28344,7 @@ This means that at this point @source is still a valid [struct@GLib.Source]
 and it is allow for the reference count to increase again until @dispose
 returns.
 
-The dispose function can be used to clear any &#x2018;weak&#x2019; references to
+The dispose function can be used to clear any ‘weak’ references to
 the @source in other data structures in a thread-safe way where it is
 possible for another thread to increase the reference count of @source again
 while it is being freed.
@@ -28392,8 +28392,8 @@ of @source.</doc>
 The name defaults to `NULL`.
 
 The source name should describe in a human-readable way
-what the source does. For example, &#x2018;X11 event queue&#x2019;
-or &#x2018;GTK repaint idle handler&#x2019;.
+what the source does. For example, ‘X11 event queue’
+or ‘GTK repaint idle handler’.
 
 It is permitted to call this function multiple times, but is not
 recommended due to the potential performance impact.  For example,
@@ -28481,7 +28481,7 @@ Do not call this API on a [struct@GLib.Source] that you did not create.</doc>
           </instance-parameter>
           <parameter name="ready_time" transfer-ownership="none">
             <doc xml:space="preserve">the monotonic time at which the source will be ready;
-  `0` for &#x2018;immediately&#x2019;, `-1` for &#x2018;never&#x2019;</doc>
+  `0` for ‘immediately’, `-1` for ‘never’</doc>
             <type name="gint64" c:type="gint64"/>
           </parameter>
         </parameters>
@@ -30832,13 +30832,13 @@ XDG directories to point into subdirectories of it for the duration of
 the unit test. The directory tree is cleaned up after the test finishes
 successfully.
 
-Note that this doesn&#x2019;t take effect until [func@GLib.test_run] is called,
+Note that this doesn’t take effect until [func@GLib.test_run] is called,
 so calls to (for example) [func@GLib.get_home_dir] will return the
-system-wide value when made in a test program&#x2019;s main() function.
+system-wide value when made in a test program’s main() function.
 
 The following functions will return subdirectories of the temporary directory
 when this option is used. The specific subdirectory paths in use are not
-guaranteed to be stable API &#x2014; always use a getter function to retrieve them.
+guaranteed to be stable API — always use a getter function to retrieve them.
 
  - [func@GLib.get_home_dir]
  - [func@GLib.get_user_cache_dir]
@@ -30851,7 +30851,7 @@ guaranteed to be stable API &#x2014; always use a getter function to retrieve th
 
 The subdirectories may not be created by the test harness; as with normal
 calls to functions like [func@GLib.get_user_cache_dir], the caller must
-be prepared to create the directory if it doesn&#x2019;t exist.</doc>
+be prepared to create the directory if it doesn’t exist.</doc>
       <type name="utf8" c:type="gchar*"/>
     </constant>
     <constant name="TEST_OPTION_NONFATAL_ASSERTIONS" value="nonfatal-assertions" c:type="G_TEST_OPTION_NONFATAL_ASSERTIONS" version="2.84">
@@ -31173,7 +31173,7 @@ and stderr.</doc>
       </member>
       <member name="inherit_descriptors" value="8" c:identifier="G_TEST_SUBPROCESS_INHERIT_DESCRIPTORS">
         <doc xml:space="preserve">If this flag is given, the
-  child process will inherit the parent&#x2019;s open file descriptors.</doc>
+  child process will inherit the parent’s open file descriptors.</doc>
       </member>
     </bitfield>
     <record name="TestSuite" c:type="GTestSuite" disguised="1" opaque="1">
@@ -32530,16 +32530,16 @@ g_date_time_unref (dt);
 
 The `GTimeZone` struct is refcounted and immutable.
 
-Each time zone has an identifier (for example, &#x2018;Europe/London&#x2019;) which is
+Each time zone has an identifier (for example, ‘Europe/London’) which is
 platform dependent. See [ctor@GLib.TimeZone.new] for information on the
 identifier formats. The identifier of a time zone can be retrieved using
 [method@GLib.TimeZone.get_identifier].
 
 A time zone contains a number of intervals. Each interval has an abbreviation
-to describe it (for example, &#x2018;PDT&#x2019;), an offset to UTC and a flag indicating
+to describe it (for example, ‘PDT’), an offset to UTC and a flag indicating
 if the daylight savings time is in effect during that interval. A time zone
-always has at least one interval &#x2014; interval 0. Note that interval abbreviations
-are not the same as time zone identifiers (apart from &#x2018;UTC&#x2019;), and cannot be
+always has at least one interval — interval 0. Note that interval abbreviations
+are not the same as time zone identifiers (apart from ‘UTC’), and cannot be
 passed to [ctor@GLib.TimeZone.new].
 
 Every UTC time is contained within exactly one interval, but a given
@@ -32584,8 +32584,8 @@ In Windows, @identifier can also be the unlocalized name of a time
 zone for standard time, for example "Pacific Standard Time".
 
 Valid RFC3339 time offsets are `"Z"` (for UTC) or
-`"&#xB1;hh:mm"`.  ISO 8601 additionally specifies
-`"&#xB1;hhmm"` and `"&#xB1;hh"`.  Offsets are
+`"±hh:mm"`.  ISO 8601 additionally specifies
+`"±hhmm"` and `"±hh"`.  Offsets are
 time values to be added to Coordinated Universal Time (UTC) to get
 the local time.
 
@@ -32597,7 +32597,7 @@ There  are  no spaces in the specification. The name of standard
 and daylight savings time zone must be three or more alphabetic
 characters. Offsets are time values to be added to local time to
 get Coordinated Universal Time (UTC) and should be
-`"[&#xB1;]hh[[:]mm[:ss]]"`.  Dates are either
+`"[±]hh[[:]mm[:ss]]"`.  Dates are either
 `"Jn"` (Julian day with n between 1 and 365, leap
 years not counted), `"n"` (zero-based Julian day
 with n between 0 and 365) or `"Mm.w.d"` (day d
@@ -32605,7 +32605,7 @@ with n between 0 and 365) or `"Mm.w.d"` (day d
 0 is a Sunday).  Times are in local wall clock time, the default is
 02:00:00.
 
-In Windows, the "tzn[+|&#x2013;]hh[:mm[:ss]][dzn]" format is used, but also
+In Windows, the "tzn[+|–]hh[:mm[:ss]][dzn]" format is used, but also
 accepts POSIX format.  The Windows format uses US rules for all time
 zones; daylight savings time is 60 minutes behind the standard time
 with date and time of change taken from Pacific Standard Time.
@@ -32626,7 +32626,7 @@ available and it is greater than 2037, then it will followed
 instead.
 
 See
-[RFC3339 &#xA7;5.6](http://tools.ietf.org/html/rfc3339#section-5.6)
+[RFC3339 §5.6](http://tools.ietf.org/html/rfc3339#section-5.6)
 for a precise definition of valid RFC3339 time offsets
 (the `time-offset` expansion) and ISO 8601 for the
 full list of valid time offsets.  See
@@ -33758,7 +33758,7 @@ are O(log(n)).</doc>
       </method>
       <method name="remove_all" c:identifier="g_tree_remove_all" version="2.70">
         <doc xml:space="preserve">Removes all nodes from a #GTree and destroys their keys and values,
-then resets the #GTree&#x2019;s root to %NULL.</doc>
+then resets the #GTree’s root to %NULL.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -35018,9 +35018,9 @@ answer. Likewise, by definition, all URIs have a path component, so
 be empty).
 
 If the URI string has an
-[&#x2018;authority&#x2019; component](https://tools.ietf.org/html/rfc3986#section-3) (that
+[‘authority’ component](https://tools.ietf.org/html/rfc3986#section-3) (that
 is, if the scheme is followed by `://` rather than just `:`), then the
-`GUri` will contain a hostname, and possibly a port and &#x2018;userinfo&#x2019;.
+`GUri` will contain a hostname, and possibly a port and ‘userinfo’.
 Additionally, depending on how the `GUri` was constructed/parsed (for example,
 using the `G_URI_FLAGS_HAS_PASSWORD` and `G_URI_FLAGS_HAS_AUTH_PARAMS` flags),
 the userinfo may be split out into a username, password, and
@@ -35066,7 +35066,7 @@ multiple threads. Its reference counting is atomic.
 
 Note that the scope of `GUri` is to help manipulate URIs in various applications,
 following [RFC 3986](https://tools.ietf.org/html/rfc3986). In particular,
-it doesn't intend to cover web browser needs, and doesn&#x2019;t implement the
+it doesn't intend to cover web browser needs, and doesn’t implement the
 [WHATWG URL](https://url.spec.whatwg.org/) standard. No APIs are provided to
 help prevent
 [homograph attacks](https://en.wikipedia.org/wiki/IDN_homograph_attack), so
@@ -35076,10 +35076,10 @@ security-sensitive decisions.
 ## Relative and absolute URIs
 
 As defined in [RFC 3986](https://tools.ietf.org/html/rfc3986#section-4), the
-hierarchical nature of URIs means that they can either be &#x2018;relative
-references&#x2019; (sometimes referred to as &#x2018;relative URIs&#x2019;) or &#x2018;URIs&#x2019; (for
-clarity, &#x2018;URIs&#x2019; are referred to in this documentation as
-&#x2018;absolute URIs&#x2019; &#x2014; although
+hierarchical nature of URIs means that they can either be ‘relative
+references’ (sometimes referred to as ‘relative URIs’) or ‘URIs’ (for
+clarity, ‘URIs’ are referred to in this documentation as
+‘absolute URIs’ — although
 [in contrast to RFC 3986](https://tools.ietf.org/html/rfc3986#section-4.3),
 fragment identifiers are always allowed).
 
@@ -35107,7 +35107,7 @@ what forms they accept.
 The most minimalist APIs for parsing URIs are [func@GLib.Uri.split] and
 [func@GLib.Uri.split_with_user]. These split a URI into its component
 parts, and return the parts; the difference between the two is that
-[func@GLib.Uri.split] treats the &#x2018;userinfo&#x2019; component of the URI as a
+[func@GLib.Uri.split] treats the ‘userinfo’ component of the URI as a
 single element, while [func@GLib.Uri.split_with_user] can (depending on the
 [flags@GLib.UriFlags] you pass) treat it as containing a username, password,
 and authentication parameters. Alternatively, [func@GLib.Uri.split_network]
@@ -35310,7 +35310,7 @@ regardless of the string or strings that @uri was created from.</doc>
         </parameters>
       </method>
       <method name="get_user" c:identifier="g_uri_get_user" version="2.66">
-        <doc xml:space="preserve">Gets the &#x2018;username&#x2019; component of @uri's userinfo, which may contain
+        <doc xml:space="preserve">Gets the ‘username’ component of @uri's userinfo, which may contain
 `%`-encoding, depending on the flags with which @uri was created.
 If @uri was not created with %G_URI_FLAGS_HAS_PASSWORD or
 %G_URI_FLAGS_HAS_AUTH_PARAMS, this is the same as g_uri_get_userinfo().</doc>
@@ -35486,7 +35486,7 @@ coherent with the passed values, in particular use `%`-encoded values with
 %G_URI_FLAGS_ENCODED.
 
 In contrast to g_uri_build(), this allows specifying the components
-of the &#x2018;userinfo&#x2019; field separately. Note that @user must be non-%NULL
+of the ‘userinfo’ field separately. Note that @user must be non-%NULL
 if either @password or @auth_params is non-%NULL.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a new #GUri</doc>
@@ -35543,10 +35543,10 @@ if either @password or @auth_params is non-%NULL.</doc>
       <function name="escape_bytes" c:identifier="g_uri_escape_bytes" version="2.66">
         <doc xml:space="preserve">Escapes arbitrary data for use in a URI.
 
-Normally all characters that are not &#x2018;unreserved&#x2019; (i.e. ASCII
+Normally all characters that are not ‘unreserved’ (i.e. ASCII
 alphanumerical characters plus dash, dot, underscore and tilde) are
 escaped. But if you specify characters in @reserved_chars_allowed
-they are not escaped. This is useful for the &#x2018;reserved&#x2019; characters
+they are not escaped. This is useful for the ‘reserved’ characters
 in the URI specification, since those are allowed unescaped in some
 portions of a URI.
 
@@ -35610,7 +35610,7 @@ returned string should be freed when no longer needed.</doc>
 [absolute URI](#relative-and-absolute-uris), i.e. it does not need to be resolved
 relative to another URI using g_uri_parse_relative().
 
-If it&#x2019;s not a valid URI, an error is returned explaining how it&#x2019;s invalid.
+If it’s not a valid URI, an error is returned explaining how it’s invalid.
 
 See g_uri_split(), and the definition of #GUriFlags, for more
 information on the effect of @flags.</doc>
@@ -35640,7 +35640,7 @@ characters (`//`). See
 [RFC 3986, section 3](https://tools.ietf.org/html/rfc3986#section-3).
 
 See also g_uri_join_with_user(), which allows specifying the
-components of the &#x2018;userinfo&#x2019; separately.
+components of the ‘userinfo’ separately.
 
 %G_URI_FLAGS_HAS_PASSWORD and %G_URI_FLAGS_HAS_AUTH_PARAMS are ignored if set
 in @flags.</doc>
@@ -35689,7 +35689,7 @@ an absolute URI string. @path may not be %NULL (though it may be the empty
 string).
 
 In contrast to g_uri_join(), this allows specifying the components
-of the &#x2018;userinfo&#x2019; separately. It otherwise behaves the same.
+of the ‘userinfo’ separately. It otherwise behaves the same.
 
 %G_URI_FLAGS_HAS_PASSWORD and %G_URI_FLAGS_HAS_AUTH_PARAMS are ignored if set
 in @flags.</doc>
@@ -35800,7 +35800,7 @@ invalid encoding.)
 
 If %G_URI_PARAMS_CASE_INSENSITIVE is passed to @flags, attributes will be
 compared case-insensitively, so a params string `attr=123&amp;Attr=456` will only
-return a single attribute&#x2013;value pair, `Attr=456`. Case will be preserved in
+return a single attribute–value pair, `Attr=456`. Case will be preserved in
 the returned attributes.
 
 If @params cannot be parsed (for example, it contains two @separators
@@ -35847,7 +35847,7 @@ URI = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
 ]|
 Common schemes include `file`, `https`, `svn+ssh`, etc.</doc>
         <return-value transfer-ownership="full" nullable="1">
-          <doc xml:space="preserve">The &#x2018;scheme&#x2019; component of the URI, or
+          <doc xml:space="preserve">The ‘scheme’ component of the URI, or
     %NULL on error. The returned string should be freed when no longer needed.</doc>
           <type name="utf8" c:type="char*"/>
         </return-value>
@@ -35870,7 +35870,7 @@ Common schemes include `file`, `https`, `svn+ssh`, etc.
 Unlike g_uri_parse_scheme(), the returned scheme is normalized to
 all-lowercase and does not need to be freed.</doc>
         <return-value transfer-ownership="none" nullable="1">
-          <doc xml:space="preserve">The &#x2018;scheme&#x2019; component of the URI, or
+          <doc xml:space="preserve">The ‘scheme’ component of the URI, or
     %NULL on error. The returned string is normalized to all-lowercase, and
     interned via g_intern_string(), so it does not need to be freed.</doc>
           <type name="utf8" c:type="const char*"/>
@@ -36233,7 +36233,7 @@ parse it with.</doc>
     [RFC 3986](https://tools.ietf.org/html/rfc3986) grammar specifies,
     fixing up or ignoring common mistakes in URIs coming from external
     sources. This is also needed for some obscure URI schemes where `;`
-    separates the host from the path. Don&#x2019;t use this flag unless you need to.</doc>
+    separates the host from the path. Don’t use this flag unless you need to.</doc>
       </member>
       <member name="has_password" value="2" c:identifier="G_URI_FLAGS_HAS_PASSWORD">
         <doc xml:space="preserve">The userinfo field may contain a password,
@@ -36319,7 +36319,7 @@ the corresponding flags.</doc>
     <record name="UriParamsIter" c:type="GUriParamsIter" version="2.66">
       <doc xml:space="preserve">Many URI schemes include one or more attribute/value pairs as part of the URI
 value. For example `scheme://server/path?query=string&amp;is=there` has two
-attributes &#x2013; `query=string` and `is=there` &#x2013; in its query part.
+attributes – `query=string` and `is=there` – in its query part.
 
 A #GUriParamsIter structure represents an iterator that can be used to
 iterate over the attribute/value pairs of a URI query string. #GUriParamsIter
@@ -36595,7 +36595,7 @@ along with information about the type of the values.
 
 A `GVariant` may contain simple types, like an integer, or a boolean value;
 or complex types, like an array of two strings, or a dictionary of key
-value pairs. A `GVariant` is also immutable: once it&#x2019;s been created neither
+value pairs. A `GVariant` is also immutable: once it’s been created neither
 its type nor its content can be modified further.
 
 `GVariant` is useful whenever data needs to be serialized, for example when
@@ -36628,7 +36628,7 @@ can never change other than by the `GVariant` itself being
 destroyed.  A `GVariant` cannot contain a pointer.
 
 `GVariant` is reference counted using [method@GLib.Variant.ref] and
-[method@GLib.Variant.unref].  `GVariant` also has floating reference counts &#x2014;
+[method@GLib.Variant.unref].  `GVariant` also has floating reference counts —
 see [method@GLib.Variant.ref_sink].
 
 `GVariant` is completely threadsafe.  A `GVariant` instance can be
@@ -36643,12 +36643,12 @@ Serialized `GVariant` data can also be sent over the network.
 
 `GVariant` is largely compatible with D-Bus.  Almost all types of
 `GVariant` instances can be sent over D-Bus.  See [type@GLib.VariantType] for
-exceptions.  (However, `GVariant`&#x2019;s serialization format is not the same
+exceptions.  (However, `GVariant`’s serialization format is not the same
 as the serialization format of a D-Bus message body: use
 [GDBusMessage](../gio/class.DBusMessage.html), in the GIO library, for those.)
 
 For space-efficiency, the `GVariant` serialization format does not
-automatically include the variant&#x2019;s length, type or endianness,
+automatically include the variant’s length, type or endianness,
 which must either be implied from context (such as knowledge that a
 particular file format always contains a little-endian
 `G_VARIANT_TYPE_VARIANT` which occupies the whole length of the file)
@@ -36656,7 +36656,7 @@ or supplied out-of-band (for instance, a length, type and/or endianness
 indicator could be placed at the beginning of a file, network message
 or network stream).
 
-A `GVariant`&#x2019;s size is limited mainly by any lower level operating
+A `GVariant`’s size is limited mainly by any lower level operating
 system constraints, such as the number of bits in `gsize`.  For
 example, it is reasonable to have a 2GB file mapped into memory
 with [struct@GLib.MappedFile], and call [ctor@GLib.Variant.new_from_data] on
@@ -36691,11 +36691,11 @@ endianness, or of the length or type of the top-level variant.
 
 The amount of memory required to store a boolean is 1 byte. 16,
 32 and 64 bit integers and double precision floating point numbers
-use their &#x2018;natural&#x2019; size.  Strings (including object path and
+use their ‘natural’ size.  Strings (including object path and
 signature strings) are stored with a nul terminator, and as such
 use the length of the string plus 1 byte.
 
-&#x2018;Maybe&#x2019; types use no space at all to represent the null value and
+‘Maybe’ types use no space at all to represent the null value and
 use the same amount of space (sometimes plus one byte) as the
 equivalent non-maybe-typed value to represent the non-null case.
 
@@ -36721,22 +36721,22 @@ As an example, consider a dictionary mapping strings to variants.
 In the case that the dictionary is empty, 0 bytes are required for
 the serialization.
 
-If we add an item &#x2018;width&#x2019; that maps to the int32 value of 500 then
+If we add an item ‘width’ that maps to the int32 value of 500 then
 we will use 4 bytes to store the int32 (so 6 for the variant
 containing it) and 6 bytes for the string.  The variant must be
-aligned to 8 after the 6 bytes of the string, so that&#x2019;s 2 extra
+aligned to 8 after the 6 bytes of the string, so that’s 2 extra
 bytes.  6 (string) + 2 (padding) + 6 (variant) is 14 bytes used
 for the dictionary entry.  An additional 1 byte is added to the
 array as a framing offset making a total of 15 bytes.
 
-If we add another entry, &#x2018;title&#x2019; that maps to a nullable string
+If we add another entry, ‘title’ that maps to a nullable string
 that happens to have a value of null, then we use 0 bytes for the
 null value (and 3 bytes for the variant to contain it along with
 its type string) plus 6 bytes for the string.  Again, we need 2
 padding bytes.  That makes a total of 6 + 2 + 3 = 11 bytes.
 
 We now require extra padding between the two items in the array.
-After the 14 bytes of the first item, that&#x2019;s 2 bytes required.
+After the 14 bytes of the first item, that’s 2 bytes required.
 We now require 2 framing offsets for an extra two
 bytes. 14 + 2 + 11 + 2 = 29 bytes to encode the entire two-item
 dictionary.
@@ -36798,12 +36798,12 @@ even [method@GLib.MappedFile.unref].
 
 One buffer management structure is used for each chunk of
 serialized data.  The size of the buffer management structure
-is `4 * (void *)`.  On 32-bit systems, that&#x2019;s 16 bytes.
+is `4 * (void *)`.  On 32-bit systems, that’s 16 bytes.
 
 ## GVariant structure
 
 The size of a `GVariant` structure is `6 * (void *)`.  On 32-bit
-systems, that&#x2019;s 24 bytes.
+systems, that’s 24 bytes.
 
 `GVariant` structures only exist if they are explicitly created
 with API calls.  For example, if a `GVariant` is constructed out of
@@ -36811,7 +36811,7 @@ serialized data for the example given above (with the dictionary)
 then although there are 9 individual values that comprise the
 entire dictionary (two keys, two values, two variants containing
 the values, two dictionary entries, plus the dictionary itself),
-only 1 `GVariant` instance exists &#x2014; the one referring to the
+only 1 `GVariant` instance exists — the one referring to the
 dictionary.
 
 If calls are made to start accessing the other values then
@@ -38357,7 +38357,7 @@ contain nul bytes.
 If @length is non-%NULL then the length of the string (in bytes) is
 returned there.  For trusted values, this information is already
 known.  Untrusted values will be validated and, if valid, a strlen() will be
-performed. If invalid, a default value will be returned &#x2014; for
+performed. If invalid, a default value will be returned — for
 %G_VARIANT_TYPE_OBJECT_PATH, this is `"/"`, and for other types it is the
 empty string.
 
@@ -39016,9 +39016,9 @@ is returned. It is never floating, and must be freed with
 In case of any error, %NULL will be returned.  If @error is non-%NULL
 then it will be set to reflect the error that occurred.
 
-Officially, the language understood by the parser is &#x201C;any string
-produced by [method@GLib.Variant.print]&#x201D;. This explicitly includes
-`g_variant_print()`&#x2019;s annotated types like `int64 -1000`.
+Officially, the language understood by the parser is “any string
+produced by [method@GLib.Variant.print]”. This explicitly includes
+`g_variant_print()`’s annotated types like `int64 -1000`.
 
 There may be implementation specific restrictions on deeply nested values,
 which would result in a %G_VARIANT_PARSE_ERROR_RECURSION error. #GVariant is
@@ -40300,33 +40300,33 @@ therefore, provides a significant amount of
 information that is useful when working with [type@GLib.Variant].
 
 The first major change with respect to the D-Bus type system is the
-introduction of maybe (or &#x2018;nullable&#x2019;) types.  Any type in [type@GLib.Variant]
+introduction of maybe (or ‘nullable’) types.  Any type in [type@GLib.Variant]
 can be converted to a maybe type, in which case, `nothing` (or `null`)
 becomes a valid value.  Maybe types have been added by introducing the
 character `m` to type strings.
 
 The second major change is that the [type@GLib.Variant] type system supports
-the concept of &#x2018;indefinite types&#x2019; &#x2014; types that are less specific than
+the concept of ‘indefinite types’ — types that are less specific than
 the normal types found in D-Bus.  For example, it is possible to speak
-of &#x2018;an array of any type&#x2019; in [type@GLib.Variant], where the D-Bus type system
-would require you to speak of &#x2018;an array of integers&#x2019; or &#x2018;an array of
-strings&#x2019;.  Indefinite types have been added by introducing the
+of ‘an array of any type’ in [type@GLib.Variant], where the D-Bus type system
+would require you to speak of ‘an array of integers’ or ‘an array of
+strings’.  Indefinite types have been added by introducing the
 characters `*`, `?` and `r` to type strings.
 
 Finally, all arbitrary restrictions relating to the complexity of
 types are lifted along with the restriction that dictionary entries
 may only appear nested inside of arrays.
 
-Just as in D-Bus, [type@GLib.Variant] types are described with strings (&#x2018;type
-strings&#x2019;).  Subject to the differences mentioned above, these strings
+Just as in D-Bus, [type@GLib.Variant] types are described with strings (‘type
+strings’).  Subject to the differences mentioned above, these strings
 are of the same form as those found in D-Bus.  Note, however: D-Bus
 always works in terms of messages and therefore individual type
-strings appear nowhere in its interface.  Instead, &#x2018;signatures&#x2019;
+strings appear nowhere in its interface.  Instead, ‘signatures’
 are a concatenation of the strings of the type of each argument in a
 message.  [type@GLib.Variant] deals with single values directly so
 [type@GLib.Variant] type strings always describe the type of exactly one
 value.  This means that a D-Bus signature string is generally not a valid
-[type@GLib.Variant] type string &#x2014; except in the case that it is the signature
+[type@GLib.Variant] type string — except in the case that it is the signature
 of a message containing exactly one argument.
 
 An indefinite type is similar in spirit to what may be called an
@@ -40335,11 +40335,11 @@ indefinite type as its type, but values can exist that have types
 that are subtypes of indefinite types.  That is to say,
 [method@GLib.Variant.get_type] will never return an indefinite type, but
 calling [method@GLib.Variant.is_of_type] with an indefinite type may return
-true.  For example, you cannot have a value that represents &#x2018;an
-array of no particular type&#x2019;, but you can have an &#x2018;array of integers&#x2019;
-which certainly matches the type of &#x2018;an array of no particular type&#x2019;,
-since &#x2018;array of integers&#x2019; is a subtype of &#x2018;array of no particular
-type&#x2019;.
+true.  For example, you cannot have a value that represents ‘an
+array of no particular type’, but you can have an ‘array of integers’
+which certainly matches the type of ‘an array of no particular type’,
+since ‘array of integers’ is a subtype of ‘array of no particular
+type’.
 
 This is similar to how instances of abstract classes may not
 directly exist in other type systems, but instances of their
@@ -40405,8 +40405,8 @@ The meaning of each of the characters is as follows:
 - `a`: used as a prefix on another type string to mean an array of that
   type; the type string `ai`, for example, is the type of an array of
   signed 32-bit integers.
-- `m`: used as a prefix on another type string to mean a &#x2018;maybe&#x2019;, or
-  &#x2018;nullable&#x2019;, version of that type; the type string `ms`, for example,
+- `m`: used as a prefix on another type string to mean a ‘maybe’, or
+  ‘nullable’, version of that type; the type string `ms`, for example,
   is the type of a value that maybe contains a string, or maybe contains
   nothing.
 - `()`: used to enclose zero or more other concatenated type strings to
@@ -40426,7 +40426,7 @@ The meaning of each of the characters is as follows:
 - `*`: the type string of `G_VARIANT_TYPE_ANY`; the indefinite type that is
   a supertype of all types.  Note that, as with all type strings, this
   character represents exactly one type. It cannot be used inside of tuples
-  to mean &#x2018;any number of items&#x2019;.
+  to mean ‘any number of items’.
 
 Any type string of a container that contains an indefinite type is,
 itself, an indefinite type. For example, the type string `a*`
@@ -40499,12 +40499,12 @@ Since 2.24</doc>
         </parameters>
       </constructor>
       <constructor name="new_maybe" c:identifier="g_variant_type_new_maybe">
-        <doc xml:space="preserve">Constructs the type corresponding to a &#x2018;maybe&#x2019; instance containing
+        <doc xml:space="preserve">Constructs the type corresponding to a ‘maybe’ instance containing
 type @type or `Nothing`.
 
 It is appropriate to call [method@GLib.VariantType.free] on the return value.</doc>
         <return-value transfer-ownership="full">
-          <doc xml:space="preserve">a new &#x2018;maybe&#x2019; type
+          <doc xml:space="preserve">a new ‘maybe’ type
 Since 2.24</doc>
           <type name="VariantType" c:type="GVariantType*"/>
         </return-value>
@@ -40575,9 +40575,9 @@ Since 2.24</doc>
         </parameters>
       </method>
       <method name="element" c:identifier="g_variant_type_element">
-        <doc xml:space="preserve">Determines the element type of an array or &#x2018;maybe&#x2019; type.
+        <doc xml:space="preserve">Determines the element type of an array or ‘maybe’ type.
 
-This function may only be used with array or &#x2018;maybe&#x2019; types.</doc>
+This function may only be used with array or ‘maybe’ types.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the element type of @type
 Since 2.24</doc>
@@ -40585,7 +40585,7 @@ Since 2.24</doc>
         </return-value>
         <parameters>
           <instance-parameter name="type" transfer-ownership="none">
-            <doc xml:space="preserve">an array or &#x2018;maybe&#x2019; type</doc>
+            <doc xml:space="preserve">an array or ‘maybe’ type</doc>
             <type name="VariantType" c:type="const GVariantType*"/>
           </instance-parameter>
         </parameters>
@@ -40704,7 +40704,7 @@ Since 2.24</doc>
 This is true if the type string for @type starts with an `a`.
 
 This function returns true for any indefinite type for which every
-definite subtype is an array type &#x2014; `G_VARIANT_TYPE_ARRAY`, for
+definite subtype is an array type — `G_VARIANT_TYPE_ARRAY`, for
 example.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">true if @type is an array type
@@ -40747,7 +40747,7 @@ Container types are any array, maybe, tuple, or dictionary
 entry types plus the variant type.
 
 This function returns true for any indefinite type for which every
-definite subtype is a container &#x2014; `G_VARIANT_TYPE_ARRAY`, for
+definite subtype is a container — `G_VARIANT_TYPE_ARRAY`, for
 example.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">true if @type is a container type
@@ -40790,7 +40790,7 @@ Since 2.24</doc>
 This is true if the type string for @type starts with a `{`.
 
 This function returns true for any indefinite type for which every
-definite subtype is a dictionary entry type &#x2014;
+definite subtype is a dictionary entry type —
 `G_VARIANT_TYPE_DICT_ENTRY`, for example.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">true if @type is a dictionary entry type
@@ -40805,15 +40805,15 @@ Since 2.24</doc>
         </parameters>
       </method>
       <method name="is_maybe" c:identifier="g_variant_type_is_maybe">
-        <doc xml:space="preserve">Determines if the given @type is a &#x2018;maybe&#x2019; type.
+        <doc xml:space="preserve">Determines if the given @type is a ‘maybe’ type.
 
 This is true if the type string for @type starts with an `m`.
 
 This function returns true for any indefinite type for which every
-definite subtype is a &#x2018;maybe&#x2019; type &#x2014; `G_VARIANT_TYPE_MAYBE`, for
+definite subtype is a ‘maybe’ type — `G_VARIANT_TYPE_MAYBE`, for
 example.</doc>
         <return-value transfer-ownership="none">
-          <doc xml:space="preserve">true if @type is a &#x2018;maybe&#x2019; type
+          <doc xml:space="preserve">true if @type is a ‘maybe’ type
 Since 2.24</doc>
           <type name="gboolean" c:type="gboolean"/>
         </return-value>
@@ -40853,7 +40853,7 @@ This is true if the type string for @type starts with a `(` or if @type is
 `G_VARIANT_TYPE_TUPLE`.
 
 This function returns true for any indefinite type for which every
-definite subtype is a tuple type &#x2014; `G_VARIANT_TYPE_TUPLE`, for
+definite subtype is a tuple type — `G_VARIANT_TYPE_TUPLE`, for
 example.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">true if @type is a tuple type
@@ -41194,10 +41194,10 @@ also clear the allocated memory before returning it.</doc>
 
 If @mem is %NULL this is a no-op (and @size is ignored).
 
-It is an error if @size doesn&#x2019;t match the size, or @alignment doesn&#x2019;t match
+It is an error if @size doesn’t match the size, or @alignment doesn’t match
 the alignment, passed when @mem was allocated. @size and @alignment are
 passed to this function to allow optimizations in the allocator. If you
-don&#x2019;t know either of them, use g_aligned_free() instead.</doc>
+don’t know either of them, use g_aligned_free() instead.</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
       </return-value>
@@ -44571,8 +44571,8 @@ need greater control.</doc>
       </return-value>
       <parameters>
         <parameter name="pid" transfer-ownership="none">
-          <doc xml:space="preserve">process to watch &#x2014; on POSIX systems, this is the positive PID of a
-  child process; on Windows it is a handle for a process (which doesn&#x2019;t have
+          <doc xml:space="preserve">process to watch — on POSIX systems, this is the positive PID of a
+  child process; on Windows it is a handle for a process (which doesn’t have
   to be a child)</doc>
           <type name="Pid" c:type="GPid"/>
         </parameter>
@@ -44624,8 +44624,8 @@ need greater control.</doc>
           <type name="gint" c:type="gint"/>
         </parameter>
         <parameter name="pid" transfer-ownership="none">
-          <doc xml:space="preserve">process to watch &#x2014; on POSIX systems, this is the positive PID of a
-  child process; on Windows it is a handle for a process (which doesn&#x2019;t have
+          <doc xml:space="preserve">process to watch — on POSIX systems, this is the positive PID of a
+  child process; on Windows it is a handle for a process (which doesn’t have
   to be a child)</doc>
           <type name="Pid" c:type="GPid"/>
         </parameter>
@@ -44673,7 +44673,7 @@ due to limitations in POSIX process interfaces:
   watched @pid in a race free manner. Since 2.78, you can do that while the
   associated [struct@GLib.MainContext] is acquired.
 * Before 2.78, even after destroying the [struct@GLib.Source], you could not
-  be sure that @pid wasn&#x2019;t already reaped. Hence, it was also not
+  be sure that @pid wasn’t already reaped. Hence, it was also not
   safe to `kill()` or `waitpid()` on the process ID after the child watch
   source was gone. Destroying the source before it fired made it
   impossible to reliably reap the process.
@@ -44690,8 +44690,8 @@ remains a valid thing to do.</doc>
       </return-value>
       <parameters>
         <parameter name="pid" transfer-ownership="none">
-          <doc xml:space="preserve">process to watch &#x2014; on POSIX systems, this is the positive PID of a
-  child process; on Windows it is a handle for a process (which doesn&#x2019;t have
+          <doc xml:space="preserve">process to watch — on POSIX systems, this is the positive PID of a
+  child process; on Windows it is a handle for a process (which doesn’t have
   to be a child)</doc>
           <type name="Pid" c:type="GPid"/>
         </parameter>
@@ -44897,7 +44897,7 @@ destroy_sync (void *sync)
   glDeleteSync (sync);
 }
 
-// &#x2026;
+// …
 
 g_clear_pointer (&amp;sync, destroy_sync);
 ```</doc>
@@ -45400,7 +45400,7 @@ See your C library manual for more details about creat().</doc>
       </parameters>
     </function>
     <function-macro name="critical" c:identifier="g_critical" introspectable="0">
-      <doc xml:space="preserve">Logs a &#x2018;critical warning&#x2019; ([flags@GLib.LogLevelFlags.LEVEL_CRITICAL]).
+      <doc xml:space="preserve">Logs a ‘critical warning’ ([flags@GLib.LogLevelFlags.LEVEL_CRITICAL]).
 
 Critical warnings are intended to be used in the event of an error
 that originated in the current process (a programmer error).
@@ -45424,7 +45424,7 @@ Any unrelated failures can be skipped over in
 [gdb](https://www.gnu.org/software/gdb/) using the `continue` command.
 
 The message should typically *not* be translated to the
-user&#x2019;s language.
+user’s language.
 
 If [func@GLib.log_default_handler] is used as the log handler function, a new-line
 character will automatically be appended to @..., and need not be entered
@@ -46111,7 +46111,7 @@ The result depends on which day is considered the first day of the week,
 which varies by locale. `first_day_of_week` must be valid.
 
 The result will be either 52 or 53. Years always have 52 seven-day periods,
-plus one or two extra days depending on whether it&#x2019;s a leap year. This
+plus one or two extra days depending on whether it’s a leap year. This
 function effectively calculates how many @first_day_of_week days there are in
 the year.</doc>
       <return-value transfer-ownership="none">
@@ -46308,7 +46308,7 @@ dcgettext() directly.</doc>
     <function-macro name="debug" c:identifier="g_debug" version="2.6" introspectable="0">
       <doc xml:space="preserve">A convenience function/macro to log a debug message.
 
-The message should typically *not* be translated to the user&#x2019;s language.
+The message should typically *not* be translated to the user’s language.
 
 If [func@GLib.log_default_handler] is used as the log handler function, a new-line
 character will automatically be appended to @..., and need not be entered
@@ -46671,7 +46671,7 @@ environment @envp.</doc>
     <function-macro name="error" c:identifier="g_error" introspectable="0">
       <doc xml:space="preserve">A convenience function/macro to log an error message.
 
-The message should typically *not* be translated to the user&#x2019;s language.
+The message should typically *not* be translated to the user’s language.
 
 This is not intended for end user error reporting. Use of [type@GLib.Error] is
 preferred for that instead, as it allows calling functions to perform actions
@@ -46679,7 +46679,7 @@ conditional on the type of error.
 
 Error messages are always fatal, resulting in a call to [func@GLib.BREAKPOINT]
 to terminate the application. This function will
-result in a core dump; don&#x2019;t use it for errors you expect.
+result in a core dump; don’t use it for errors you expect.
 Using this function indicates a bug in your program, i.e.
 an assertion failure.
 
@@ -46936,7 +46936,7 @@ wrapper around calling g_file_set_contents_full() with `flags` set to
       <doc xml:space="preserve">Writes all of @contents to a file named @filename, with good error checking.
 If a file called @filename already exists it will be overwritten.
 
-@flags control the properties of the write operation: whether it&#x2019;s atomic,
+@flags control the properties of the write operation: whether it’s atomic,
 and what the tradeoff is between returning quickly or being resilient to
 system crashes.
 
@@ -46984,7 +46984,7 @@ Possible error codes are those in the #GFileError enumeration.
 Note that the name for the temporary file is constructed by appending up
 to 7 characters to @filename.
 
-If the file didn&#x2019;t exist before and is created, it will be given the
+If the file didn’t exist before and is created, it will be given the
 permissions from @mode. Otherwise, the permissions of the existing file will
 remain unchanged.</doc>
       <return-value transfer-ownership="none">
@@ -47367,7 +47367,7 @@ string.  Sizes are rounded to the nearest size prefix (kB, MB, GB)
 and are displayed rounded to the nearest tenth. E.g. the file size
 3292528 bytes will be converted into the string "3.2 MB". The returned string
 is UTF-8, and may use a non-breaking space to separate the number and units,
-to ensure they aren&#x2019;t separated when line wrapped.
+to ensure they aren’t separated when line wrapped.
 
 The prefix units base is 1000 (i.e. 1 kB is 1000 bytes).
 
@@ -47486,9 +47486,9 @@ against %NULL before calling this function.</doc>
 
 If @mem is %NULL this is a no-op (and @size is ignored).
 
-It is an error if @size doesn&#x2019;t match the size passed when @mem was
+It is an error if @size doesn’t match the size passed when @mem was
 allocated. @size is passed to this function to allow optimizations in the
-allocator. If you don&#x2019;t know the allocation size, use g_free() instead.
+allocator. If you don’t know the allocation size, use g_free() instead.
 
 In case a GCC compatible compiler is used, this function may be used
 automatically via g_free() if the allocated size is known at compile time,
@@ -47862,7 +47862,7 @@ use g_get_language_names().</doc>
     <function name="get_monotonic_time" c:identifier="g_get_monotonic_time" version="2.28">
       <doc xml:space="preserve">Queries the system monotonic time in microseconds.
 
-The monotonic clock will always increase and doesn&#x2019;t suffer
+The monotonic clock will always increase and doesn’t suffer
 discontinuities when the user (or NTP) changes the system time.  It
 may or may not continue to tick during times where the machine is
 suspended.
@@ -47882,7 +47882,7 @@ A more accurate version of this function exists.
     <function name="get_monotonic_time_ns" c:identifier="g_get_monotonic_time_ns" version="2.88">
       <doc xml:space="preserve">Queries the system monotonic time in nanoseconds.
 
-The monotonic clock will always increase and doesn&#x2019;t suffer
+The monotonic clock will always increase and doesn’t suffer
 discontinuities when the user (or NTP) changes the system time.  It
 may or may not continue to tick during times where the machine is
 suspended.
@@ -47907,7 +47907,7 @@ used as a parameter to g_thread_pool_new() for CPU bound tasks and
 similar cases.
 
 On platforms where enough information is known, this will be the number of
-high performance cores and will not include low power &#x2018;efficiency&#x2019; cores.
+high performance cores and will not include low power ‘efficiency’ cores.
 Use platform specific APIs to query for low power cores if needed.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">Number of schedulable threads, always greater than 0</doc>
@@ -47997,7 +47997,7 @@ FOLDERID_ProgramData folder. This information will not roam and is available
 to anyone using the computer.
 
 The return value is cached and modifying it at runtime is not supported, as
-it&#x2019;s not thread-safe to modify environment variables at runtime.</doc>
+it’s not thread-safe to modify environment variables at runtime.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">
     a %NULL-terminated array of strings owned by GLib that must not be
@@ -48041,7 +48041,7 @@ Note that on Windows the returned list can vary depending on where
 this function is called.
 
 The return value is cached and modifying it at runtime is not supported, as
-it&#x2019;s not thread-safe to modify environment variables at runtime.</doc>
+it’s not thread-safe to modify environment variables at runtime.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">
     a %NULL-terminated array of strings owned by GLib that must not be
@@ -48087,7 +48087,7 @@ repository for temporary Internet files is used instead. A typical path is
 See the [documentation for `FOLDERID_InternetCache`](https://docs.microsoft.com/en-us/windows/win32/shell/knownfolderid).
 
 The return value is cached and modifying it at runtime is not supported, as
-it&#x2019;s not thread-safe to modify environment variables at runtime.</doc>
+it’s not thread-safe to modify environment variables at runtime.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">a string owned by GLib that
   must not be modified or freed.</doc>
@@ -48111,7 +48111,7 @@ Note that in this case on Windows it will be  the same
 as what g_get_user_data_dir() returns.
 
 The return value is cached and modifying it at runtime is not supported, as
-it&#x2019;s not thread-safe to modify environment variables at runtime.</doc>
+it’s not thread-safe to modify environment variables at runtime.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">a string owned by GLib that
   must not be modified or freed.</doc>
@@ -48135,7 +48135,7 @@ Note that in this case on Windows it will be the same
 as what g_get_user_config_dir() returns.
 
 The return value is cached and modifying it at runtime is not supported, as
-it&#x2019;s not thread-safe to modify environment variables at runtime.</doc>
+it’s not thread-safe to modify environment variables at runtime.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">a string owned by GLib that must
   not be modified or freed.</doc>
@@ -48165,7 +48165,7 @@ In the case that this variable is not set, we return the value of
 g_get_user_cache_dir(), after verifying that it exists.
 
 The return value is cached and modifying it at runtime is not supported, as
-it&#x2019;s not thread-safe to modify environment variables at runtime.</doc>
+it’s not thread-safe to modify environment variables at runtime.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">a string owned by GLib that must not be
     modified or freed.</doc>
@@ -48213,7 +48213,7 @@ Note that in this case on Windows it will be the same
 as what g_get_user_data_dir() returns.
 
 The return value is cached and modifying it at runtime is not supported, as
-it&#x2019;s not thread-safe to modify environment variables at runtime.</doc>
+it’s not thread-safe to modify environment variables at runtime.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">a string owned by GLib that
   must not be modified or freed.</doc>
@@ -49316,7 +49316,7 @@ This function otherwise behaves like [func@GLib.idle_add].</doc>
       </return-value>
       <parameters>
         <parameter name="data" transfer-ownership="none" nullable="1" allow-none="1">
-          <doc xml:space="preserve">the data for the idle source&#x2019;s callback.</doc>
+          <doc xml:space="preserve">the data for the idle source’s callback.</doc>
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
       </parameters>
@@ -49943,11 +49943,11 @@ are fatal. See [Using Structured Logging](logging.html#using-structured-logging)
       <doc xml:space="preserve">Enable or disable debug output from the GLib logging system for all domains.
 
 This value interacts disjunctively with `G_MESSAGES_DEBUG`, `DEBUG_INVOCATION` and
-[func@GLib.log_writer_default_set_debug_domains] &#x2014; if any of them would allow
+[func@GLib.log_writer_default_set_debug_domains] — if any of them would allow
 a debug message to be outputted, it will be.
 
 Note that this should not be used from within library code to enable debug
-output &#x2014; it is intended for external use.</doc>
+output — it is intended for external use.</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
       </return-value>
@@ -50123,7 +50123,7 @@ message.
 Each program should set a writer function, or the default writer
 ([func@GLib.log_writer_default]) will be used.
 
-Libraries **must not** call this function &#x2014; only programs are allowed to
+Libraries **must not** call this function — only programs are allowed to
 install a writer function, as there must be a single, central point where
 log messages are formatted and outputted.
 
@@ -50141,7 +50141,7 @@ There can only be one writer function. It is an error to set more than one.</doc
           <type name="gpointer" c:type="gpointer"/>
         </parameter>
         <parameter name="user_data_free" transfer-ownership="none" scope="async">
-          <doc xml:space="preserve">function to free @user_data once it&#x2019;s
+          <doc xml:space="preserve">function to free @user_data once it’s
    finished with, if non-`NULL`</doc>
           <type name="DestroyNotify" c:type="GDestroyNotify"/>
         </parameter>
@@ -50158,8 +50158,8 @@ is [flags@GLib.LogLevelFlags.LEVEL_ERROR]), the program will be aborted by calli
 See the documentation for [type@GLib.LogWriterFunc] for information on chaining
 writers.
 
-The structured data is provided as key&#x2013;value pairs, where keys are UTF-8
-strings, and values are arbitrary pointers &#x2014; typically pointing to UTF-8
+The structured data is provided as key–value pairs, where keys are UTF-8
+strings, and values are arbitrary pointers — typically pointing to UTF-8
 strings, but that is not a requirement. To pass binary (non-nul-terminated)
 structured data, use [func@GLib.log_structured_array]. The keys for structured data
 should follow the [systemd journal
@@ -50280,7 +50280,7 @@ This assumes that @log_level is already present in @fields (typically as the
           <type name="LogLevelFlags" c:type="GLogLevelFlags"/>
         </parameter>
         <parameter name="fields" transfer-ownership="none">
-          <doc xml:space="preserve">key&#x2013;value pairs of structured data to add
+          <doc xml:space="preserve">key–value pairs of structured data to add
    to the log message</doc>
           <array length="2" zero-terminated="0" c:type="const GLogField*">
             <type name="LogField" c:type="GLogField"/>
@@ -50391,7 +50391,7 @@ up to the writer function to determine which log messages are fatal.</doc>
           <type name="LogLevelFlags" c:type="GLogLevelFlags"/>
         </parameter>
         <parameter name="fields" transfer-ownership="none">
-          <doc xml:space="preserve">key&#x2013;value pairs of structured data forming
+          <doc xml:space="preserve">key–value pairs of structured data forming
    the log message</doc>
           <array length="2" zero-terminated="0" c:type="const GLogField*">
             <type name="LogField" c:type="GLogField"/>
@@ -50479,7 +50479,7 @@ if (!g_log_writer_default_would_drop (G_LOG_LEVEL_DEBUG, G_LOG_DOMAIN))
   }
 ```</doc>
       <return-value transfer-ownership="none">
-        <doc xml:space="preserve">`TRUE` if the log message would be dropped by GLib&#x2019;s
+        <doc xml:space="preserve">`TRUE` if the log message would be dropped by GLib’s
   default log handlers</doc>
         <type name="gboolean" c:type="gboolean"/>
       </return-value>
@@ -50519,7 +50519,7 @@ UTF-8.</doc>
           <type name="LogLevelFlags" c:type="GLogLevelFlags"/>
         </parameter>
         <parameter name="fields" transfer-ownership="none">
-          <doc xml:space="preserve">key&#x2013;value pairs of structured data forming
+          <doc xml:space="preserve">key–value pairs of structured data forming
    the log message</doc>
           <array length="2" zero-terminated="0" c:type="const GLogField*">
             <type name="LogField" c:type="GLogField"/>
@@ -50560,7 +50560,7 @@ is_journald = g_log_writer_is_journald (fileno (stderr));
     </function>
     <function name="log_writer_journald" c:identifier="g_log_writer_journald" version="2.50">
       <doc xml:space="preserve">Format a structured log message and send it to the systemd journal as a set
-of key&#x2013;value pairs.
+of key–value pairs.
 
 All fields are sent to the journal, but if a field has
 length zero (indicating program-specific data) then only its key will be
@@ -50581,7 +50581,7 @@ defined, but will always return [enum@GLib.LogWriterOutput.UNHANDLED].</doc>
           <type name="LogLevelFlags" c:type="GLogLevelFlags"/>
         </parameter>
         <parameter name="fields" transfer-ownership="none">
-          <doc xml:space="preserve">key&#x2013;value pairs of structured data forming
+          <doc xml:space="preserve">key–value pairs of structured data forming
    the log message</doc>
           <array length="2" zero-terminated="0" c:type="const GLogField*">
             <type name="LogField" c:type="GLogField"/>
@@ -50627,7 +50627,7 @@ This is suitable for use as a [type@GLib.LogWriterFunc].</doc>
           <type name="LogLevelFlags" c:type="GLogLevelFlags"/>
         </parameter>
         <parameter name="fields" transfer-ownership="none">
-          <doc xml:space="preserve">key&#x2013;value pairs of structured data forming
+          <doc xml:space="preserve">key–value pairs of structured data forming
    the log message</doc>
           <array length="2" zero-terminated="0" c:type="const GLogField*">
             <type name="LogField" c:type="GLogField"/>
@@ -50683,7 +50683,7 @@ return [enum@GLib.LogWriterOutput.UNHANDLED].</doc>
           <type name="LogLevelFlags" c:type="GLogLevelFlags"/>
         </parameter>
         <parameter name="fields" transfer-ownership="none">
-          <doc xml:space="preserve">key&#x2013;value pairs of structured data forming
+          <doc xml:space="preserve">key–value pairs of structured data forming
    the log message</doc>
           <array length="2" zero-terminated="0" c:type="const GLogField*">
             <type name="LogField" c:type="GLogField"/>
@@ -50802,7 +50802,7 @@ See your C library manual for more details about lstat().</doc>
 
 This is the main context
 used for main loop functions when a main loop is not explicitly
-specified, and corresponds to the &#x2018;main&#x2019; main loop. See also
+specified, and corresponds to the ‘main’ main loop. See also
 [func@GLib.MainContext.get_thread_default].</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the global-default main context.</doc>
@@ -50863,7 +50863,7 @@ a callback to a recursive call to [method@GLib.MainContext.iteration],
 it returns `2`. And so forth.
 
 This function is useful in a situation like the following:
-Imagine an extremely simple &#x2018;garbage collected&#x2019; system.
+Imagine an extremely simple ‘garbage collected’ system.
 
 ```c
 static GList *free_list;
@@ -50899,7 +50899,7 @@ This works from an application, however, if you want to do the same
 thing from a library, it gets more difficult, since you no longer
 control the main loop. You might think you can simply use an idle
 function to make the call to `free_allocated_memory()`, but that
-doesn&#x2019;t work, since the idle function could be called from a
+doesn’t work, since the idle function could be called from a
 recursive callback. This can be fixed by using [func@GLib.main_depth]
 
 ```c
@@ -50939,10 +50939,10 @@ There is a temptation to use [func@GLib.main_depth] to solve
 problems with reentrancy. For instance, while waiting for data
 to be received from the network in response to a menu item,
 the menu item might be selected again. It might seem that
-one could make the menu item&#x2019;s callback return immediately
+one could make the menu item’s callback return immediately
 and do nothing if [func@GLib.main_depth] returns a value greater than 1.
 However, this should be avoided since the user then sees selecting
-the menu item do nothing. Furthermore, you&#x2019;ll find yourself adding
+the menu item do nothing. Furthermore, you’ll find yourself adding
 these checks all over your code, since there are doubtless many,
 many things that the user could do. Instead, you can use the
 following techniques:
@@ -50951,7 +50951,7 @@ following techniques:
    the user from interacting with elements while the main
    loop is recursing.
 
-2. Avoid main loop recursion in situations where you can&#x2019;t handle
+2. Avoid main loop recursion in situations where you can’t handle
    arbitrary  callbacks. Instead, structure your code so that you
    simply return to the main loop and then get called again when
    there is more work to do.</doc>
@@ -51329,7 +51329,7 @@ profiling tools instead</doc-deprecated>
       <doc xml:space="preserve">Allocates @byte_size bytes of memory, and copies @byte_size bytes into it
 from @mem. If @mem is `NULL` it returns `NULL`.</doc>
       <doc-deprecated xml:space="preserve">Use [func@GLib.memdup2] instead, as it accepts a gsize argument
-  for @byte_size, avoiding the possibility of overflow in a `gsize` &#x2192; `guint`
+  for @byte_size, avoiding the possibility of overflow in a `gsize` → `guint`
   conversion</doc-deprecated>
       <return-value transfer-ownership="full" nullable="1">
         <doc xml:space="preserve">a pointer to the newly-allocated copy of the memory</doc>
@@ -52249,7 +52249,7 @@ requires reverse matches.
 
 Note that, if the user code will (possibly) match a string against a
 multitude of patterns containing wildcards, chances are high that
-some patterns will require a reversed string. In this case, it&#x2019;s
+some patterns will require a reversed string. In this case, it’s
 more efficient to provide the reversed string to avoid multiple
 constructions thereof in the various calls to `g_pattern_match()`.
 
@@ -52286,7 +52286,7 @@ does not contain any multibyte characters. GLib offers the
       <doc xml:space="preserve">Matches a string against a pattern given as a string.
 
 If this
-function is to be called in a loop, it&#x2019;s more efficient to compile
+function is to be called in a loop, it’s more efficient to compile
 the pattern once with [ctor@GLib.PatternSpec.new] and call
 [method@GLib.PatternSpec.match_string] repeatedly.</doc>
       <return-value transfer-ownership="none">
@@ -52741,7 +52741,7 @@ g_prefix_error().</doc>
     </function>
     <function name="ptr_array_find" c:identifier="g_ptr_array_find" moved-to="PtrArray.find" version="2.54" introspectable="0">
       <doc xml:space="preserve">Checks whether @needle exists in @haystack. If the element is found, true
-is returned and the element&#x2019;s index is returned in @index_ (if non-`NULL`).
+is returned and the element’s index is returned in @index_ (if non-`NULL`).
 Otherwise, false is returned and @index_ is undefined. If @needle exists
 multiple times in @haystack, the index of the first instance is returned.
 
@@ -52772,7 +52772,7 @@ checks, such as string comparisons, use
     </function>
     <function name="ptr_array_find_with_equal_func" c:identifier="g_ptr_array_find_with_equal_func" moved-to="PtrArray.find_with_equal_func" version="2.54" introspectable="0">
       <doc xml:space="preserve">Checks whether @needle exists in @haystack, using the given @equal_func.
-If the element is found, true is returned and the element&#x2019;s index is
+If the element is found, true is returned and the element’s index is
 returned in @index_ (if non-`NULL`). Otherwise, false is returned and @index_
 is undefined. If @needle exists multiple times in @haystack, the index of
 the first instance is returned.
@@ -52824,7 +52824,7 @@ so you are responsible for checking it against the array length.</doc>
     </function-macro>
     <function name="ptr_array_new_from_array" c:identifier="g_ptr_array_new_from_array" moved-to="PtrArray.new_from_array" version="2.76" introspectable="0">
       <doc xml:space="preserve">Creates a new `GPtrArray`, copying @len pointers from @data, and setting
-the array&#x2019;s reference count to 1.
+the array’s reference count to 1.
 
 This avoids having to manually add each element one by one.
 
@@ -54566,7 +54566,7 @@ they are passed through literally.
 Possible errors are those from the %G_SHELL_ERROR domain.
 
 In particular, if @command_line is an empty string (or a string containing
-only whitespace), %G_SHELL_ERROR_EMPTY_STRING will be returned. It&#x2019;s
+only whitespace), %G_SHELL_ERROR_EMPTY_STRING will be returned. It’s
 guaranteed that @argvp will be a non-empty array if this function returns
 successfully.
 
@@ -54602,7 +54602,7 @@ quoted string to mean @unquoted_string.
 
 If you pass a filename or other untrusted input to [func@GLib.shell_parse_argv],
 you should first quote it with this function. This is sufficient to ensure
-untrusted input cannot &#x2018;break out&#x2019; of the quotes. Beware: this only works
+untrusted input cannot ‘break out’ of the quotes. Beware: this only works
 because [func@GLib.shell_parse_argv] is not a real Unix shell. Quoting untrusted
 input is not an adequate security mechanism when using a real shell.
 
@@ -56011,7 +56011,7 @@ See your C library manual for more details about stat().</doc>
 
 Conceptually, this transfers the ownership of the file descriptor
 from the referenced variable to the caller of the function (i.e.
-&#x2018;steals&#x2019; the reference). This is very similar to [func@GLib.steal_pointer],
+‘steals’ the reference). This is very similar to [func@GLib.steal_pointer],
 but for file descriptors.
 
 On POSIX platforms, this function is async-signal safe
@@ -56035,7 +56035,7 @@ This function preserves the value of `errno`.</doc>
       <doc xml:space="preserve">Sets @handle_pointer to `0`, returning the value that was there before.
 
 Conceptually, this transfers the ownership of the handle ID from the
-referenced variable to the &#x2018;caller&#x2019; of the macro (ie: &#x2018;steals&#x2019; the
+referenced variable to the ‘caller’ of the macro (ie: ‘steals’ the
 handle ID).
 
 This can be very useful to make ownership transfer explicit, or to prevent
@@ -56049,7 +56049,7 @@ maybe_unsubscribe_signal (ContextStruct *data)
     {
       g_dbus_connection_signal_unsubscribe (data-&gt;connection,
                                             g_steal_handle_id (&amp;data-&gt;subscription_id));
-      // now data-&gt;subscription_id isn&#x2019;t a dangling handle
+      // now data-&gt;subscription_id isn’t a dangling handle
     }
 }
 ```
@@ -56263,11 +56263,11 @@ your corpus and build an index on the returned folded tokens, then
 call `g_str_tokenize_and_fold()` on the search term and
 perform lookups into that index.
 
-As some examples, searching for &#x2018;fred&#x2019; would match the potential hit
-&#x2018;Smith, Fred&#x2019; and also &#x2018;Fr&#xE9;d&#xE9;ric&#x2019;.  Searching for &#x2018;Fr&#xE9;d&#x2019; would match
-&#x2018;Fr&#xE9;d&#xE9;ric&#x2019; but not &#x2018;Frederic&#x2019; (due to the one-directional nature of
-accent matching).  Searching &#x2018;fo&#x2019; would match &#x2018;Foo&#x2019; and &#x2018;Bar Foo
-Baz&#x2019;, but not &#x2018;SFO&#x2019; (because no word has &#x2018;fo&#x2019; as a prefix).</doc>
+As some examples, searching for ‘fred’ would match the potential hit
+‘Smith, Fred’ and also ‘Frédéric’.  Searching for ‘Fréd’ would match
+‘Frédéric’ but not ‘Frederic’ (due to the one-directional nature of
+accent matching).  Searching ‘fo’ would match ‘Foo’ and ‘Bar Foo
+Baz’, but not ‘SFO’ (because no word has ‘fo’ as a prefix).</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">true if @potential_hit is a hit</doc>
         <type name="gboolean" c:type="gboolean"/>
@@ -56375,7 +56375,7 @@ g_ascii_strup (g_strcanon (str, "abc", '?'))
 In order to modify a copy, you may use [func@GLib.strdup]:
 ```C
 reformatted = g_strcanon (g_strdup (const_str), "abc", '?');
-&#x2026;
+…
 g_free (reformatted);
 ```</doc>
       <return-value transfer-ownership="full">
@@ -56486,14 +56486,14 @@ Comparing two `NULL` pointers returns 0.</doc>
       <doc xml:space="preserve">Makes a copy of a string replacing C string-style escape
 sequences with their one byte equivalent:
 
-- `\b` &#x2192; [U+0008 Backspace](https://en.wikipedia.org/wiki/Backspace)
-- `\f` &#x2192; [U+000C Form Feed](https://en.wikipedia.org/wiki/Form_feed)
-- `\n` &#x2192; [U+000A Line Feed](https://en.wikipedia.org/wiki/Newline)
-- `\r` &#x2192; [U+000D Carriage Return](https://en.wikipedia.org/wiki/Carriage_return)
-- `\t` &#x2192; [U+0009 Horizontal Tabulation](https://en.wikipedia.org/wiki/Tab_character)
-- `\v` &#x2192; [U+000B Vertical Tabulation](https://en.wikipedia.org/wiki/Vertical_Tab)
-- `\` followed by one to three octal digits &#x2192; the numeric value (mod 256)
-- `\` followed by any other character &#x2192; the character as is.
+- `\b` → [U+0008 Backspace](https://en.wikipedia.org/wiki/Backspace)
+- `\f` → [U+000C Form Feed](https://en.wikipedia.org/wiki/Form_feed)
+- `\n` → [U+000A Line Feed](https://en.wikipedia.org/wiki/Newline)
+- `\r` → [U+000D Carriage Return](https://en.wikipedia.org/wiki/Carriage_return)
+- `\t` → [U+0009 Horizontal Tabulation](https://en.wikipedia.org/wiki/Tab_character)
+- `\v` → [U+000B Vertical Tabulation](https://en.wikipedia.org/wiki/Vertical_Tab)
+- `\` followed by one to three octal digits → the numeric value (mod 256)
+- `\` followed by any other character → the character as is.
   For example, `\\` will turn into a backslash (`\`) and `\"` into a double quote (`"`).
 
 [func@GLib.strescape] does the reverse conversion.</doc>
@@ -56548,7 +56548,7 @@ g_ascii_strup (g_strdelimit (str, "abc", '?'))
 In order to modify a copy, you may use [func@GLib.strdup]:
 ```C
 reformatted = g_strdelimit (g_strdup (const_str), "abc", '?');
-&#x2026;
+…
 g_free (reformatted);
 ```</doc>
       <return-value transfer-ownership="full">
@@ -56574,7 +56574,7 @@ g_free (reformatted);
     <function name="strdown" c:identifier="g_strdown" deprecated="1" deprecated-version="2.2">
       <doc xml:space="preserve">Converts a string to lower case.</doc>
       <doc-deprecated xml:space="preserve">This function is totally broken for the reasons discussed
-  in the [func@GLib.strncasecmp] docs &#x2014; use [func@GLib.ascii_strdown] or
+  in the [func@GLib.strncasecmp] docs — use [func@GLib.ascii_strdown] or
   [func@GLib.utf8_strdown] instead.</doc-deprecated>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the string</doc>
@@ -56681,7 +56681,7 @@ such process".
 Unlike `strerror()`, this always returns a string in
 UTF-8 encoding, and the pointer is guaranteed to remain valid for
 the lifetime of the process. If the error code is unknown, it returns a
-string like &#x201C;Unknown error &lt;code\&gt;&#x201D;.
+string like “Unknown error &lt;code\&gt;”.
 
 Note that the string may be translated according to the current locale.
 
@@ -57042,7 +57042,7 @@ a historical artifact.</doc>
     </function>
     <function name="strsignal" c:identifier="g_strsignal">
       <doc xml:space="preserve">Returns a string describing the given signal, e.g. "Segmentation fault".
-If the signal is unknown, it returns &#x201C;unknown signal (&lt;signum\&gt;)&#x201D;.
+If the signal is unknown, it returns “unknown signal (&lt;signum\&gt;)”.
 
 You should use this function in preference to `strsignal()`, because it
 returns a string in UTF-8 encoding, and since not all platforms support
@@ -57154,7 +57154,7 @@ to delimit UTF-8 strings for anything but ASCII characters.</doc>
 of the string @needle, limiting the length of the search
 to @haystack_len or a nul terminator byte (whichever is reached first).
 
-A length of `-1` can be used to mean &#x201C;search the entire string&#x201D;, like
+A length of `-1` can be used to mean “search the entire string”, like
 `strstr()`.
 
 The fact that this function returns `gchar *` rather than `const gchar *` is
@@ -57222,7 +57222,7 @@ point in some locales, causing unexpected results.</doc>
     <function name="strup" c:identifier="g_strup" deprecated="1" deprecated-version="2.2">
       <doc xml:space="preserve">Converts a string to upper case.</doc>
       <doc-deprecated xml:space="preserve">This function is totally broken for the reasons discussed
-  in the [func@GLib.strncasecmp] docs &#x2014; use [func@GLib.ascii_strup] or
+  in the [func@GLib.strncasecmp] docs — use [func@GLib.ascii_strup] or
   [func@GLib.utf8_strup] instead.</doc-deprecated>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">the string</doc>
@@ -57352,7 +57352,7 @@ required via the `-p` command-line option or [func@GLib.test_trap_subprocess].
 
 No component of @testpath may start with a dot (`.`) if the
 [const@GLib.TEST_OPTION_ISOLATE_DIRS] option is being used;
-and it is recommended to do so even if it isn&#x2019;t.</doc>
+and it is recommended to do so even if it isn’t.</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
       </return-value>
@@ -57412,7 +57412,7 @@ required via the `-p` command-line option or [func@GLib.test_trap_subprocess].
 
 No component of @testpath may start with a dot (`.`) if the
 [const@GLib.TEST_OPTION_ISOLATE_DIRS] option is being used; and
-it is recommended to do so even if it isn&#x2019;t.</doc>
+it is recommended to do so even if it isn’t.</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
       </return-value>
@@ -57674,7 +57674,7 @@ g_test_assert_expected_messages ();
 ```
 
 Note that you cannot use this to test [func@GLib.error] messages, since
-[func@GLib.error] intentionally never returns even if the program doesn&#x2019;t
+[func@GLib.error] intentionally never returns even if the program doesn’t
 abort; use [func@GLib.test_trap_subprocess] in this case.
 
 If messages at [flags@GLib.LogLevelFlags.LEVEL_DEBUG] are emitted, but not explicitly
@@ -57782,7 +57782,7 @@ but you don't need to free the return value.</doc>
 This is the same as [func@GLib.test_build_filename] with two differences.
 The first difference is that you must only use this function from within
 a testcase function. The second difference is that you need not free
-the return value &#x2014; it will be automatically freed when the testcase
+the return value — it will be automatically freed when the testcase
 finishes running.
 
 It is safe to use this function from a thread inside of a testcase
@@ -58606,7 +58606,7 @@ ending with "`/subprocess`" if the test only has one child test);
 tests with names of this form will automatically be skipped in the
 parent process.
 
-If @envp is `NULL`, the parent process&#x2019; environment will be inherited.
+If @envp is `NULL`, the parent process’ environment will be inherited.
 
 If @usec_timeout is non-0, the test subprocess is aborted and
 considered failing if its run time exceeds it.
@@ -59058,12 +59058,12 @@ Note that timeout functions may be delayed, due to the processing of other
 event sources. Thus they should not be relied on for precise timing.
 After each call to the timeout function, the time of the next
 timeout is recalculated based on the current time and the given interval
-(it does not try to &#x2018;catch up&#x2019; time lost in delays).
+(it does not try to ‘catch up’ time lost in delays).
 
 See [main loop memory management](main-loop.html#memory-management-of-sources) for details
 on how to handle the return value and memory management of @data.
 
-If you want to have a timer in the &#x2018;seconds&#x2019; range and do not care
+If you want to have a timer in the ‘seconds’ range and do not care
 about the exact time of the first call of the timer, use the
 [func@GLib.timeout_add_seconds] function; this function allows for more
 optimizations and more efficient system power usage.
@@ -59113,7 +59113,7 @@ Note that timeout functions may be delayed, due to the processing of other
 event sources. Thus they should not be relied on for precise timing.
 After each call to the timeout function, the time of the next
 timeout is recalculated based on the current time and the given interval
-(it does not try to &#x2018;catch up&#x2019; time lost in delays).
+(it does not try to ‘catch up’ time lost in delays).
 
 See [main loop memory management](main-loop.html#memory-management-of-sources) for details
 on how to handle the return value and memory management of @data.
@@ -59254,7 +59254,7 @@ If you want timing more precise than whole seconds, use
 
 The grouping of timers to fire at the same time results in a more power
 and CPU efficient behavior so if your timer is in multiples of seconds
-and you don&#x2019;t require the first timer exactly one second from now, the
+and you don’t require the first timer exactly one second from now, the
 use of [func@GLib.timeout_add_seconds] is preferred over
 [func@GLib.timeout_add].
 
@@ -60302,7 +60302,7 @@ terminals support zero-width rendering of zero-width marks.</doc>
       <doc xml:space="preserve">Checks whether @ch is a valid Unicode character.
 
 Some possible integer values of @ch will not be valid. U+0000 is considered a
-valid character, though it&#x2019;s normally a string terminator.</doc>
+valid character, though it’s normally a string terminator.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">`TRUE` if @ch is a valid Unicode character</doc>
         <type name="gboolean" c:type="gboolean"/>
@@ -60518,7 +60518,7 @@ coherent with the passed values, in particular use `%`-encoded values with
 %G_URI_FLAGS_ENCODED.
 
 In contrast to g_uri_build(), this allows specifying the components
-of the &#x2018;userinfo&#x2019; field separately. Note that @user must be non-%NULL
+of the ‘userinfo’ field separately. Note that @user must be non-%NULL
 if either @password or @auth_params is non-%NULL.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">a new #GUri</doc>
@@ -60575,10 +60575,10 @@ if either @password or @auth_params is non-%NULL.</doc>
     <function name="uri_escape_bytes" c:identifier="g_uri_escape_bytes" moved-to="Uri.escape_bytes" version="2.66">
       <doc xml:space="preserve">Escapes arbitrary data for use in a URI.
 
-Normally all characters that are not &#x2018;unreserved&#x2019; (i.e. ASCII
+Normally all characters that are not ‘unreserved’ (i.e. ASCII
 alphanumerical characters plus dash, dot, underscore and tilde) are
 escaped. But if you specify characters in @reserved_chars_allowed
-they are not escaped. This is useful for the &#x2018;reserved&#x2019; characters
+they are not escaped. This is useful for the ‘reserved’ characters
 in the URI specification, since those are allowed unescaped in some
 portions of a URI.
 
@@ -60642,7 +60642,7 @@ returned string should be freed when no longer needed.</doc>
 [absolute URI](#relative-and-absolute-uris), i.e. it does not need to be resolved
 relative to another URI using g_uri_parse_relative().
 
-If it&#x2019;s not a valid URI, an error is returned explaining how it&#x2019;s invalid.
+If it’s not a valid URI, an error is returned explaining how it’s invalid.
 
 See g_uri_split(), and the definition of #GUriFlags, for more
 information on the effect of @flags.</doc>
@@ -60672,7 +60672,7 @@ characters (`//`). See
 [RFC 3986, section 3](https://tools.ietf.org/html/rfc3986#section-3).
 
 See also g_uri_join_with_user(), which allows specifying the
-components of the &#x2018;userinfo&#x2019; separately.
+components of the ‘userinfo’ separately.
 
 %G_URI_FLAGS_HAS_PASSWORD and %G_URI_FLAGS_HAS_AUTH_PARAMS are ignored if set
 in @flags.</doc>
@@ -60721,7 +60721,7 @@ an absolute URI string. @path may not be %NULL (though it may be the empty
 string).
 
 In contrast to g_uri_join(), this allows specifying the components
-of the &#x2018;userinfo&#x2019; separately. It otherwise behaves the same.
+of the ‘userinfo’ separately. It otherwise behaves the same.
 
 %G_URI_FLAGS_HAS_PASSWORD and %G_URI_FLAGS_HAS_AUTH_PARAMS are ignored if set
 in @flags.</doc>
@@ -60832,7 +60832,7 @@ invalid encoding.)
 
 If %G_URI_PARAMS_CASE_INSENSITIVE is passed to @flags, attributes will be
 compared case-insensitively, so a params string `attr=123&amp;Attr=456` will only
-return a single attribute&#x2013;value pair, `Attr=456`. Case will be preserved in
+return a single attribute–value pair, `Attr=456`. Case will be preserved in
 the returned attributes.
 
 If @params cannot be parsed (for example, it contains two @separators
@@ -60879,7 +60879,7 @@ URI = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
 ]|
 Common schemes include `file`, `https`, `svn+ssh`, etc.</doc>
       <return-value transfer-ownership="full" nullable="1">
-        <doc xml:space="preserve">The &#x2018;scheme&#x2019; component of the URI, or
+        <doc xml:space="preserve">The ‘scheme’ component of the URI, or
     %NULL on error. The returned string should be freed when no longer needed.</doc>
         <type name="utf8" c:type="char*"/>
       </return-value>
@@ -60902,7 +60902,7 @@ Common schemes include `file`, `https`, `svn+ssh`, etc.
 Unlike g_uri_parse_scheme(), the returned scheme is normalized to
 all-lowercase and does not need to be freed.</doc>
       <return-value transfer-ownership="none" nullable="1">
-        <doc xml:space="preserve">The &#x2018;scheme&#x2019; component of the URI, or
+        <doc xml:space="preserve">The ‘scheme’ component of the URI, or
     %NULL on error. The returned string is normalized to all-lowercase, and
     interned via g_intern_string(), so it does not need to be freed.</doc>
         <type name="utf8" c:type="const char*"/>
@@ -61282,7 +61282,7 @@ ambiguous endianness.
 Further note that this function does not validate the result
 string; it may (for example) include embedded nul characters. The only
 validation done by this function is to ensure that the input can
-be correctly interpreted as UTF-16, i.e. it doesn&#x2019;t contain
+be correctly interpreted as UTF-16, i.e. it doesn’t contain
 unpaired surrogates or partial character sequences.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">a pointer to a newly allocated UTF-8 string.
@@ -61634,7 +61634,7 @@ step backwards. It is usually worth stepping backwards from the end
 instead of forwards if @offset is in the last fourth of the string,
 since moving forward is about 3 times faster than moving backward.
 
-Note that this function doesn&#x2019;t abort when reaching the end of @str.
+Note that this function doesn’t abort when reaching the end of @str.
 Therefore you should be sure that @offset is within string boundaries
 before calling that function. Call [func@GLib.utf8_strlen] when unsure.
 This limitation exists as this function is called frequently during
@@ -61743,7 +61743,7 @@ characters in the string changing.</doc>
     </function>
     <function name="utf8_strlen" c:identifier="g_utf8_strlen">
       <doc xml:space="preserve">Computes the length of the string in characters, not including
-the terminating nul character. If the @max&#x2019;th byte falls in the
+the terminating nul character. If the @max’th byte falls in the
 middle of a character, the last (partial) character is not counted.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the length of the string in characters</doc>
@@ -62028,8 +62028,8 @@ If @truncate_length is `0`, an empty string is returned.</doc>
 
 If @end is non-`NULL`, then the end of the valid range will be stored there.
 This is the first byte of the first invalid character if some bytes were
-invalid, or the end of the text being validated otherwise &#x2014; either the
-trailing nul byte, or the first byte beyond @max_len (if it&#x2019;s positive).
+invalid, or the end of the text being validated otherwise — either the
+trailing nul byte, or the first byte beyond @max_len (if it’s positive).
 
 Note that `g_utf8_validate()` returns `FALSE` if @max_len is  positive and
 any of the @max_len bytes are nul.
@@ -62213,9 +62213,9 @@ is returned. It is never floating, and must be freed with
 In case of any error, %NULL will be returned.  If @error is non-%NULL
 then it will be set to reflect the error that occurred.
 
-Officially, the language understood by the parser is &#x201C;any string
-produced by [method@GLib.Variant.print]&#x201D;. This explicitly includes
-`g_variant_print()`&#x2019;s annotated types like `int64 -1000`.
+Officially, the language understood by the parser is “any string
+produced by [method@GLib.Variant.print]”. This explicitly includes
+`g_variant_print()`’s annotated types like `int64 -1000`.
 
 There may be implementation specific restrictions on deeply nested values,
 which would result in a %G_VARIANT_PARSE_ERROR_RECURSION error. #GVariant is
@@ -62567,7 +62567,7 @@ and [func@GLib.warn_if_fail] macros.</doc>
     <function-macro name="warning" c:identifier="g_warning" introspectable="0">
       <doc xml:space="preserve">A convenience function/macro to log a warning message.
 
-The message should typically *not* be translated to the user&#x2019;s language.
+The message should typically *not* be translated to the user’s language.
 
 This is not intended for end user error reporting. Use of [type@GLib.Error] is
 preferred for that instead, as it allows calling functions to perform actions

--- a/GLibUnix-2.0.gir
+++ b/GLibUnix-2.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -303,7 +303,7 @@ specify a non-default priority and a provide a #GDestroyNotify for
       <doc xml:space="preserve">Creates a #GSource to watch for a particular I/O condition on a file
 descriptor.
 
-The source will never close the @fd &#x2014; you must do it yourself.
+The source will never close the @fd — you must do it yourself.
 
 Any callback attached to the returned #GSource must have type
 #GUnixFDSourceFunc.</doc>
@@ -350,7 +350,7 @@ See [`signal(7)`](man:signal(7)) and
     </function>
     <function name="get_passwd_entry" c:identifier="g_unix_get_passwd_entry" version="2.64" throws="1">
       <doc xml:space="preserve">Get the `passwd` file entry for the given @user_name using `getpwnam_r()`.
-This can fail if the given @user_name doesn&#x2019;t exist.
+This can fail if the given @user_name doesn’t exist.
 
 The returned `struct passwd` has been allocated using g_malloc() and should
 be freed using g_free(). The strings referenced by the returned struct are
@@ -378,7 +378,7 @@ uses the pipe2() system call, which atomically creates a pipe with
 the configured flags.
 
 As of GLib 2.78, the supported flags are `O_CLOEXEC`/`FD_CLOEXEC` (see below)
-and `O_NONBLOCK`. Prior to GLib 2.78, only `FD_CLOEXEC` was supported &#x2014; if
+and `O_NONBLOCK`. Prior to GLib 2.78, only `FD_CLOEXEC` was supported — if
 you wanted to configure `O_NONBLOCK` then that had to be done separately with
 `fcntl()`.
 

--- a/GLibWin32-2.0.gir
+++ b/GLibWin32-2.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -84,8 +84,8 @@ The error code could be as returned by
 [`GetLastError()`](https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror)
 or [`WSAGetLastError()`](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-wsagetlasterror).
 
-The message is either language neutral, or in the thread&#x2019;s language, or the
-user&#x2019;s language, the system&#x2019;s language, or US English (see documentation for
+The message is either language neutral, or in the thread’s language, or the
+user’s language, the system’s language, or US English (see documentation for
 [`FormatMessage()`](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessagew)).
 The returned string is in UTF-8.
 

--- a/GModule-2.0.gir
+++ b/GModule-2.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -824,7 +824,7 @@ and/or use gtk-doc annotations.  -->
 It should only be accessed via the following functions.
 
 To ensure correct lock ordering, these functions must not be called from
-global constructors (for example, those using GCC&#x2019;s
+global constructors (for example, those using GCC’s
 `__attribute__((constructor))` attribute).</doc>
       <method name="close" c:identifier="g_module_close">
         <doc xml:space="preserve">Closes a module.</doc>

--- a/GObject-2.0.gir
+++ b/GObject-2.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -7304,7 +7304,7 @@ operation, for user data on an object.
 If the previous value was replaced then ownership of the
 old value (@oldval) is passed to the caller, including
 the registered destroy notify for it (passed out in @old_destroy).
-It&#x2019;s up to the caller to free this as needed, which may
+It’s up to the caller to free this as needed, which may
 or may not include using @old_destroy as sometimes replacement
 should not destroy the object in the normal way.
 
@@ -7353,7 +7353,7 @@ operation, for user data on an object.
 If the previous value was replaced then ownership of the
 old value (@oldval) is passed to the caller, including
 the registered destroy notify for it (passed out in @old_destroy).
-It&#x2019;s up to the caller to free this as needed, which may
+It’s up to the caller to free this as needed, which may
 or may not include using @old_destroy as sometimes replacement
 should not destroy the object in the normal way.</doc>
         <return-value transfer-ownership="none">
@@ -7442,7 +7442,7 @@ the old association will be destroyed.
 
 Internally, the @key is converted to a #GQuark using g_quark_from_string().
 This means a copy of @key is kept permanently (even after @object has been
-finalized) &#x2014; so it is recommended to only use a small, bounded set of values
+finalized) — so it is recommended to only use a small, bounded set of values
 for @key in your program, to avoid the #GQuark storage growing unbounded.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -7859,7 +7859,7 @@ Use #GWeakRef if thread-safety is required.</doc>
         <doc xml:space="preserve">The notify signal is emitted on an object when one of its properties has
 its value set through g_object_set_property(), g_object_set(), et al.
 
-Note that getting this signal doesn&#x2019;t itself guarantee that the value of
+Note that getting this signal doesn’t itself guarantee that the value of
 the property has actually changed. When it is emitted is determined by the
 derived GObject class. If the implementor did not create the property with
 %G_PARAM_EXPLICIT_NOTIFY, then any call to g_object_set_property() results
@@ -8755,7 +8755,7 @@ for signal naming (see [func@GObject.signal_new]).
 
 When creating and looking up a `GParamSpec`, either separator can be
 used, but they cannot be mixed. Using `-` is considerably more
-efficient, and is the &#x2018;canonical form&#x2019;. Using `_` is discouraged.</doc>
+efficient, and is the ‘canonical form’. Using `_` is discouraged.</doc>
       <function name="internal" c:identifier="g_param_spec_internal" introspectable="0">
         <doc xml:space="preserve">Creates a new #GParamSpec instance.
 
@@ -10799,7 +10799,7 @@ fundamental types built into GLib are classed.
 
 Interfaces are not classed: while their #GTypeInterface struct could be
 considered similar to #GTypeClass, and classes can derive interfaces,
-#GTypeInterface doesn&#x2019;t allow for subclassing.</doc>
+#GTypeInterface doesn’t allow for subclassing.</doc>
       <parameters>
         <parameter name="type">
           <doc xml:space="preserve">A #GType value</doc>
@@ -12269,7 +12269,7 @@ to `collect_format`.
 
 The @collect_flags argument provided as a hint by the caller. It may
 contain the flag %G_VALUE_NOCOPY_CONTENTS indicating that the collected
-value contents may be considered &#x2018;static&#x2019; for the duration of the @value
+value contents may be considered ‘static’ for the duration of the @value
 lifetime. Thus an extra copy of the contents stored in @collect_values is
 not required for assignment to @value.
 
@@ -12889,7 +12889,7 @@ and [callback@GObject.TypeValueLCopyFunc].</doc>
       </parameters>
     </function-macro>
     <function-macro name="VALUE_LCOPY" c:identifier="G_VALUE_LCOPY" introspectable="0">
-      <doc xml:space="preserve">Stores a value&#x2019;s value into one or more argument locations from a `va_list`.
+      <doc xml:space="preserve">Stores a value’s value into one or more argument locations from a `va_list`.
 
 This is the inverse of G_VALUE_COLLECT().</doc>
       <parameters>
@@ -12911,10 +12911,10 @@ This is the inverse of G_VALUE_COLLECT().</doc>
       </parameters>
     </function-macro>
     <constant name="VALUE_NOCOPY_CONTENTS" value="134217728" c:type="G_VALUE_NOCOPY_CONTENTS">
-      <doc xml:space="preserve">Flag to indicate that allocated data in a [struct@GObject.Value] shouldn&#x2019;t be
+      <doc xml:space="preserve">Flag to indicate that allocated data in a [struct@GObject.Value] shouldn’t be
 copied.
 
-If passed to [func@GObject.VALUE_COLLECT], allocated data won&#x2019;t be copied
+If passed to [func@GObject.VALUE_COLLECT], allocated data won’t be copied
 but used verbatim. This does not affect ref-counted types like objects.
 
 This does not affect usage of [method@GObject.Value.copy]: the data will
@@ -12995,7 +12995,7 @@ calling [method@GObject.Value.init] on it.
 
 Many types which are stored within a `GValue` need to allocate data on the
 heap, so [method@GObject.Value.unset] must always be called on a `GValue` to
-free any such data once you&#x2019;re finished with the `GValue`, even if the
+free any such data once you’re finished with the `GValue`, even if the
 `GValue` itself is stored on the stack.
 
 The data within the structure has protected scope: it is accessible only
@@ -13404,13 +13404,13 @@ Get the contents of a %G_TYPE_CHAR #GValue.</doc>
 to the initial value for @type.
 
 This must be called before any other methods on a [struct@GObject.Value], so
-the value knows what type it&#x2019;s meant to store.
+the value knows what type it’s meant to store.
 
 ```c
   GValue value = G_VALUE_INIT;
 
   g_value_init (&amp;value, SOME_G_TYPE);
-  &#x2026;
+  …
   g_value_unset (&amp;value);
 ```</doc>
         <return-value transfer-ownership="none">
@@ -13436,7 +13436,7 @@ This calls the [callback@GObject.TypeValueCollectFunc] function for the type
 the [struct@GObject.Value] contains.
 
 Note: The @value will be initialised with the exact type of
-@instance.  If you wish to set the @value&#x2019;s type to a different
+@instance.  If you wish to set the @value’s type to a different
 [type@GObject.Type] (such as a parent class type), you need to manually call
 [method@GObject.Value.init] and [method@GObject.Value.set_instance].</doc>
         <return-value transfer-ownership="none">
@@ -14003,8 +14003,8 @@ of the string. Otherwise the transfer notation would be ambiguous.</doc>
       </method>
       <method name="take_boxed" c:identifier="g_value_take_boxed" version="2.4">
         <doc xml:space="preserve">Sets the contents of a %G_TYPE_BOXED derived #GValue to @v_boxed
-and takes over the ownership of the caller&#x2019;s reference to @v_boxed;
-the caller doesn&#x2019;t have to unref it any more.</doc>
+and takes over the ownership of the caller’s reference to @v_boxed;
+the caller doesn’t have to unref it any more.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14021,8 +14021,8 @@ the caller doesn&#x2019;t have to unref it any more.</doc>
       </method>
       <method name="take_object" c:identifier="g_value_take_object" version="2.4" introspectable="0">
         <doc xml:space="preserve">Sets the contents of a %G_TYPE_OBJECT derived #GValue to @v_object
-and takes over the ownership of the caller&#x2019;s reference to @v_object;
-the caller doesn&#x2019;t have to unref it any more (i.e. the reference
+and takes over the ownership of the caller’s reference to @v_object;
+the caller doesn’t have to unref it any more (i.e. the reference
 count of the object is not increased).
 
 If you want the #GValue to hold its own reference to @v_object, use
@@ -14043,8 +14043,8 @@ g_value_set_object() instead.</doc>
       </method>
       <method name="take_param" c:identifier="g_value_take_param" version="2.4" introspectable="0">
         <doc xml:space="preserve">Sets the contents of a %G_TYPE_PARAM #GValue to @param and takes
-over the ownership of the caller&#x2019;s reference to @param; the caller
-doesn&#x2019;t have to unref it any more.</doc>
+over the ownership of the caller’s reference to @param; the caller
+doesn’t have to unref it any more.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -14131,7 +14131,7 @@ guaranteed over time.</doc>
         </parameters>
       </method>
       <method name="unset" c:identifier="g_value_unset">
-        <doc xml:space="preserve">Clears the current value in @value (if any) and &#x2018;unsets&#x2019; the type.
+        <doc xml:space="preserve">Clears the current value in @value (if any) and ‘unsets’ the type.
 
 This releases all resources associated with this [struct@GObject.Value]. An
 unset value is the same as a cleared (zero-filled)
@@ -14473,7 +14473,7 @@ Since the object is already being disposed when the #GWeakNotify is called,
 there's not much you could do with the object, apart from e.g. using its
 address as hash-index or the like.
 
-In particular, this means it&#x2019;s invalid to call g_object_ref(),
+In particular, this means it’s invalid to call g_object_ref(),
 g_weak_ref_init(), g_weak_ref_set(), g_object_add_toggle_ref(),
 g_object_weak_ref(), g_object_add_weak_pointer() or any function which calls
 them on the object from this callback.</doc>
@@ -14508,7 +14508,7 @@ atomic with respect to invalidation of weak pointers to destroyed
 objects.
 
 If the object's #GObjectClass.dispose method results in additional
-references to the object being held (&#x2018;re-referencing&#x2019;), any #GWeakRefs taken
+references to the object being held (‘re-referencing’), any #GWeakRefs taken
 before it was disposed will continue to point to %NULL.  Any #GWeakRefs taken
 during disposal and after re-referencing, or after disposal has returned due
 to the re-referencing, will continue to point to the object until its refcount
@@ -15876,7 +15876,7 @@ definition  than to write one yourself using g_enum_register_static().</doc>
       </parameters>
     </function>
     <function name="enum_to_string" c:identifier="g_enum_to_string" version="2.54">
-      <doc xml:space="preserve">Pretty-prints @value in the form of the enum&#x2019;s name.
+      <doc xml:space="preserve">Pretty-prints @value in the form of the enum’s name.
 
 This is intended to be used for debugging purposes. The format of the output
 may change in the future.</doc>
@@ -17229,9 +17229,9 @@ The handler will be called synchronously, before the default handler of the sign
 See [memory management of signal handlers](signals.html#memory-management-of-signal-handlers) for
 details on how to handle the return value and memory management of @data.
 
-This function cannot fail. If the given signal name doesn&#x2019;t exist,
+This function cannot fail. If the given signal name doesn’t exist,
 a critical warning is emitted. No validation is performed on the
-&#x2018;detail&#x2019; string when specified in @detailed_signal, other than a
+‘detail’ string when specified in @detailed_signal, other than a
 non-empty check.
 
 Refer to the [signals documentation](signals.html) for more
@@ -17256,9 +17256,9 @@ details.</doc>
 
 The handler will be called synchronously, after the default handler of the signal.
 
-This function cannot fail. If the given signal name doesn&#x2019;t exist,
+This function cannot fail. If the given signal name doesn’t exist,
 a critical warning is emitted. No validation is performed on the
-&#x2018;detail&#x2019; string when specified in @detailed_signal, other than a
+‘detail’ string when specified in @detailed_signal, other than a
 non-empty check.
 
 Refer to the [signals documentation](signals.html) for more
@@ -17284,9 +17284,9 @@ details.</doc>
 If @closure is a floating reference (see g_closure_sink()), this function
 takes ownership of @closure.
 
-This function cannot fail. If the given signal name doesn&#x2019;t exist,
+This function cannot fail. If the given signal name doesn’t exist,
 a critical warning is emitted. No validation is performed on the
-&#x2018;detail&#x2019; string when specified in @detailed_signal, other than a
+‘detail’ string when specified in @detailed_signal, other than a
 non-empty check.
 
 Refer to the [signals documentation](signals.html) for more
@@ -17321,9 +17321,9 @@ details.</doc>
 If @closure is a floating reference (see g_closure_sink()), this function
 takes ownership of @closure.
 
-This function cannot fail. If the given signal name doesn&#x2019;t exist,
+This function cannot fail. If the given signal name doesn’t exist,
 a critical warning is emitted. No validation is performed on the
-&#x2018;detail&#x2019; string when specified in @detailed_signal, other than a
+‘detail’ string when specified in @detailed_signal, other than a
 non-empty check.
 
 Refer to the [signals documentation](signals.html) for more
@@ -17363,9 +17363,9 @@ which will be called when the signal handler is disconnected and no longer
 used. Specify @connect_flags if you need `..._after()` or
 `..._swapped()` variants of this function.
 
-This function cannot fail. If the given signal name doesn&#x2019;t exist,
+This function cannot fail. If the given signal name doesn’t exist,
 a critical warning is emitted. No validation is performed on the
-&#x2018;detail&#x2019; string when specified in @detailed_signal, other than a
+‘detail’ string when specified in @detailed_signal, other than a
 non-empty check.
 
 Refer to the [signals documentation](signals.html) for more
@@ -17411,7 +17411,7 @@ disconnected.  Note that this is not currently threadsafe (ie:
 emitting a signal while @gobject is being destroyed in another thread
 is not safe).
 
-This function cannot fail. If the given signal name doesn&#x2019;t exist,
+This function cannot fail. If the given signal name doesn’t exist,
 a critical warning is emitted. No validation is performed on the
 "detail" string when specified in @detailed_signal, other than a
 non-empty check.
@@ -17474,9 +17474,9 @@ g_signal_connect (button, "clicked",
                   (GCallback) button_clicked_cb, other_widget);
 ]|
 
-This function cannot fail. If the given signal name doesn&#x2019;t exist,
+This function cannot fail. If the given signal name doesn’t exist,
 a critical warning is emitted. No validation is performed on the
-&#x2018;detail&#x2019; string when specified in @detailed_signal, other than a
+‘detail’ string when specified in @detailed_signal, other than a
 non-empty check.
 
 Refer to the [signals documentation](signals.html) for more
@@ -19133,7 +19133,7 @@ includes the type itself, so that e.g. a fundamental type has depth 1.</doc>
       <doc xml:space="preserve">Ensures that the indicated @type has been registered with the
 type system, and its _class_init() method has been run.
 
-Typically, calling the type&#x2019;s `_get_type()` method (or using the
+Typically, calling the type’s `_get_type()` method (or using the
 corresponding macro) will take care of this. In situations where a
 type is looked up dynamically, however, you may need to explicitly call
 `g_type_ensure()` to ensure expected types are registered before the

--- a/Gdk-3.0.gir
+++ b/Gdk-3.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -270,7 +270,7 @@ of strings on the X server.</doc>
           </parameter>
           <parameter name="only_if_exists" transfer-ownership="none">
             <doc xml:space="preserve">if %TRUE, GDK is allowed to not create a new atom, but
-  just return %GDK_NONE if the requested atom doesn&#x2019;t already
+  just return %GDK_NONE if the requested atom doesn’t already
   exists. Currently, the flag is ignored, since checking the
   existance of an atom is as expensive as creating it.</doc>
             <type name="gboolean" c:type="gboolean"/>
@@ -497,7 +497,7 @@ table that stores #GdkColors.</doc>
       </method>
       <method name="to_string" c:identifier="gdk_color_to_string" version="2.12" deprecated="1" deprecated-version="3.14">
         <doc xml:space="preserve">Returns a textual specification of @color in the hexadecimal
-form &#x201C;\#rrrrggggbbbb&#x201D; where &#x201C;r&#x201D;, &#x201C;g&#x201D; and &#x201C;b&#x201D; are hex digits
+form “\#rrrrggggbbbb” where “r”, “g” and “b” are hex digits
 representing the red, green and blue components respectively.
 
 The returned string can be parsed by gdk_color_parse().</doc>
@@ -519,11 +519,11 @@ The returned string can be parsed by gdk_color_parse().</doc>
 
 The string can either one of a large set of standard names
 (taken from the X11 `rgb.txt` file), or it can be a hexadecimal
-value in the form &#x201C;\#rgb&#x201D; &#x201C;\#rrggbb&#x201D;, &#x201C;\#rrrgggbbb&#x201D; or
-&#x201C;\#rrrrggggbbbb&#x201D; where &#x201C;r&#x201D;, &#x201C;g&#x201D; and &#x201C;b&#x201D; are hex digits of
+value in the form “\#rgb” “\#rrggbb”, “\#rrrgggbbb” or
+“\#rrrrggggbbbb” where “r”, “g” and “b” are hex digits of
 the red, green, and blue components of the color, respectively.
-(White in the four forms is &#x201C;\#fff&#x201D;, &#x201C;\#ffffff&#x201D;, &#x201C;\#fffffffff&#x201D;
-and &#x201C;\#ffffffffffff&#x201D;).</doc>
+(White in the four forms is “\#fff”, “\#ffffff”, “\#fffffffff”
+and “\#ffffffffffff”).</doc>
         <doc-deprecated xml:space="preserve">Use #GdkRGBA</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE if the parsing succeeded</doc>
@@ -573,7 +573,7 @@ and &#x201C;\#ffffffffffff&#x201D;).</doc>
       <member name="device_switch" value="8" c:identifier="GDK_CROSSING_DEVICE_SWITCH" glib:nick="device-switch" glib:name="GDK_CROSSING_DEVICE_SWITCH">
         <doc xml:space="preserve">crossing because of a device switch (i.e.
   a mouse taking control of the pointer after a touch device), this event
-  is synthetic as the pointer didn&#x2019;t leave the window.</doc>
+  is synthetic as the pointer didn’t leave the window.</doc>
       </member>
     </enumeration>
     <class name="Cursor" c:symbol-prefix="cursor" c:type="GdkCursor" parent="GObject.Object" abstract="1" glib:type-name="GdkCursor" glib:get-type="gdk_cursor_get_type">
@@ -687,7 +687,7 @@ gdk_display_get_maximal_cursor_size() give information about
 cursor sizes.
 
 If @x or @y are `-1`, the pixbuf must have
-options named &#x201C;x_hot&#x201D; and &#x201C;y_hot&#x201D;, resp., containing
+options named “x_hot” and “y_hot”, resp., containing
 integer values between `0` and the width resp. height of
 the pixbuf. (Since: 3.0)
 
@@ -707,11 +707,11 @@ sufficently new version of the X Render extension.</doc>
             <type name="GdkPixbuf.Pixbuf" c:type="GdkPixbuf*"/>
           </parameter>
           <parameter name="x" transfer-ownership="none">
-            <doc xml:space="preserve">the horizontal offset of the &#x201C;hotspot&#x201D; of the cursor.</doc>
+            <doc xml:space="preserve">the horizontal offset of the “hotspot” of the cursor.</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="y" transfer-ownership="none">
-            <doc xml:space="preserve">the vertical offset of the &#x201C;hotspot&#x201D; of the cursor.</doc>
+            <doc xml:space="preserve">the vertical offset of the “hotspot” of the cursor.</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
         </parameters>
@@ -744,11 +744,11 @@ sufficently new version of the X Render extension.</doc>
             <type name="cairo.Surface" c:type="cairo_surface_t*"/>
           </parameter>
           <parameter name="x" transfer-ownership="none">
-            <doc xml:space="preserve">the horizontal offset of the &#x201C;hotspot&#x201D; of the cursor</doc>
+            <doc xml:space="preserve">the horizontal offset of the “hotspot” of the cursor</doc>
             <type name="gdouble" c:type="gdouble"/>
           </parameter>
           <parameter name="y" transfer-ownership="none">
-            <doc xml:space="preserve">the vertical offset of the &#x201C;hotspot&#x201D; of the cursor</doc>
+            <doc xml:space="preserve">the vertical offset of the “hotspot” of the cursor</doc>
             <type name="gdouble" c:type="gdouble"/>
           </parameter>
         </parameters>
@@ -1695,7 +1695,7 @@ it. See gdk_device_get_vendor_id() for more information.</doc>
       </method>
       <method name="get_state" c:identifier="gdk_device_get_state" introspectable="0">
         <doc xml:space="preserve">Gets the current state of a pointer device relative to @window. As a slave
-device&#x2019;s coordinates are those of its master pointer, this
+device’s coordinates are those of its master pointer, this
 function may not be called on devices of type %GDK_DEVICE_TYPE_SLAVE,
 unless there is an ongoing grab on them. See gdk_device_grab().</doc>
         <return-value transfer-ownership="none">
@@ -1851,8 +1851,8 @@ events that are emitted when the grab ends unvoluntarily.</doc>
           <instance-parameter name="device" transfer-ownership="none">
             <doc xml:space="preserve">a #GdkDevice. To get the device you can use gtk_get_current_event_device()
   or gdk_event_get_device() if the grab is in reaction to an event. Also, you can use
-  gdk_device_manager_get_client_pointer() but only in code that isn&#x2019;t triggered by a
-  #GdkEvent and there aren&#x2019;t other means to get a meaningful #GdkDevice to operate on.</doc>
+  gdk_device_manager_get_client_pointer() but only in code that isn’t triggered by a
+  #GdkEvent and there aren’t other means to get a meaningful #GdkDevice to operate on.</doc>
             <type name="Device" c:type="GdkDevice*"/>
           </instance-parameter>
           <parameter name="window" transfer-ownership="none">
@@ -1887,7 +1887,7 @@ events that are emitted when the grab ends unvoluntarily.</doc>
           <parameter name="time_" transfer-ownership="none">
             <doc xml:space="preserve">the timestamp of the event which led to this pointer grab. This
         usually comes from the #GdkEvent struct, though %GDK_CURRENT_TIME
-        can be used if the time isn&#x2019;t known.</doc>
+        can be used if the time isn’t known.</doc>
             <type name="guint32" c:type="guint32"/>
           </parameter>
         </parameters>
@@ -1976,7 +1976,7 @@ is pressed.</doc>
       </method>
       <method name="set_mode" c:identifier="gdk_device_set_mode">
         <doc xml:space="preserve">Sets a the mode of an input device. The mode controls if the
-device is active and whether the device&#x2019;s range is mapped to the
+device is active and whether the device’s range is mapped to the
 entire screen or to a single window.
 
 Note: This is only meaningful for floating devices, master devices (and
@@ -2166,8 +2166,8 @@ Unless gdk_disable_multidevice() is called, the XInput 2
 #GdkDeviceManager implementation will be used as the input source.
 Otherwise either the core or XInput 1 implementations will be used.
 
-For simple applications that don&#x2019;t have any special interest in
-input devices, the so-called &#x201C;client pointer&#x201D;
+For simple applications that don’t have any special interest in
+input devices, the so-called “client pointer”
 provides a reasonable approximation to a simple setup with a single
 pointer and keyboard. The device that has been set as the client
 pointer can be accessed via gdk_device_manager_get_client_pointer().
@@ -2184,27 +2184,27 @@ gdk_device_get_associated_device().
 
 There may be several virtual devices, and several physical devices could
 be controlling each of these virtual devices. Physical devices may also
-be &#x201C;floating&#x201D;, which means they are not attached to any virtual device.
+be “floating”, which means they are not attached to any virtual device.
 
 # Master and slave devices
 
 |[
 carlos@sacarino:~$ xinput list
-&#x23A1; Virtual core pointer                          id=2    [master pointer  (3)]
-&#x239C;   &#x21B3; Virtual core XTEST pointer                id=4    [slave  pointer  (2)]
-&#x239C;   &#x21B3; Wacom ISDv4 E6 Pen stylus                 id=10   [slave  pointer  (2)]
-&#x239C;   &#x21B3; Wacom ISDv4 E6 Finger touch               id=11   [slave  pointer  (2)]
-&#x239C;   &#x21B3; SynPS/2 Synaptics TouchPad                id=13   [slave  pointer  (2)]
-&#x239C;   &#x21B3; TPPS/2 IBM TrackPoint                     id=14   [slave  pointer  (2)]
-&#x239C;   &#x21B3; Wacom ISDv4 E6 Pen eraser                 id=16   [slave  pointer  (2)]
-&#x23A3; Virtual core keyboard                         id=3    [master keyboard (2)]
-    &#x21B3; Virtual core XTEST keyboard               id=5    [slave  keyboard (3)]
-    &#x21B3; Power Button                              id=6    [slave  keyboard (3)]
-    &#x21B3; Video Bus                                 id=7    [slave  keyboard (3)]
-    &#x21B3; Sleep Button                              id=8    [slave  keyboard (3)]
-    &#x21B3; Integrated Camera                         id=9    [slave  keyboard (3)]
-    &#x21B3; AT Translated Set 2 keyboard              id=12   [slave  keyboard (3)]
-    &#x21B3; ThinkPad Extra Buttons                    id=15   [slave  keyboard (3)]
+⎡ Virtual core pointer                          id=2    [master pointer  (3)]
+⎜   ↳ Virtual core XTEST pointer                id=4    [slave  pointer  (2)]
+⎜   ↳ Wacom ISDv4 E6 Pen stylus                 id=10   [slave  pointer  (2)]
+⎜   ↳ Wacom ISDv4 E6 Finger touch               id=11   [slave  pointer  (2)]
+⎜   ↳ SynPS/2 Synaptics TouchPad                id=13   [slave  pointer  (2)]
+⎜   ↳ TPPS/2 IBM TrackPoint                     id=14   [slave  pointer  (2)]
+⎜   ↳ Wacom ISDv4 E6 Pen eraser                 id=16   [slave  pointer  (2)]
+⎣ Virtual core keyboard                         id=3    [master keyboard (2)]
+    ↳ Virtual core XTEST keyboard               id=5    [slave  keyboard (3)]
+    ↳ Power Button                              id=6    [slave  keyboard (3)]
+    ↳ Video Bus                                 id=7    [slave  keyboard (3)]
+    ↳ Sleep Button                              id=8    [slave  keyboard (3)]
+    ↳ Integrated Camera                         id=9    [slave  keyboard (3)]
+    ↳ AT Translated Set 2 keyboard              id=12   [slave  keyboard (3)]
+    ↳ ThinkPad Extra Buttons                    id=15   [slave  keyboard (3)]
 ]|
 
 By default, GDK will automatically listen for events coming from all
@@ -2244,7 +2244,7 @@ device that is routing events through it. Whenever the physical device
 changes, the #GdkDevice:n-axes property will be notified, and
 gdk_device_list_axes() will return the new device axes.
 
-Devices may also have associated &#x201C;keys&#x201D; or
+Devices may also have associated “keys” or
 macro buttons. Such keys can be globally set to map into normal X
 keyboard events. The mapping is set using gdk_device_set_key().
 
@@ -2256,8 +2256,8 @@ written code.</doc>
 for this application. In X11, window managers may change this depending on the interaction
 pattern under the presence of several pointers.
 
-You should use this function seldomly, only in code that isn&#x2019;t triggered by a #GdkEvent
-and there aren&#x2019;t other means to get a meaningful #GdkDevice to operate on.</doc>
+You should use this function seldomly, only in code that isn’t triggered by a #GdkEvent
+and there aren’t other means to get a meaningful #GdkDevice to operate on.</doc>
         <doc-deprecated xml:space="preserve">Use gdk_seat_get_pointer() instead.</doc-deprecated>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">The client pointer. This memory is
@@ -2953,7 +2953,7 @@ mask for a given display.</doc>
       <method name="get_primary_monitor" c:identifier="gdk_display_get_primary_monitor" version="3.22">
         <doc xml:space="preserve">Gets the primary monitor for the display.
 
-The primary monitor is considered the monitor where the &#x201C;main desktop&#x201D;
+The primary monitor is considered the monitor where the “main desktop”
 lives. While normal application windows typically allow the window
 manager to place the windows, specialized desktop applications
 such as panels should place themselves on the primary monitor.</doc>
@@ -3118,7 +3118,7 @@ disable that feature.</doc>
         </parameters>
       </method>
       <method name="peek_event" c:identifier="gdk_display_peek_event" version="2.2">
-        <doc xml:space="preserve">Gets a copy of the first #GdkEvent in the @display&#x2019;s event queue, without
+        <doc xml:space="preserve">Gets a copy of the first #GdkEvent in the @display’s event queue, without
 removing the event from the queue.  (Note that this function will
 not get more events from the windowing system.  It only checks the events
 that have already been moved to the GDK event queue.)</doc>
@@ -3280,7 +3280,7 @@ according to the
       </method>
       <method name="supports_clipboard_persistence" c:identifier="gdk_display_supports_clipboard_persistence" version="2.6">
         <doc xml:space="preserve">Returns whether the speicifed display supports clipboard
-persistance; i.e. if it&#x2019;s possible to store the clipboard data after an
+persistance; i.e. if it’s possible to store the clipboard data after an
 application has quit. On X11 this checks if a clipboard daemon is
 running.</doc>
         <return-value transfer-ownership="none">
@@ -3669,7 +3669,7 @@ should do with the dropped data.</doc>
       </member>
       <member name="private" value="16" c:identifier="GDK_ACTION_PRIVATE" glib:nick="private" glib:name="GDK_ACTION_PRIVATE">
         <doc xml:space="preserve">Special action which tells the source that the
- destination will do something that the source doesn&#x2019;t understand.</doc>
+ destination will do something that the source doesn’t understand.</doc>
       </member>
       <member name="ask" value="32" c:identifier="GDK_ACTION_ASK" glib:nick="ask" glib:name="GDK_ACTION_ASK">
         <doc xml:space="preserve">Ask the user what to do with the data.</doc>
@@ -4286,7 +4286,7 @@ will be returned in @x and @y.</doc>
       </method>
       <method name="copy" c:identifier="gdk_event_copy">
         <doc xml:space="preserve">Copies a #GdkEvent, copying or incrementing the reference count of the
-resources associated with it (e.g. #GdkWindow&#x2019;s and strings).</doc>
+resources associated with it (e.g. #GdkWindow’s and strings).</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a copy of @event. The returned #GdkEvent should be freed with
 gdk_event_free().</doc>
@@ -4392,7 +4392,7 @@ an event structure.</doc>
         </parameters>
       </method>
       <method name="get_device" c:identifier="gdk_event_get_device" version="3.0">
-        <doc xml:space="preserve">If the event contains a &#x201C;device&#x201D; field, this function will return
+        <doc xml:space="preserve">If the event contains a “device” field, this function will return
 it, else it will return %NULL.</doc>
         <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">a #GdkDevice, or %NULL.</doc>
@@ -4655,7 +4655,7 @@ gdk_event_get_scroll_deltas(); for instance:
       <method name="get_source_device" c:identifier="gdk_event_get_source_device" version="3.0">
         <doc xml:space="preserve">This function returns the hardware (slave) #GdkDevice that has
 triggered the event, falling back to the virtual (master) device
-(as in gdk_event_get_device()) if the event wasn&#x2019;t caused by
+(as in gdk_event_get_device()) if the event wasn’t caused by
 interaction with a hardware device. This may happen for example
 in synthesized crossing events after a #GdkWindow updates its
 geometry or a grab is acquired/released.
@@ -4674,9 +4674,9 @@ return %NULL.</doc>
         </parameters>
       </method>
       <method name="get_state" c:identifier="gdk_event_get_state">
-        <doc xml:space="preserve">If the event contains a &#x201C;state&#x201D; field, puts that field in @state. Otherwise
+        <doc xml:space="preserve">If the event contains a “state” field, puts that field in @state. Otherwise
 stores an empty state (0). Returns %TRUE if there was a state field
-in the event. @event may be %NULL, in which case it&#x2019;s treated
+in the event. @event may be %NULL, in which case it’s treated
 as if the event had no state field.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE if there was a state field in the event</doc>
@@ -4741,7 +4741,7 @@ Stop scroll events always have a a delta of 0/0.</doc>
       </method>
       <method name="put" c:identifier="gdk_event_put">
         <doc xml:space="preserve">Appends a copy of the given event onto the front of the event
-queue for event-&gt;any.window&#x2019;s display, or the default event
+queue for event-&gt;any.window’s display, or the default event
 queue if event-&gt;any.window is %NULL. See gdk_display_put_event().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -5185,7 +5185,7 @@ redrawn.</doc>
       </field>
       <field name="count" writable="1">
         <doc xml:space="preserve">the number of contiguous %GDK_EXPOSE events following this one.
-  The only use for this is &#x201C;exposure compression&#x201D;, i.e. handling all
+  The only use for this is “exposure compression”, i.e. handling all
   contiguous %GDK_EXPOSE events in one go, though GDK performs some
   exposure compression so this is not normally needed.</doc>
         <type name="gint" c:type="gint"/>
@@ -5659,11 +5659,11 @@ extension.</doc>
       </field>
     </record>
     <record name="EventProximity" c:type="GdkEventProximity">
-      <doc xml:space="preserve">Proximity events are generated when using GDK&#x2019;s wrapper for the
+      <doc xml:space="preserve">Proximity events are generated when using GDK’s wrapper for the
 XInput extension. The XInput extension is an add-on for standard X
 that allows you to use nonstandard devices such as graphics tablets.
 A proximity event indicates that the stylus has moved in or out of
-contact with the tablet, or perhaps that the user&#x2019;s finger has moved
+contact with the tablet, or perhaps that the user’s finger has moved
 in or out of contact with a touch screen.
 
 This event type will be used pretty rarely. It only is important for
@@ -5695,7 +5695,7 @@ gdk_event_get_source_device() to get the slave device.</doc>
 usually configured to generate button press events for buttons 4 and 5
 when the wheel is turned.
 
-Some GDK backends can also generate &#x201C;smooth&#x201D; scroll events, which
+Some GDK backends can also generate “smooth” scroll events, which
 can be recognized by the %GDK_SCROLL_SMOOTH scroll direction. For
 these, the scroll deltas can be obtained with
 gdk_event_get_scroll_deltas().</doc>
@@ -6353,7 +6353,7 @@ timescale as g_get_monotonic_time(), however, it is not the same
 as g_get_monotonic_time(). The frame time does not advance during
 the time a frame is being painted, and outside of a frame, an attempt
 is made so that all calls to gdk_frame_clock_get_frame_time() that
-are called at a &#x201C;similar&#x201D; time get the same value. This means that
+are called at a “similar” time get the same value. This means that
 if different animations are timed by looking at the difference in
 time between an initial value from gdk_frame_clock_get_frame_time()
 and the value inside the #GdkFrameClock::update signal of the clock,
@@ -6422,10 +6422,10 @@ each frame drawn.</doc>
       </method>
       <method name="get_frame_time" c:identifier="gdk_frame_clock_get_frame_time" version="3.8">
         <doc xml:space="preserve">Gets the time that should currently be used for animations.  Inside
-the processing of a frame, it&#x2019;s the time used to compute the
+the processing of a frame, it’s the time used to compute the
 animation position of everything in a frame. Outside of a frame, it's
-the time of the conceptual &#x201C;previous frame,&#x201D; which may be either
-the actual previous frame time, or if that&#x2019;s too old, an updated
+the time of the conceptual “previous frame,” which may be either
+the actual previous frame time, or if that’s too old, an updated
 time.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a timestamp in microseconds, in the timescale of
@@ -6632,11 +6632,11 @@ correspond to the signals of #GdkFrameClock.</doc>
     <record name="FrameClockPrivate" c:type="GdkFrameClockPrivate" disguised="1" opaque="1"/>
     <record name="FrameTimings" c:type="GdkFrameTimings" opaque="1" glib:type-name="GdkFrameTimings" glib:get-type="gdk_frame_timings_get_type" c:symbol-prefix="frame_timings">
       <doc xml:space="preserve">A #GdkFrameTimings object holds timing information for a single frame
-of the application&#x2019;s displays. To retrieve #GdkFrameTimings objects,
+of the application’s displays. To retrieve #GdkFrameTimings objects,
 use gdk_frame_clock_get_timings() or gdk_frame_clock_get_current_timings().
 The information in #GdkFrameTimings is useful for precise synchronization
 of video with the event or audio streams, and for measuring
-quality metrics for the application&#x2019;s display, such as latency and jitter.</doc>
+quality metrics for the application’s display, such as latency and jitter.</doc>
       <method name="get_complete" c:identifier="gdk_frame_timings_get_complete" version="3.8">
         <doc xml:space="preserve">The timing information in a #GdkFrameTimings is filled in
 incrementally as the frame as drawn and passed off to the
@@ -6731,7 +6731,7 @@ became visible to the user.</doc>
       <method name="get_refresh_interval" c:identifier="gdk_frame_timings_get_refresh_interval" version="3.8">
         <doc xml:space="preserve">Gets the natural interval between presentation times for
 the display that this frame was displayed on. Frame presentation
-usually happens during the &#x201C;vertical blanking interval&#x201D;.</doc>
+usually happens during the “vertical blanking interval”.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the refresh interval of the display, in microseconds,
  or 0 if the refresh interval is not available.
@@ -7162,7 +7162,7 @@ OpenGL ES API, extensions, or shaders.</doc>
     </function-macro>
     <record name="Geometry" c:type="GdkGeometry">
       <doc xml:space="preserve">The #GdkGeometry struct gives the window manager information about
-a window&#x2019;s geometry constraints. Normally you would set these on
+a window’s geometry constraints. Normally you would set these on
 the GTK+ level using gtk_window_set_geometry_hints(). #GtkWindow
 then sets the hints on the #GdkWindow it creates.
 
@@ -7187,10 +7187,10 @@ scrollbar. Then, the @width_inc and @height_inc fields should be set to the
 size of one character in the terminal. Finally, the base size should be set
 to the size of one character. The net effect is that the minimum size of the
 terminal will have a 1x1 character terminal area, and only terminal sizes on
-the &#x201C;character grid&#x201D; will be allowed.
+the “character grid” will be allowed.
 
-Here&#x2019;s an example of how the terminal example would be implemented, assuming
-a terminal area widget called &#x201C;terminal&#x201D; and a toplevel window &#x201C;toplevel&#x201D;:
+Here’s an example of how the terminal example would be implemented, assuming
+a terminal area widget called “terminal” and a toplevel window “toplevel”:
 
 |[&lt;!-- language="C" --&gt;
 	GdkGeometry hints;
@@ -7270,13 +7270,13 @@ aspect ratio.</doc>
     <enumeration name="GrabOwnership" glib:type-name="GdkGrabOwnership" glib:get-type="gdk_grab_ownership_get_type" c:type="GdkGrabOwnership">
       <doc xml:space="preserve">Defines how device grabs interact with other devices.</doc>
       <member name="none" value="0" c:identifier="GDK_OWNERSHIP_NONE" glib:nick="none" glib:name="GDK_OWNERSHIP_NONE">
-        <doc xml:space="preserve">All other devices&#x2019; events are allowed.</doc>
+        <doc xml:space="preserve">All other devices’ events are allowed.</doc>
       </member>
       <member name="window" value="1" c:identifier="GDK_OWNERSHIP_WINDOW" glib:nick="window" glib:name="GDK_OWNERSHIP_WINDOW">
-        <doc xml:space="preserve">Other devices&#x2019; events are blocked for the grab window.</doc>
+        <doc xml:space="preserve">Other devices’ events are blocked for the grab window.</doc>
       </member>
       <member name="application" value="2" c:identifier="GDK_OWNERSHIP_APPLICATION" glib:nick="application" glib:name="GDK_OWNERSHIP_APPLICATION">
-        <doc xml:space="preserve">Other devices&#x2019; events are blocked for the whole application.</doc>
+        <doc xml:space="preserve">Other devices’ events are blocked for the whole application.</doc>
       </member>
     </enumeration>
     <enumeration name="GrabStatus" glib:type-name="GdkGrabStatus" glib:get-type="gdk_grab_status_get_type" c:type="GdkGrabStatus">
@@ -7467,11 +7467,11 @@ specification for more details.</doc>
         <doc xml:space="preserve">the device is disabled and will not report any events.</doc>
       </member>
       <member name="screen" value="1" c:identifier="GDK_MODE_SCREEN" glib:nick="screen" glib:name="GDK_MODE_SCREEN">
-        <doc xml:space="preserve">the device is enabled. The device&#x2019;s coordinate space
+        <doc xml:space="preserve">the device is enabled. The device’s coordinate space
                   maps to the entire screen.</doc>
       </member>
       <member name="window" value="2" c:identifier="GDK_MODE_WINDOW" glib:nick="window" glib:name="GDK_MODE_WINDOW">
-        <doc xml:space="preserve">the device is enabled. The device&#x2019;s coordinate space
+        <doc xml:space="preserve">the device is enabled. The device’s coordinate space
                   is mapped to a single window. The manner in which this window
                   is chosen is undefined, but it will typically be the same
                   way in which the focus window for key events is determined.</doc>
@@ -7491,7 +7491,7 @@ specification for more details.</doc>
                     of a stylus on a graphics tablet.</doc>
       </member>
       <member name="cursor" value="3" c:identifier="GDK_SOURCE_CURSOR" glib:nick="cursor" glib:name="GDK_SOURCE_CURSOR">
-        <doc xml:space="preserve">the device is a graphics tablet &#x201C;puck&#x201D; or similar device.</doc>
+        <doc xml:space="preserve">the device is a graphics tablet “puck” or similar device.</doc>
       </member>
       <member name="keyboard" value="4" c:identifier="GDK_SOURCE_KEYBOARD" glib:nick="keyboard" glib:name="GDK_SOURCE_KEYBOARD">
         <doc xml:space="preserve">the device is a keyboard.</doc>
@@ -14514,7 +14514,7 @@ with g_free().</doc>
         </parameters>
       </method>
       <method name="get_modifier_mask" c:identifier="gdk_keymap_get_modifier_mask" version="3.4">
-        <doc xml:space="preserve">Returns the modifier mask the @keymap&#x2019;s windowing system backend
+        <doc xml:space="preserve">Returns the modifier mask the @keymap’s windowing system backend
 uses for a particular purpose.
 
 Note that this function always returns real hardware modifiers, not
@@ -14647,7 +14647,7 @@ groups and levels. The @effective_group is the group that was
 actually used for the translation; some keys such as Enter are not
 affected by the active keyboard group. The @level is derived from
 @state. For convenience, #GdkEventKey already contains the translated
-keyval, so this function isn&#x2019;t as useful as you might think.
+keyval, so this function isn’t as useful as you might think.
 
 @consumed_modifiers gives modifiers that should be masked outfrom @state
 when comparing this key press to a hot key. For instance, on a US keyboard,
@@ -14670,7 +14670,7 @@ all modifiers that might affect the translation of the key;
 this allowed accelerators to be stored with irrelevant consumed
 modifiers, by doing:
 |[&lt;!-- language="C" --&gt;
-// XXX Don&#x2019;t do this XXX
+// XXX Don’t do this XXX
 if (keyval == accel_keyval &amp;&amp;
     (event-&gt;state &amp; ~consumed &amp; ALL_ACCELS_MASK) == (accel_mods &amp; ~consumed))
   // Accelerator was pressed
@@ -14765,9 +14765,9 @@ See gdk_keymap_get_caps_lock_state().</doc>
       </field>
       <field name="level" writable="1">
         <doc xml:space="preserve">indicates which symbol on the key will be used, in a vertical direction.
-  So on a standard US keyboard, the key with the number &#x201C;1&#x201D; on it also has the
+  So on a standard US keyboard, the key with the number “1” on it also has the
   exclamation point ("!") character on it. The level indicates whether to use
-  the &#x201C;1&#x201D; or the &#x201C;!&#x201D; symbol. The letter keys are considered to have a lowercase
+  the “1” or the “!” symbol. The letter keys are considered to have a lowercase
   letter at level 0, and an uppercase letter at level 1, though only the
   uppercase letter is printed.</doc>
         <type name="gint" c:type="gint"/>
@@ -14797,7 +14797,7 @@ in order to determine what modifiers the
 currently used windowing system backend uses for particular
 purposes. For example, on X11/Windows, the Control key is used for
 invoking menu shortcuts (accelerators), whereas on Apple computers
-it&#x2019;s the Command key (which correspond to %GDK_CONTROL_MASK and
+it’s the Command key (which correspond to %GDK_CONTROL_MASK and
 %GDK_MOD2_MASK, respectively).</doc>
       <member name="primary_accelerator" value="0" c:identifier="GDK_MODIFIER_INTENT_PRIMARY_ACCELERATOR" glib:nick="primary-accelerator" glib:name="GDK_MODIFIER_INTENT_PRIMARY_ACCELERATOR">
         <doc xml:space="preserve">the primary modifier used to invoke
@@ -14981,8 +14981,8 @@ APIs in GdkScreen to obtain monitor-related information.</doc>
       </method>
       <method name="get_geometry" c:identifier="gdk_monitor_get_geometry" glib:get-property="geometry" version="3.22">
         <doc xml:space="preserve">Retrieves the size and position of an individual monitor within the
-display coordinate space. The returned geometry is in  &#x201D;application pixels&#x201D;,
-not in &#x201D;device pixels&#x201D; (see gdk_monitor_get_scale_factor()).</doc>
+display coordinate space. The returned geometry is in  ”application pixels”,
+not in ”device pixels” (see gdk_monitor_get_scale_factor()).</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -15063,7 +15063,7 @@ to the actual device pixels. On traditional systems this is 1, but
 on very high density outputs this can be a higher value (often 2).
 
 This can be used if you want to create pixel based data for a
-particular monitor, but most of the time you&#x2019;re drawing to a window
+particular monitor, but most of the time you’re drawing to a window
 where it is better to use gdk_window_get_scale_factor() instead.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the scale factor</doc>
@@ -15104,9 +15104,9 @@ primaries for each pixel in this monitor, if available.</doc>
         </parameters>
       </method>
       <method name="get_workarea" c:identifier="gdk_monitor_get_workarea" glib:get-property="workarea" version="3.22">
-        <doc xml:space="preserve">Retrieves the size and position of the &#x201C;work area&#x201D; on a monitor
+        <doc xml:space="preserve">Retrieves the size and position of the “work area” on a monitor
 within the display coordinate space. The returned geometry is in
-&#x201D;application pixels&#x201D;, not in &#x201D;device pixels&#x201D; (see
+”application pixels”, not in ”device pixels” (see
 gdk_monitor_get_scale_factor()).
 
 The work area should be considered when positioning menus and
@@ -15280,7 +15280,7 @@ using gdk_property_change().</doc>
     </enumeration>
     <record name="RGBA" c:type="GdkRGBA" glib:type-name="GdkRGBA" glib:get-type="gdk_rgba_get_type" c:symbol-prefix="rgba">
       <doc xml:space="preserve">A #GdkRGBA is used to represent a (possibly translucent)
-color, in a way that is compatible with cairo&#x2019;s notion of color.</doc>
+color, in a way that is compatible with cairo’s notion of color.</doc>
       <field name="red" writable="1">
         <doc xml:space="preserve">The intensity of the red channel from 0.0 to 1.0 inclusive</doc>
         <type name="gdouble" c:type="gdouble"/>
@@ -15362,14 +15362,14 @@ the @red, @green, @blue and @alpha fields of the @rgba #GdkRGBA.
 
 The string can be either one of:
 - A standard name (Taken from the X11 rgb.txt file).
-- A hexadecimal value in the form &#x201C;\#rgb&#x201D;, &#x201C;\#rrggbb&#x201D;,
-  &#x201C;\#rrrgggbbb&#x201D; or &#x201D;\#rrrrggggbbbb&#x201D;
-- A RGB color in the form &#x201C;rgb(r,g,b)&#x201D; (In this case the color will
+- A hexadecimal value in the form “\#rgb”, “\#rrggbb”,
+  “\#rrrgggbbb” or ”\#rrrrggggbbbb”
+- A RGB color in the form “rgb(r,g,b)” (In this case the color will
   have full opacity)
-- A RGBA color in the form &#x201C;rgba(r,g,b,a)&#x201D;
+- A RGBA color in the form “rgba(r,g,b,a)”
 
-Where &#x201C;r&#x201D;, &#x201C;g&#x201D;, &#x201C;b&#x201D; and &#x201C;a&#x201D; are respectively the red, green, blue and
-alpha color values. In the last two cases, &#x201C;r&#x201D;, &#x201C;g&#x201D;, and &#x201C;b&#x201D; are either integers
+Where “r”, “g”, “b” and “a” are respectively the red, green, blue and
+alpha color values. In the last two cases, “r”, “g”, and “b” are either integers
 in the range 0 to 255 or percentage values in the range 0% to 100%, and
 a is a floating point value in the range 0 to 1.</doc>
         <return-value transfer-ownership="none">
@@ -15391,16 +15391,16 @@ a is a floating point value in the range 0 to 1.</doc>
         <doc xml:space="preserve">Returns a textual specification of @rgba in the form
 `rgb(r,g,b)` or
 `rgba(r g,b,a)`,
-where &#x201C;r&#x201D;, &#x201C;g&#x201D;, &#x201C;b&#x201D; and &#x201C;a&#x201D; represent the red, green,
-blue and alpha values respectively. &#x201C;r&#x201D;, &#x201C;g&#x201D;, and &#x201C;b&#x201D; are
-represented as integers in the range 0 to 255, and &#x201C;a&#x201D;
+where “r”, “g”, “b” and “a” represent the red, green,
+blue and alpha values respectively. “r”, “g”, and “b” are
+represented as integers in the range 0 to 255, and “a”
 is represented as a floating point value in the range 0 to 1.
 
 These string forms are string forms that are supported by
 the CSS3 colors module, and can be parsed by gdk_rgba_parse().
 
 Note that this string representation may lose some
-precision, since &#x201C;r&#x201D;, &#x201C;g&#x201D; and &#x201C;b&#x201D; are represented as 8-bit
+precision, since “r”, “g” and “b” are represented as 8-bit
 integers. If this is a concern, you should use a
 different representation.</doc>
         <return-value transfer-ownership="full">
@@ -15450,7 +15450,7 @@ different representation.</doc>
       <method name="intersect" c:identifier="gdk_rectangle_intersect">
         <doc xml:space="preserve">Calculates the intersection of two rectangles. It is allowed for
 @dest to be the same as either @src1 or @src2. If the rectangles
-do not intersect, @dest&#x2019;s width and height is set to 0 and its x
+do not intersect, @dest’s width and height is set to 0 and its x
 and y values are undefined. If you are only interested in whether
 the rectangles intersect, but not in the intersecting area itself,
 pass %NULL for @dest.</doc>
@@ -15536,7 +15536,7 @@ gdk_display_get_default ()).</doc>
       </function>
       <function name="height" c:identifier="gdk_screen_height" deprecated="1" deprecated-version="3.22">
         <doc xml:space="preserve">Gets the height of the default screen in pixels. The returned
-size is in &#x201D;application pixels&#x201D;, not in &#x201D;device pixels&#x201D; (see
+size is in ”application pixels”, not in ”device pixels” (see
 gdk_screen_get_monitor_scale_factor()).</doc>
         <doc-deprecated xml:space="preserve">Use per-monitor information</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -15556,7 +15556,7 @@ though it is not always correct.</doc>
       </function>
       <function name="width" c:identifier="gdk_screen_width" deprecated="1" deprecated-version="3.22">
         <doc xml:space="preserve">Gets the width of the default screen in pixels. The returned
-size is in &#x201D;application pixels&#x201D;, not in &#x201D;device pixels&#x201D; (see
+size is in ”application pixels”, not in ”device pixels” (see
 gdk_screen_get_monitor_scale_factor()).</doc>
         <doc-deprecated xml:space="preserve">Use per-monitor information</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -15575,7 +15575,7 @@ though it is not always correct.</doc>
         </return-value>
       </function>
       <method name="get_active_window" c:identifier="gdk_screen_get_active_window" version="2.10" deprecated="1" deprecated-version="3.22">
-        <doc xml:space="preserve">Returns the screen&#x2019;s currently active window.
+        <doc xml:space="preserve">Returns the screen’s currently active window.
 
 On X11, this is done by inspecting the _NET_ACTIVE_WINDOW property
 on the root window, as described in the
@@ -15630,7 +15630,7 @@ no longer needed.</doc>
       </method>
       <method name="get_height" c:identifier="gdk_screen_get_height" version="2.2" deprecated="1" deprecated-version="3.22">
         <doc xml:space="preserve">Gets the height of @screen in pixels. The returned size is in
-&#x201D;application pixels&#x201D;, not in &#x201D;device pixels&#x201D; (see
+”application pixels”, not in ”device pixels” (see
 gdk_screen_get_monitor_scale_factor()).</doc>
         <doc-deprecated xml:space="preserve">Use per-monitor information instead</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -15709,7 +15709,7 @@ bounding rectangle of @window resides.</doc>
       <method name="get_monitor_geometry" c:identifier="gdk_screen_get_monitor_geometry" version="2.2" deprecated="1" deprecated-version="3.22">
         <doc xml:space="preserve">Retrieves the #GdkRectangle representing the size and position of
 the individual monitor within the entire screen area. The returned
-geometry is in &#x201D;application pixels&#x201D;, not in &#x201D;device pixels&#x201D; (see
+geometry is in ”application pixels”, not in ”device pixels” (see
 gdk_screen_get_monitor_scale_factor()).
 
 Monitor numbers start at 0. To obtain the number of monitors of
@@ -15782,7 +15782,7 @@ to the actual device pixels. On traditional systems this is 1, but
 on very high density outputs this can be a higher value (often 2).
 
 This can be used if you want to create pixel based data for a
-particular monitor, but most of the time you&#x2019;re drawing to a window
+particular monitor, but most of the time you’re drawing to a window
 where it is better to use gdk_window_get_scale_factor() instead.</doc>
         <doc-deprecated xml:space="preserve">Use gdk_monitor_get_scale_factor() instead</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -15820,8 +15820,8 @@ where it is better to use gdk_window_get_scale_factor() instead.</doc>
       </method>
       <method name="get_monitor_workarea" c:identifier="gdk_screen_get_monitor_workarea" version="3.4" deprecated="1" deprecated-version="3.22">
         <doc xml:space="preserve">Retrieves the #GdkRectangle representing the size and position of
-the &#x201C;work area&#x201D; on a monitor within the entire screen area. The returned
-geometry is in &#x201D;application pixels&#x201D;, not in &#x201D;device pixels&#x201D; (see
+the “work area” on a monitor within the entire screen area. The returned
+geometry is in ”application pixels”, not in ”device pixels” (see
 gdk_screen_get_monitor_scale_factor()).
 
 The work area should be considered when positioning menus and
@@ -15884,7 +15884,7 @@ to which it belongs. (See gdk_screen_get_display())</doc>
       </method>
       <method name="get_primary_monitor" c:identifier="gdk_screen_get_primary_monitor" version="2.20" deprecated="1" deprecated-version="3.22">
         <doc xml:space="preserve">Gets the primary monitor for @screen.  The primary monitor
-is considered the monitor where the &#x201C;main desktop&#x201D; lives.
+is considered the monitor where the “main desktop” lives.
 While normal application windows typically allow the window
 manager to place the windows, specialized desktop applications
 such as panels should place themselves on the primary monitor.
@@ -15923,7 +15923,7 @@ has been set.</doc>
 The windowing system on which GTK+ is running
 may not support this capability, in which case %NULL will
 be returned. Even if a non-%NULL value is returned, its
-possible that the window&#x2019;s alpha channel won&#x2019;t be honored
+possible that the window’s alpha channel won’t be honored
 when displaying the window on the screen: in particular, for
 X an appropriate windowing manager and compositing manager
 must be running to provide appropriate display.
@@ -15985,7 +15985,7 @@ more information.</doc>
         </parameters>
       </method>
       <method name="get_system_visual" c:identifier="gdk_screen_get_system_visual" version="2.2">
-        <doc xml:space="preserve">Get the system&#x2019;s default visual for @screen.
+        <doc xml:space="preserve">Get the system’s default visual for @screen.
 This is the visual for the root window of the display.
 The return value should not be freed.</doc>
         <return-value transfer-ownership="none">
@@ -16022,7 +16022,7 @@ its elements need not be freed.</doc>
       </method>
       <method name="get_width" c:identifier="gdk_screen_get_width" version="2.2" deprecated="1" deprecated-version="3.22">
         <doc xml:space="preserve">Gets the width of @screen in pixels. The returned size is in
-&#x201D;application pixels&#x201D;, not in &#x201D;device pixels&#x201D; (see
+”application pixels”, not in ”device pixels” (see
 gdk_screen_get_monitor_scale_factor()).</doc>
         <doc-deprecated xml:space="preserve">Use per-monitor information instead</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -16109,7 +16109,7 @@ A visual describes a hardware image data format.
 For example, a visual might support 24-bit color, or 8-bit color,
 and might expect pixels to be in a certain format.
 
-Call g_list_free() on the return value when you&#x2019;re finished with it.</doc>
+Call g_list_free() on the return value when you’re finished with it.</doc>
         <return-value transfer-ownership="container">
           <doc xml:space="preserve">
     a list of visuals; the list must be freed, but not its contents</doc>
@@ -16140,7 +16140,7 @@ a #GdkDisplay with this screen as the default screen.</doc>
       </method>
       <method name="set_font_options" c:identifier="gdk_screen_set_font_options" glib:set-property="font-options" version="2.10">
         <doc xml:space="preserve">Sets the default font options for the screen. These
-options will be set on any #PangoContext&#x2019;s newly created
+options will be set on any #PangoContext’s newly created
 with gdk_pango_context_get_for_screen(). Changing the
 default set of font options does not affect contexts that
 have already been created.</doc>
@@ -16173,7 +16173,7 @@ font will be 13 units high. (10 * 96. / 72. = 13.3).</doc>
             <type name="Screen" c:type="GdkScreen*"/>
           </instance-parameter>
           <parameter name="dpi" transfer-ownership="none">
-            <doc xml:space="preserve">the resolution in &#x201C;dots per inch&#x201D;. (Physical inches aren&#x2019;t actually
+            <doc xml:space="preserve">the resolution in “dots per inch”. (Physical inches aren’t actually
   involved; the terminology is conventional.)</doc>
             <type name="gdouble" c:type="gdouble"/>
           </parameter>
@@ -16575,7 +16575,7 @@ begun with #GDK_THREADS_ENTER.</doc>
         <type name="guint32" c:type="guint32"/>
       </field>
       <field name="axes" writable="1">
-        <doc xml:space="preserve">the values of the device&#x2019;s axes.</doc>
+        <doc xml:space="preserve">the values of the device’s axes.</doc>
         <array zero-terminated="0" fixed-size="128">
           <type name="gdouble" c:type="gdouble"/>
         </array>
@@ -16655,8 +16655,8 @@ GDK screen. The return value should not be freed.</doc>
         </return-value>
       </function>
       <function name="get_best_depth" c:identifier="gdk_visual_get_best_depth" deprecated="1" deprecated-version="3.22">
-        <doc xml:space="preserve">Get the best available depth for the default GDK screen.  &#x201C;Best&#x201D;
-means &#x201C;largest,&#x201D; i.e. 32 preferred over 24 preferred over 8 bits
+        <doc xml:space="preserve">Get the best available depth for the default GDK screen.  “Best”
+means “largest,” i.e. 32 preferred over 24 preferred over 8 bits
 per pixel.</doc>
         <doc-deprecated xml:space="preserve">Visual selection should be done using
     gdk_screen_get_system_visual() and gdk_screen_get_rgba_visual()</doc-deprecated>
@@ -16732,7 +16732,7 @@ should not be freed. %NULL may be returned if no visual has type
         </parameters>
       </function>
       <function name="get_system" c:identifier="gdk_visual_get_system" deprecated="1" deprecated-version="3.22">
-        <doc xml:space="preserve">Get the system&#x2019;s default visual for the default GDK screen.
+        <doc xml:space="preserve">Get the system’s default visual for the default GDK screen.
 This is the visual for the root window of the display.
 The return value should not be freed.</doc>
         <doc-deprecated xml:space="preserve">Use gdk_screen_get_system_visual (gdk_screen_get_default ()).</doc-deprecated>
@@ -16760,8 +16760,8 @@ Not all GDK backend provide a meaningful value for this function.</doc>
       </method>
       <method name="get_blue_pixel_details" c:identifier="gdk_visual_get_blue_pixel_details" version="2.22">
         <doc xml:space="preserve">Obtains values that are needed to calculate blue pixel values in TrueColor
-and DirectColor. The &#x201C;mask&#x201D; is the significant bits within the pixel.
-The &#x201C;shift&#x201D; is the number of bits left we must shift a primary for it
+and DirectColor. The “mask” is the significant bits within the pixel.
+The “shift” is the number of bits left we must shift a primary for it
 to be in position (according to the "mask"). Finally, "precision" refers
 to how much precision the pixel value contains for a particular primary.</doc>
         <return-value transfer-ownership="none">
@@ -16836,8 +16836,8 @@ You have to use platform-specific APIs to manipulate colormaps.</doc>
       </method>
       <method name="get_green_pixel_details" c:identifier="gdk_visual_get_green_pixel_details" version="2.22">
         <doc xml:space="preserve">Obtains values that are needed to calculate green pixel values in TrueColor
-and DirectColor. The &#x201C;mask&#x201D; is the significant bits within the pixel.
-The &#x201C;shift&#x201D; is the number of bits left we must shift a primary for it
+and DirectColor. The “mask” is the significant bits within the pixel.
+The “shift” is the number of bits left we must shift a primary for it
 to be in position (according to the "mask"). Finally, "precision" refers
 to how much precision the pixel value contains for a particular primary.</doc>
         <return-value transfer-ownership="none">
@@ -16864,8 +16864,8 @@ to how much precision the pixel value contains for a particular primary.</doc>
       </method>
       <method name="get_red_pixel_details" c:identifier="gdk_visual_get_red_pixel_details" version="2.22">
         <doc xml:space="preserve">Obtains values that are needed to calculate red pixel values in TrueColor
-and DirectColor. The &#x201C;mask&#x201D; is the significant bits within the pixel.
-The &#x201C;shift&#x201D; is the number of bits left we must shift a primary for it
+and DirectColor. The “mask” is the significant bits within the pixel.
+The “shift” is the number of bits left we must shift a primary for it
 to be in position (according to the "mask"). Finally, "precision" refers
 to how much precision the pixel value contains for a particular primary.</doc>
         <return-value transfer-ownership="none">
@@ -17049,7 +17049,7 @@ display, @parent must be specified.</doc>
         <doc xml:space="preserve">Obtains the window underneath the mouse pointer, returning the
 location of that window in @win_x, @win_y. Returns %NULL if the
 window under the mouse pointer is not known to GDK (if the window
-belongs to another application and a #GdkWindow hasn&#x2019;t been created
+belongs to another application and a #GdkWindow hasn’t been created
 for it with gdk_window_foreign_new())
 
 NOTE: For multihead-aware widgets or applications use
@@ -17123,7 +17123,7 @@ In essence, because the GDK rendering model prevents all flicker,
 if you are redrawing the same region 400 times you may never
 notice, aside from noticing a speed problem. Enabling update
 debugging causes GTK to flicker slowly and noticeably, so you can
-see exactly what&#x2019;s being redrawn when, in what order.
+see exactly what’s being redrawn when, in what order.
 
 The --gtk-debug=updates command line option passed to GTK+ programs
 enables this debug option at application startup time. That's
@@ -17280,7 +17280,7 @@ as individual drawing operations are performed in sequence.
 
 When using GTK+, the widget system automatically places calls to
 gdk_window_begin_draw_frame() and gdk_window_end_draw_frame() around
-emissions of the `GtkWidget::draw` signal. That is, if you&#x2019;re
+emissions of the `GtkWidget::draw` signal. That is, if you’re
 drawing the contents of the widget yourself, you can assume that the
 widget has a cleared background, is already set as the clip region,
 and already has a backing store. Therefore in most cases, application
@@ -17337,7 +17337,7 @@ to begin a drag with a different device.</doc>
       </method>
       <method name="begin_move_drag_for_device" c:identifier="gdk_window_begin_move_drag_for_device" version="3.4">
         <doc xml:space="preserve">Begins a window move operation (for a toplevel window).
-You might use this function to implement a &#x201C;window move grip,&#x201D; for
+You might use this function to implement a “window move grip,” for
 example. The function works best with window managers that support the
 [Extended Window Manager Hints](http://www.freedesktop.org/Standards/wm-spec)
 but has a fallback implementation for other window managers.</doc>
@@ -17412,7 +17412,7 @@ programmer, so you can avoid doing that work yourself.
 
 When using GTK+, the widget system automatically places calls to
 gdk_window_begin_paint_region() and gdk_window_end_paint() around
-emissions of the expose_event signal. That is, if you&#x2019;re writing an
+emissions of the expose_event signal. That is, if you’re writing an
 expose event handler, you can assume that the exposed area in
 #GdkEventExpose has already been cleared to the window background,
 is already set as the clip region, and already has a backing store.
@@ -17482,7 +17482,7 @@ to begin a drag with a different device.</doc>
       </method>
       <method name="begin_resize_drag_for_device" c:identifier="gdk_window_begin_resize_drag_for_device" version="3.4">
         <doc xml:space="preserve">Begins a window resize operation (for a toplevel window).
-You might use this function to implement a &#x201C;window resize grip,&#x201D; for
+You might use this function to implement a “window resize grip,” for
 example; in fact #GtkStatusbar uses it. The function works best
 with window managers that support the
 [Extended Window Manager Hints](http://www.freedesktop.org/Standards/wm-spec)
@@ -17560,19 +17560,19 @@ See also: gdk_window_coords_to_parent()</doc>
             <type name="Window" c:type="GdkWindow*"/>
           </instance-parameter>
           <parameter name="parent_x" transfer-ownership="none">
-            <doc xml:space="preserve">X coordinate in parent&#x2019;s coordinate system</doc>
+            <doc xml:space="preserve">X coordinate in parent’s coordinate system</doc>
             <type name="gdouble" c:type="gdouble"/>
           </parameter>
           <parameter name="parent_y" transfer-ownership="none">
-            <doc xml:space="preserve">Y coordinate in parent&#x2019;s coordinate system</doc>
+            <doc xml:space="preserve">Y coordinate in parent’s coordinate system</doc>
             <type name="gdouble" c:type="gdouble"/>
           </parameter>
           <parameter name="x" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
-            <doc xml:space="preserve">return location for X coordinate in child&#x2019;s coordinate system</doc>
+            <doc xml:space="preserve">return location for X coordinate in child’s coordinate system</doc>
             <type name="gdouble" c:type="gdouble*"/>
           </parameter>
           <parameter name="y" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
-            <doc xml:space="preserve">return location for Y coordinate in child&#x2019;s coordinate system</doc>
+            <doc xml:space="preserve">return location for Y coordinate in child’s coordinate system</doc>
             <type name="gdouble" c:type="gdouble*"/>
           </parameter>
         </parameters>
@@ -17603,21 +17603,21 @@ See also: gdk_window_coords_from_parent()</doc>
             <type name="Window" c:type="GdkWindow*"/>
           </instance-parameter>
           <parameter name="x" transfer-ownership="none">
-            <doc xml:space="preserve">X coordinate in child&#x2019;s coordinate system</doc>
+            <doc xml:space="preserve">X coordinate in child’s coordinate system</doc>
             <type name="gdouble" c:type="gdouble"/>
           </parameter>
           <parameter name="y" transfer-ownership="none">
-            <doc xml:space="preserve">Y coordinate in child&#x2019;s coordinate system</doc>
+            <doc xml:space="preserve">Y coordinate in child’s coordinate system</doc>
             <type name="gdouble" c:type="gdouble"/>
           </parameter>
           <parameter name="parent_x" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">return location for X coordinate
-in parent&#x2019;s coordinate system, or %NULL</doc>
+in parent’s coordinate system, or %NULL</doc>
             <type name="gdouble" c:type="gdouble*"/>
           </parameter>
           <parameter name="parent_y" direction="out" caller-allocates="0" transfer-ownership="full" optional="1" allow-none="1">
             <doc xml:space="preserve">return location for Y coordinate
-in parent&#x2019;s coordinate system, or %NULL</doc>
+in parent’s coordinate system, or %NULL</doc>
             <type name="gdouble" c:type="gdouble*"/>
           </parameter>
         </parameters>
@@ -17678,7 +17678,7 @@ owns the surface and should call cairo_surface_destroy() when done
 with it.
 
 This function always returns a valid pointer, but it will return a
-pointer to a &#x201C;nil&#x201D; surface if @other is already in an error state
+pointer to a “nil” surface if @other is already in an error state
 or any other error occurs.</doc>
           <type name="cairo.Surface" c:type="cairo_surface_t*"/>
         </return-value>
@@ -17722,7 +17722,7 @@ owns the surface and should call cairo_surface_destroy() when done
 with it.
 
 This function always returns a valid pointer, but it will return a
-pointer to a &#x201C;nil&#x201D; surface if @other is already in an error state
+pointer to a “nil” surface if @other is already in an error state
 or any other error occurs.</doc>
           <type name="cairo.Surface" c:type="cairo_surface_t*"/>
         </return-value>
@@ -17764,7 +17764,7 @@ unminimizes it, and puts it on the current desktop.</doc>
       <method name="destroy" c:identifier="gdk_window_destroy">
         <doc xml:space="preserve">Destroys the window system resources associated with @window and decrements @window's
 reference count. The window system resources for all children of @window are also
-destroyed, but the children&#x2019;s reference counts are not decremented.
+destroyed, but the children’s reference counts are not decremented.
 
 Note that a window will not be destroyed automatically when its reference count
 reaches zero. You must call this function yourself before that happens.</doc>
@@ -17912,7 +17912,7 @@ for use by GTK+.</doc>
         </parameters>
       </method>
       <method name="freeze_updates" c:identifier="gdk_window_freeze_updates">
-        <doc xml:space="preserve">Temporarily freezes a window such that it won&#x2019;t receive expose
+        <doc xml:space="preserve">Temporarily freezes a window such that it won’t receive expose
 events.  The window will begin receiving expose events again when
 gdk_window_thaw_updates() is called. If gdk_window_freeze_updates()
 has been called more than once, gdk_window_thaw_updates() must be called
@@ -17937,7 +17937,7 @@ If the window was already fullscreen, then this function does nothing.
 On X11, asks the window manager to put @window in a fullscreen
 state, if the window manager supports this operation. Not all
 window managers support this, and some deliberately ignore it or
-don&#x2019;t have a concept of &#x201C;fullscreen&#x201D;; so you can&#x2019;t rely on the
+don’t have a concept of “fullscreen”; so you can’t rely on the
 fullscreenification actually happening. But it will happen with
 most standard window managers, and GDK makes a best effort to get
 it to happen.</doc>
@@ -18017,7 +18017,7 @@ background or %NULL if there is no background.</doc>
       <method name="get_children" c:identifier="gdk_window_get_children">
         <doc xml:space="preserve">Gets the list of children of @window known to GDK.
 This function only returns children created via GDK,
-so for example it&#x2019;s useless when used with the root window;
+so for example it’s useless when used with the root window;
 it only returns windows an application created itself.
 
 The returned list must be freed, but the elements in the
@@ -18278,7 +18278,7 @@ window is not known to GDK.</doc>
       <method name="get_effective_parent" c:identifier="gdk_window_get_effective_parent" version="2.22">
         <doc xml:space="preserve">Obtains the parent of @window, as known to GDK. Works like
 gdk_window_get_parent() for normal windows, but returns the
-window&#x2019;s embedder for offscreen windows.
+window’s embedder for offscreen windows.
 
 See also: gdk_offscreen_window_get_embedder()</doc>
         <return-value transfer-ownership="none">
@@ -18293,7 +18293,7 @@ See also: gdk_offscreen_window_get_embedder()</doc>
         </parameters>
       </method>
       <method name="get_effective_toplevel" c:identifier="gdk_window_get_effective_toplevel" version="2.22">
-        <doc xml:space="preserve">Gets the toplevel window that&#x2019;s an ancestor of @window.
+        <doc xml:space="preserve">Gets the toplevel window that’s an ancestor of @window.
 
 Works like gdk_window_get_toplevel(), but treats an offscreen window's
 embedder as its parent, using gdk_window_get_effective_parent().
@@ -18401,7 +18401,7 @@ the frame) in root window coordinates, use gdk_window_get_origin().</doc>
       </method>
       <method name="get_geometry" c:identifier="gdk_window_get_geometry">
         <doc xml:space="preserve">Any of the return location arguments to this function may be %NULL,
-if you aren&#x2019;t interested in getting the value of that field.
+if you aren’t interested in getting the value of that field.
 
 The X and Y coordinates returned are relative to the parent window
 of @window, which for toplevels usually means relative to the
@@ -18517,7 +18517,7 @@ relative to its parent window.)</doc>
       <method name="get_parent" c:identifier="gdk_window_get_parent">
         <doc xml:space="preserve">Obtains the parent of @window, as known to GDK. Does not query the
 X server; thus this returns the parent as passed to gdk_window_new(),
-not the actual parent. This should never matter unless you&#x2019;re using
+not the actual parent. This should never matter unless you’re using
 Xlib calls mixed with GDK calls on the X11 platform. It may also
 matter for toplevel windows, because the window manager may choose
 to reparent them.
@@ -18560,7 +18560,7 @@ corner of @window.</doc>
         <return-value transfer-ownership="none" nullable="1">
           <doc xml:space="preserve">the window containing the
 pointer (as with gdk_window_at_pointer()), or %NULL if the window
-containing the pointer isn&#x2019;t known to GDK</doc>
+containing the pointer isn’t known to GDK</doc>
           <type name="Window" c:type="GdkWindow*"/>
         </return-value>
         <parameters>
@@ -18592,7 +18592,7 @@ gdk_window_get_geometry() which queries the X server for the
 current window position, regardless of which events have been
 received or processed.
 
-The position coordinates are relative to the window&#x2019;s parent window.</doc>
+The position coordinates are relative to the window’s parent window.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -18747,14 +18747,14 @@ devices.</doc>
         </parameters>
       </method>
       <method name="get_toplevel" c:identifier="gdk_window_get_toplevel">
-        <doc xml:space="preserve">Gets the toplevel window that&#x2019;s an ancestor of @window.
+        <doc xml:space="preserve">Gets the toplevel window that’s an ancestor of @window.
 
 Any window type but %GDK_WINDOW_CHILD is considered a
 toplevel window, as is a %GDK_WINDOW_CHILD window that
 has a root window as parent.
 
 Note that you should use gdk_window_get_effective_toplevel() when
-you want to get to a window&#x2019;s toplevel as seen on screen, because
+you want to get to a window’s toplevel as seen on screen, because
 gdk_window_get_toplevel() will most likely not do what you expect
 if there are offscreen windows in the hierarchy.</doc>
         <return-value transfer-ownership="none">
@@ -18787,7 +18787,7 @@ of the function. That is, after calling this function, @window will
 no longer have an invalid/dirty region; the update area is removed
 from @window and handed to you. If a window has no update area,
 gdk_window_get_update_area() returns %NULL. You are responsible for
-calling cairo_region_destroy() on the returned region if it&#x2019;s non-%NULL.</doc>
+calling cairo_region_destroy() on the returned region if it’s non-%NULL.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">the update area for @window</doc>
           <type name="cairo.Region" c:type="cairo_region_t*"/>
@@ -18893,7 +18893,7 @@ you can use gdk_window_ensure_native() if a native window is needed.</doc>
       <method name="hide" c:identifier="gdk_window_hide">
         <doc xml:space="preserve">For toplevel windows, withdraws them, so they will no longer be
 known to the window manager; for all windows, unmaps them, so
-they won&#x2019;t be displayed. Normally done automatically as
+they won’t be displayed. Normally done automatically as
 part of gtk_widget_hide().</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -18931,7 +18931,7 @@ An input shape is typically used with RGBA windows.
 The alpha channel of the window defines which pixels are
 invisible and allows for nicely antialiased borders,
 and the input shape controls where the window is
-&#x201C;clickable&#x201D;.
+“clickable”.
 
 On the X11 platform, this requires version 1.1 of the
 shape extension.
@@ -18962,7 +18962,7 @@ function does nothing.</doc>
       </method>
       <method name="invalidate_maybe_recurse" c:identifier="gdk_window_invalidate_maybe_recurse">
         <doc xml:space="preserve">Adds @region to the update area for @window. The update area is the
-region that needs to be redrawn, or &#x201C;dirty region.&#x201D; The call
+region that needs to be redrawn, or “dirty region.” The call
 gdk_window_process_updates() sends one or more expose events to the
 window, which together cover the entire update area. An
 application would normally redraw the contents of @window in
@@ -18970,7 +18970,7 @@ response to those expose events.
 
 GDK will call gdk_window_process_all_updates() on your behalf
 whenever your program returns to the main loop and becomes idle, so
-normally there&#x2019;s no need to do that manually, you just need to
+normally there’s no need to do that manually, you just need to
 invalidate regions that you know should be redrawn.
 
 The @child_func parameter controls whether the region of
@@ -19025,7 +19025,7 @@ gdk_window_invalidate_region() for details.</doc>
       </method>
       <method name="invalidate_region" c:identifier="gdk_window_invalidate_region">
         <doc xml:space="preserve">Adds @region to the update area for @window. The update area is the
-region that needs to be redrawn, or &#x201C;dirty region.&#x201D; The call
+region that needs to be redrawn, or “dirty region.” The call
 gdk_window_process_updates() sends one or more expose events to the
 window, which together cover the entire update area. An
 application would normally redraw the contents of @window in
@@ -19033,7 +19033,7 @@ response to those expose events.
 
 GDK will call gdk_window_process_all_updates() on your behalf
 whenever your program returns to the main loop and becomes idle, so
-normally there&#x2019;s no need to do that manually, you just need to
+normally there’s no need to do that manually, you just need to
 invalidate regions that you know should be redrawn.
 
 The @invalidate_children parameter controls whether the region of
@@ -19137,7 +19137,7 @@ If @window is a toplevel, the window manager may choose to deny the
 request to move the window in the Z-order, gdk_window_lower() only
 requests the restack, does not guarantee it.
 
-Note that gdk_window_show() raises the window again, so don&#x2019;t call this
+Note that gdk_window_show() raises the window again, so don’t call this
 function before gdk_window_show(). (Try gdk_window_show_unraised().)</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -19178,8 +19178,8 @@ this function does nothing.
 
 On X11, asks the window manager to maximize @window, if the window
 manager supports this operation. Not all window managers support
-this, and some deliberately ignore it or don&#x2019;t have a concept of
-&#x201C;maximized&#x201D;; so you can&#x2019;t rely on the maximization actually
+this, and some deliberately ignore it or don’t have a concept of
+“maximized”; so you can’t rely on the maximization actually
 happening. But it will happen with most standard window managers,
 and GDK makes a best effort to get it to happen.
 
@@ -19201,7 +19201,7 @@ for @window and its children will become the new input mask
 for @window. See gdk_window_input_shape_combine_region().
 
 This function is distinct from gdk_window_set_child_input_shapes()
-because it includes @window&#x2019;s input shape mask in the set of
+because it includes @window’s input shape mask in the set of
 shapes to be merged.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -19220,7 +19220,7 @@ for @window and its children will become the new mask
 for @window. See gdk_window_shape_combine_region().
 
 This function is distinct from gdk_window_set_child_shapes()
-because it includes @window&#x2019;s shape mask in the set of shapes to
+because it includes @window’s shape mask in the set of shapes to
 be merged.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -19239,7 +19239,7 @@ you should probably use gtk_window_move() on a #GtkWindow widget
 anyway, instead of using GDK functions. For child windows,
 the move will reliably succeed.
 
-If you&#x2019;re also planning to resize the window, use gdk_window_move_resize()
+If you’re also planning to resize the window, use gdk_window_move_resize()
 to both move and resize simultaneously, for a nicer visual effect.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -19250,11 +19250,11 @@ to both move and resize simultaneously, for a nicer visual effect.</doc>
             <type name="Window" c:type="GdkWindow*"/>
           </instance-parameter>
           <parameter name="x" transfer-ownership="none">
-            <doc xml:space="preserve">X coordinate relative to window&#x2019;s parent</doc>
+            <doc xml:space="preserve">X coordinate relative to window’s parent</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="y" transfer-ownership="none">
-            <doc xml:space="preserve">Y coordinate relative to window&#x2019;s parent</doc>
+            <doc xml:space="preserve">Y coordinate relative to window’s parent</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
         </parameters>
@@ -19291,7 +19291,7 @@ Child windows are not moved.</doc>
         <doc xml:space="preserve">Equivalent to calling gdk_window_move() and gdk_window_resize(),
 except that both operations are performed at once, avoiding strange
 visual effects. (i.e. the user may be able to see the window first
-move, then resize, if you don&#x2019;t use gdk_window_move_resize().)</doc>
+move, then resize, if you don’t use gdk_window_move_resize().)</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -19301,11 +19301,11 @@ move, then resize, if you don&#x2019;t use gdk_window_move_resize().)</doc>
             <type name="Window" c:type="GdkWindow*"/>
           </instance-parameter>
           <parameter name="x" transfer-ownership="none">
-            <doc xml:space="preserve">new X position relative to window&#x2019;s parent</doc>
+            <doc xml:space="preserve">new X position relative to window’s parent</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="y" transfer-ownership="none">
-            <doc xml:space="preserve">new Y position relative to window&#x2019;s parent</doc>
+            <doc xml:space="preserve">new Y position relative to window’s parent</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="width" transfer-ownership="none">
@@ -19390,7 +19390,7 @@ children, so the list does not need to be freed.</doc>
         <doc xml:space="preserve">Sends one or more expose events to @window. The areas in each
 expose event will cover the entire update area for the window (see
 gdk_window_invalidate_region() for details). Normally GDK calls
-gdk_window_process_all_updates() on your behalf, so there&#x2019;s no
+gdk_window_process_all_updates() on your behalf, so there’s no
 need to call this function unless you want to force expose events
 to be delivered immediately and synchronously (vs. the usual
 case, where GDK delivers them in an idle handler). Occasionally
@@ -19491,7 +19491,7 @@ use gtk_window_resize() instead of this low-level GDK function.
 
 Windows may not be resized below 1x1.
 
-If you&#x2019;re also planning to move the window, use gdk_window_move_resize()
+If you’re also planning to move the window, use gdk_window_move_resize()
 to both move and resize simultaneously, for a nicer visual effect.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -19548,7 +19548,7 @@ invalidated. The invalidated region may be bigger than what would
 strictly be necessary.
 
 For X11, a minimum area will be invalidated if the window has no
-subwindows, or if the edges of the window&#x2019;s parent do not extend
+subwindows, or if the edges of the window’s parent do not extend
 beyond the edges of the window. In other cases, a multi-step process
 is used to scroll the window which may produce temporary visual
 artifacts and unnecessary invalidations.</doc>
@@ -19572,7 +19572,7 @@ artifacts and unnecessary invalidations.</doc>
       </method>
       <method name="set_accept_focus" c:identifier="gdk_window_set_accept_focus" version="2.4">
         <doc xml:space="preserve">Setting @accept_focus to %FALSE hints the desktop environment that the
-window doesn&#x2019;t want to receive input focus.
+window doesn’t want to receive input focus.
 
 On X, it is the responsibility of the window manager to interpret this
 hint. ICCCM-compliant window manager usually respect it.</doc>
@@ -19594,8 +19594,8 @@ hint. ICCCM-compliant window manager usually respect it.</doc>
         <doc xml:space="preserve">Sets the background color of @window.
 
 However, when using GTK+, influence the background of a widget
-using a style class or CSS &#x2014; if you&#x2019;re an application &#x2014; or with
-gtk_style_context_set_background() &#x2014; if you're implementing a
+using a style class or CSS — if you’re an application — or with
+gtk_style_context_set_background() — if you're implementing a
 custom widget.</doc>
         <doc-deprecated xml:space="preserve">Don't use this function</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -19690,7 +19690,7 @@ the shape mask of @window in the masks to be merged.</doc>
 windows do not automatically have their contents drawn to
 the screen. Drawing is redirected to an offscreen buffer
 and an expose event is emitted on the parent of the composited
-window. It is the responsibility of the parent&#x2019;s expose handler
+window. It is the responsibility of the parent’s expose handler
 to manually merge the off-screen content onto the screen in
 whatever way it sees fit.
 
@@ -19749,7 +19749,7 @@ should use this default.</doc>
         </parameters>
       </method>
       <method name="set_decorations" c:identifier="gdk_window_set_decorations">
-        <doc xml:space="preserve">&#x201C;Decorations&#x201D; are the features the window manager adds to a toplevel #GdkWindow.
+        <doc xml:space="preserve">“Decorations” are the features the window manager adds to a toplevel #GdkWindow.
 This function sets the traditional Motif window manager hints that tell the
 window manager which decorations you would like your window to have.
 Usually you should use gtk_window_set_decorated() on a #GtkWindow instead of
@@ -19875,8 +19875,8 @@ See the [input handling overview][event-masks] for details.</doc>
       </method>
       <method name="set_focus_on_map" c:identifier="gdk_window_set_focus_on_map" version="2.6">
         <doc xml:space="preserve">Setting @focus_on_map to %FALSE hints the desktop environment that the
-window doesn&#x2019;t want to receive input focus when it is mapped.
-focus_on_map should be turned off for windows that aren&#x2019;t triggered
+window doesn’t want to receive input focus when it is mapped.
+focus_on_map should be turned off for windows that aren’t triggered
 interactively (such as popups from network activity).
 
 On X, it is the responsibility of the window manager to interpret
@@ -19911,7 +19911,7 @@ manager to span the @window over these monitors.
 If the XINERAMA extension is not available or not usable, this function
 has no effect.
 
-Not all window managers support this, so you can&#x2019;t rely on the fullscreen
+Not all window managers support this, so you can’t rely on the fullscreen
 window to span over the multiple monitors when #GDK_FULLSCREEN_ON_ALL_MONITORS
 is specified.</doc>
         <return-value transfer-ownership="none">
@@ -19940,7 +19940,7 @@ entirely.
 The @functions argument is the logical OR of values from the
 #GdkWMFunction enumeration. If the bitmask includes #GDK_FUNC_ALL,
 then the other bits indicate which functions to disable; if
-it doesn&#x2019;t include #GDK_FUNC_ALL, it indicates which functions to
+it doesn’t include #GDK_FUNC_ALL, it indicates which functions to
 enable.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -19974,7 +19974,7 @@ of type %GDK_WINDOW_TEMP or windows where override redirect
 has been turned on via gdk_window_set_override_redirect()
 since these windows are not resizable by the user.
 
-Since you can&#x2019;t count on the windowing system doing the
+Since you can’t count on the windowing system doing the
 constraints for programmatic resizes, you should generally
 call gdk_window_constrain_size() yourself to determine
 appropriate sizes.</doc>
@@ -20083,7 +20083,7 @@ is invalidated.
 This can be used to record the invalidated region, which is
 useful if you are keeping an offscreen copy of some region
 and want to keep it up to date. You can also modify the
-invalidated region in case you&#x2019;re doing some effect where
+invalidated region in case you’re doing some effect where
 e.g. a child widget appears in multiple places.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -20105,8 +20105,8 @@ window was already above, then this function does nothing.
 
 On X11, asks the window manager to keep @window above, if the window
 manager supports this operation. Not all window managers support
-this, and some deliberately ignore it or don&#x2019;t have a concept of
-&#x201C;keep above&#x201D;; so you can&#x2019;t rely on the window being kept above.
+this, and some deliberately ignore it or don’t have a concept of
+“keep above”; so you can’t rely on the window being kept above.
 But it will happen with most standard window managers,
 and GDK makes a best effort to get it to happen.</doc>
         <return-value transfer-ownership="none">
@@ -20129,8 +20129,8 @@ window was already below, then this function does nothing.
 
 On X11, asks the window manager to keep @window below, if the window
 manager supports this operation. Not all window managers support
-this, and some deliberately ignore it or don&#x2019;t have a concept of
-&#x201C;keep below&#x201D;; so you can&#x2019;t rely on the window being kept below.
+this, and some deliberately ignore it or don’t have a concept of
+“keep below”; so you can’t rely on the window being kept below.
 But it will happen with most standard window managers,
 and GDK makes a best effort to get it to happen.</doc>
         <return-value transfer-ownership="none">
@@ -20233,9 +20233,9 @@ property in your #GtkWidget::style-updated handler.</doc>
       </method>
       <method name="set_override_redirect" c:identifier="gdk_window_set_override_redirect">
         <doc xml:space="preserve">An override redirect window is not under the control of the window manager.
-This means it won&#x2019;t have a titlebar, won&#x2019;t be minimizable, etc. - it will
+This means it won’t have a titlebar, won’t be minimizable, etc. - it will
 be entirely under the control of the application. The window manager
-can&#x2019;t see the override redirect window at all.
+can’t see the override redirect window at all.
 
 Override redirect should only be used for short-lived temporary
 windows, such as popup menus. #GtkMenu uses an override redirect
@@ -20291,13 +20291,13 @@ enter/leave events on its way to the destination window.</doc>
         <doc xml:space="preserve">When using GTK+, typically you should use gtk_window_set_role() instead
 of this low-level function.
 
-The window manager and session manager use a window&#x2019;s role to
+The window manager and session manager use a window’s role to
 distinguish it from other kinds of window in the same application.
 When an application is restarted after being saved in a previous
 session, all windows with the same title and role are treated as
 interchangeable.  So if you have two windows with the same title
 that should be distinguished for session management purposes, you
-should set the role on those windows. It doesn&#x2019;t matter what string
+should set the role on those windows. It doesn’t matter what string
 you use for the role, as long as you have a different role for each
 non-interchangeable kind of window.</doc>
         <return-value transfer-ownership="none">
@@ -20319,7 +20319,7 @@ non-interchangeable kind of window.</doc>
 around their frames for effects like shadows and invisible borders.
 Window managers that want to maximize windows or snap to edges need
 to know where the extents of the actual frame lie, so that users
-don&#x2019;t feel like windows are snapping against random invisible edges.
+don’t feel like windows are snapping against random invisible edges.
 
 Note that this property is automatically updated by GTK+, so this
 function should only be used by applications which do not use GTK+
@@ -20354,7 +20354,7 @@ to create toplevel windows.</doc>
         <doc xml:space="preserve">Toggles whether a window should appear in a pager (workspace
 switcher, or other desktop utility program that displays a small
 thumbnail representation of the windows on the desktop). If a
-window&#x2019;s semantic type as specified with gdk_window_set_type_hint()
+window’s semantic type as specified with gdk_window_set_type_hint()
 already fully describes the window, this function should
 not be called in addition, instead you should
 allow the window to be treated according to standard policy for
@@ -20375,7 +20375,7 @@ its semantic type.</doc>
       </method>
       <method name="set_skip_taskbar_hint" c:identifier="gdk_window_set_skip_taskbar_hint" version="2.2">
         <doc xml:space="preserve">Toggles whether a window should appear in a task list or window
-list. If a window&#x2019;s semantic type as specified with
+list. If a window’s semantic type as specified with
 gdk_window_set_type_hint() already fully describes the window, this
 function should not be called in addition,
 instead you should allow the window to be treated according to
@@ -20438,7 +20438,7 @@ instead of this low-level function.</doc>
         <doc xml:space="preserve">Used to set the bit gravity of the given window to static, and flag
 it so all children get static subwindow gravity. This is used if you
 are implementing scary features that involve deep knowledge of the
-windowing system. Don&#x2019;t worry about it.</doc>
+windowing system. Don’t worry about it.</doc>
         <doc-deprecated xml:space="preserve">static gravities haven't worked on anything but X11
   for a long time.</doc-deprecated>
         <return-value transfer-ownership="none">
@@ -20477,7 +20477,7 @@ per device enter/leave events, device grabs and grab ownerships.</doc>
       </method>
       <method name="set_title" c:identifier="gdk_window_set_title">
         <doc xml:space="preserve">Sets the title of a toplevel window, to be displayed in the titlebar.
-If you haven&#x2019;t explicitly set the icon name for the window
+If you haven’t explicitly set the icon name for the window
 (using gdk_window_set_icon_name()), the icon name will be set to
 @title as well. @title must be in UTF-8 encoding (as with all
 user-readable strings in GDK/GTK+). @title may not be %NULL.</doc>
@@ -20501,7 +20501,7 @@ associated with the application window @parent. This allows the
 window manager to do things like center @window on @parent and
 keep @window above @parent.
 
-See gtk_window_set_transient_for() if you&#x2019;re using #GtkWindow or
+See gtk_window_set_transient_for() if you’re using #GtkWindow or
 #GtkDialog.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -20619,11 +20619,11 @@ This function works on both toplevel and child windows.</doc>
 top of the window stack (moves the window to the front of the
 Z-order).
 
-This function maps a window so it&#x2019;s visible onscreen. Its opposite
+This function maps a window so it’s visible onscreen. Its opposite
 is gdk_window_hide().
 
 When implementing a #GtkWidget, you should call this function on the widget's
-#GdkWindow as part of the &#x201C;map&#x201D; method.</doc>
+#GdkWindow as part of the “map” method.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -20641,7 +20641,7 @@ to the top of the window stack.
 
 On the X11 platform, in Xlib terms, this function calls
 XMapWindow() (it also updates some internal GDK state, which means
-that you can&#x2019;t really use XMapWindow() directly on a GDK window).</doc>
+that you can’t really use XMapWindow() directly on a GDK window).</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -20674,15 +20674,15 @@ on the window decorations.</doc>
         </parameters>
       </method>
       <method name="stick" c:identifier="gdk_window_stick">
-        <doc xml:space="preserve">&#x201C;Pins&#x201D; a window such that it&#x2019;s on all workspaces and does not scroll
+        <doc xml:space="preserve">“Pins” a window such that it’s on all workspaces and does not scroll
 with viewports, for window managers that have scrollable viewports.
 (When using #GtkWindow, gtk_window_stick() may be more useful.)
 
 On the X11 platform, this function depends on window manager
 support, so may have no effect with many window managers. However,
 GDK will do the best it can to convince the window manager to stick
-the window. For window managers that don&#x2019;t support this operation,
-there&#x2019;s nothing you can do to force it to happen.</doc>
+the window. For window managers that don’t support this operation,
+there’s nothing you can do to force it to happen.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -20729,7 +20729,7 @@ fullscreen, does nothing.
 On X11, asks the window manager to move @window out of the fullscreen
 state, if the window manager supports this operation. Not all
 window managers support this, and some deliberately ignore it or
-don&#x2019;t have a concept of &#x201C;fullscreen&#x201D;; so you can&#x2019;t rely on the
+don’t have a concept of “fullscreen”; so you can’t rely on the
 unfullscreenification actually happening. But it will happen with
 most standard window managers, and GDK makes a best effort to get
 it to happen.</doc>
@@ -20744,13 +20744,13 @@ it to happen.</doc>
         </parameters>
       </method>
       <method name="unmaximize" c:identifier="gdk_window_unmaximize">
-        <doc xml:space="preserve">Unmaximizes the window. If the window wasn&#x2019;t maximized, then this
+        <doc xml:space="preserve">Unmaximizes the window. If the window wasn’t maximized, then this
 function does nothing.
 
 On X11, asks the window manager to unmaximize @window, if the
 window manager supports this operation. Not all window managers
-support this, and some deliberately ignore it or don&#x2019;t have a
-concept of &#x201C;maximized&#x201D;; so you can&#x2019;t rely on the unmaximization
+support this, and some deliberately ignore it or don’t have a
+concept of “maximized”; so you can’t rely on the unmaximization
 actually happening. But it will happen with most standard window
 managers, and GDK makes a best effort to get it to happen.
 
@@ -20981,11 +20981,11 @@ See also #GdkWindow::from-embedder.</doc>
         <type name="Cursor" c:type="GdkCursor*"/>
       </field>
       <field name="wmclass_name" writable="1">
-        <doc xml:space="preserve">don&#x2019;t use (see gtk_window_set_wmclass())</doc>
+        <doc xml:space="preserve">don’t use (see gtk_window_set_wmclass())</doc>
         <type name="utf8" c:type="gchar*"/>
       </field>
       <field name="wmclass_class" writable="1">
-        <doc xml:space="preserve">don&#x2019;t use (see gtk_window_set_wmclass())</doc>
+        <doc xml:space="preserve">don’t use (see gtk_window_set_wmclass())</doc>
         <type name="utf8" c:type="gchar*"/>
       </field>
       <field name="override_redirect" writable="1">
@@ -20999,8 +20999,8 @@ See also #GdkWindow::from-embedder.</doc>
     </record>
     <bitfield name="WindowAttributesType" glib:type-name="GdkWindowAttributesType" glib:get-type="gdk_window_attributes_type_get_type" c:type="GdkWindowAttributesType">
       <doc xml:space="preserve">Used to indicate which fields in the #GdkWindowAttr struct should be honored.
-For example, if you filled in the &#x201C;cursor&#x201D; and &#x201C;x&#x201D; fields of #GdkWindowAttr,
-pass &#x201C;@GDK_WA_X | @GDK_WA_CURSOR&#x201D; to gdk_window_new(). Fields in
+For example, if you filled in the “cursor” and “x” fields of #GdkWindowAttr,
+pass “@GDK_WA_X | @GDK_WA_CURSOR” to gdk_window_new(). Fields in
 #GdkWindowAttr not covered by a bit in this enum are required; for example,
 the @width/@height, @wclass, and @window_type fields are required, they have
 no corresponding flag in #GdkWindowAttributesType.</doc>
@@ -21251,11 +21251,11 @@ gtk_window_parse_geometry() automatically sets these flags.</doc>
         <doc xml:space="preserve">window gravity field is set</doc>
       </member>
       <member name="user_pos" value="128" c:identifier="GDK_HINT_USER_POS" glib:nick="user-pos" glib:name="GDK_HINT_USER_POS">
-        <doc xml:space="preserve">indicates that the window&#x2019;s position was explicitly set
+        <doc xml:space="preserve">indicates that the window’s position was explicitly set
  by the user</doc>
       </member>
       <member name="user_size" value="256" c:identifier="GDK_HINT_USER_SIZE" glib:nick="user-size" glib:name="GDK_HINT_USER_SIZE">
-        <doc xml:space="preserve">indicates that the window&#x2019;s size was explicitly set by
+        <doc xml:space="preserve">indicates that the window’s size was explicitly set by
  the user</doc>
       </member>
     </bitfield>
@@ -21412,7 +21412,7 @@ specification for more details about window types.</doc>
         <doc xml:space="preserve">A tooltip.</doc>
       </member>
       <member name="notification" value="11" c:identifier="GDK_WINDOW_TYPE_HINT_NOTIFICATION" glib:nick="notification" glib:name="GDK_WINDOW_TYPE_HINT_NOTIFICATION">
-        <doc xml:space="preserve">A notification - typically a &#x201C;bubble&#x201D;
+        <doc xml:space="preserve">A notification - typically a “bubble”
  that belongs to a status icon.</doc>
       </member>
       <member name="combo" value="12" c:identifier="GDK_WINDOW_TYPE_HINT_COMBO" glib:nick="combo" glib:name="GDK_WINDOW_TYPE_HINT_COMBO">
@@ -21426,7 +21426,7 @@ specification for more details about window types.</doc>
       <doc xml:space="preserve">@GDK_INPUT_OUTPUT windows are the standard kind of window you might expect.
 Such windows receive events and are also displayed on screen.
 @GDK_INPUT_ONLY windows are invisible; they are usually placed above other
-windows in order to trap or filter the events. You can&#x2019;t draw on
+windows in order to trap or filter the events. You can’t draw on
 @GDK_INPUT_ONLY windows.</doc>
       <member name="input_output" value="0" c:identifier="GDK_INPUT_OUTPUT" glib:nick="input-output" glib:name="GDK_INPUT_OUTPUT">
         <doc xml:space="preserve">window for graphics and events</doc>
@@ -21463,7 +21463,7 @@ not public API and must not be used by applications.</doc>
         </parameter>
         <parameter name="only_if_exists" transfer-ownership="none">
           <doc xml:space="preserve">if %TRUE, GDK is allowed to not create a new atom, but
-  just return %GDK_NONE if the requested atom doesn&#x2019;t already
+  just return %GDK_NONE if the requested atom doesn’t already
   exists. Currently, the flag is ignored, since checking the
   existance of an atom is as expensive as creating it.</doc>
           <type name="gboolean" c:type="gboolean"/>
@@ -21797,11 +21797,11 @@ the pixbuf.</doc>
 
 The string can either one of a large set of standard names
 (taken from the X11 `rgb.txt` file), or it can be a hexadecimal
-value in the form &#x201C;\#rgb&#x201D; &#x201C;\#rrggbb&#x201D;, &#x201C;\#rrrgggbbb&#x201D; or
-&#x201C;\#rrrrggggbbbb&#x201D; where &#x201C;r&#x201D;, &#x201C;g&#x201D; and &#x201C;b&#x201D; are hex digits of
+value in the form “\#rgb” “\#rrggbb”, “\#rrrgggbbb” or
+“\#rrrrggggbbbb” where “r”, “g” and “b” are hex digits of
 the red, green, and blue components of the color, respectively.
-(White in the four forms is &#x201C;\#fff&#x201D;, &#x201C;\#ffffff&#x201D;, &#x201C;\#fffffffff&#x201D;
-and &#x201C;\#ffffffffffff&#x201D;).</doc>
+(White in the four forms is “\#fff”, “\#ffffff”, “\#fffffffff”
+and “\#ffffffffffff”).</doc>
       <doc-deprecated xml:space="preserve">Use #GdkRGBA</doc-deprecated>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">%TRUE if the parsing succeeded</doc>
@@ -21846,10 +21846,10 @@ gdk_window_set_cursor() or by setting the cursor member of the
 to gdk_display_open(), gtk_init(), gtk_init_with_args() or
 gtk_init_check() in order to take effect.
 
-Most common GTK+ applications won&#x2019;t ever need to call this. Only
+Most common GTK+ applications won’t ever need to call this. Only
 applications that do mixed GDK/Xlib calls could want to disable
 multidevice support if such Xlib code deals with input devices in
-any way and doesn&#x2019;t observe the presence of XInput 2.</doc>
+any way and doesn’t observe the presence of XInput 2.</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
       </return-value>
@@ -22207,7 +22207,7 @@ to a drop initiated by the drag source.</doc>
       <doc xml:space="preserve">Removes an error trap pushed with gdk_error_trap_push().
 May block until an error has been definitively received
 or not received from the X server. gdk_error_trap_pop_ignored()
-is preferred if you don&#x2019;t need to know whether an error
+is preferred if you don’t need to know whether an error
 occurred, because it never has to block. If you don't
 need the return value of gdk_error_trap_pop(), use
 gdk_error_trap_pop_ignored().
@@ -22234,7 +22234,7 @@ trap was pushed, that error will be ignored.</doc>
 behavior of exiting the application. It should only be used if it
 is not possible to avoid the X error in any other way. Errors are
 ignored on all #GdkDisplay currently known to the
-#GdkDisplayManager. If you don&#x2019;t care which error happens and just
+#GdkDisplayManager. If you don’t care which error happens and just
 want to ignore everything, pop with gdk_error_trap_pop_ignored().
 If you need the error code, use gdk_error_trap_pop() which may have
 to block and wait for the error to arrive from the X server.
@@ -22643,10 +22643,10 @@ is a mapping from #GdkKeymapKey to key values. You can think of a #GdkKeymapKey
 as a representation of a symbol printed on a physical keyboard key. That is, it
 contains three pieces of information. First, it contains the hardware keycode;
 this is an identifying number for a physical key. Second, it contains the
-&#x201C;level&#x201D; of the key. The level indicates which symbol on the
+“level” of the key. The level indicates which symbol on the
 key will be used, in a vertical direction. So on a standard US keyboard, the key
-with the number &#x201C;1&#x201C; on it also has the exclamation point (&#x201D;!&#x201D;) character on
-it. The level indicates whether to use the &#x201C;1&#x201D; or the &#x201C;!&#x201D; symbol.  The letter
+with the number “1“ on it also has the exclamation point (”!”) character on
+it. The level indicates whether to use the “1” or the “!” symbol.  The letter
 keys are considered to have a lowercase letter at level 0, and an uppercase
 letter at level 1, though only the uppercase letter is printed.  Third, the
 #GdkKeymapKey contains a group; groups are not used on standard US keyboards,
@@ -22657,14 +22657,14 @@ group 0, a key might have two English characters, and in group 1 it might have
 two Hebrew characters. The Hebrew characters will be printed on the key next to
 the English characters.
 
-In order to use a keymap to interpret a key event, it&#x2019;s necessary to first
+In order to use a keymap to interpret a key event, it’s necessary to first
 convert the keyboard state into an effective group and level. This is done via a
 set of rules that varies widely according to type of keyboard and user
 configuration. The function gdk_keymap_translate_keyboard_state() accepts a
 keyboard state -- consisting of hardware keycode pressed, active modifiers, and
 active group -- applies the appropriate rules, and returns the group/level to be
 used to index the keymap, along with the modifiers which did not affect the
-group and level. i.e. it returns &#x201C;unconsumed modifiers.&#x201D; The keyboard group may
+group and level. i.e. it returns “unconsumed modifiers.” The keyboard group may
 differ from the effective group used for keymap lookups because some keys don't
 have multiple groups - e.g. the Enter key is always in group 0 regardless of
 keyboard state.
@@ -22672,7 +22672,7 @@ keyboard state.
 Note that gdk_keymap_translate_keyboard_state() also returns the keyval, i.e. it
 goes ahead and performs the keymap lookup in addition to telling you which
 effective group/level values were used for the lookup. #GdkEventKey already
-contains this keyval, however, so you don&#x2019;t normally need to call
+contains this keyval, however, so you don’t normally need to call
 gdk_keymap_translate_keyboard_state() just to get the keyval.</doc>
     </docsection>
     <function name="keyval_convert_case" c:identifier="gdk_keyval_convert_case">
@@ -22701,7 +22701,7 @@ Examples of keyvals are #GDK_KEY_a, #GDK_KEY_Enter, #GDK_KEY_F1, etc.</doc>
 
 The names are the same as those in the
 `gdk/gdkkeysyms.h` header file
-but without the leading &#x201C;GDK_KEY_&#x201D;.</doc>
+but without the leading “GDK_KEY_”.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the corresponding key value, or %GDK_KEY_VoidSymbol
     if the key name is not a valid key</doc>
@@ -22747,7 +22747,7 @@ but without the leading &#x201C;GDK_KEY_&#x201D;.</doc>
 
 The names are the same as those in the
 `gdk/gdkkeysyms.h` header file
-but without the leading &#x201C;GDK_KEY_&#x201D;.</doc>
+but without the leading “GDK_KEY_”.</doc>
       <return-value transfer-ownership="none" nullable="1">
         <doc xml:space="preserve">a string containing the name
     of the key, or %NULL if @keyval is not a valid key. The string
@@ -22811,7 +22811,7 @@ A visual describes a hardware image data format.
 For example, a visual might support 24-bit color, or 8-bit color,
 and might expect pixels to be in a certain format.
 
-Call g_list_free() on the return value when you&#x2019;re finished with it.</doc>
+Call g_list_free() on the return value when you’re finished with it.</doc>
       <doc-deprecated xml:space="preserve">Use gdk_screen_list_visuals (gdk_screen_get_default ()).</doc-deprecated>
       <return-value transfer-ownership="container">
         <doc xml:space="preserve">
@@ -22824,7 +22824,7 @@ Call g_list_free() on the return value when you&#x2019;re finished with it.</doc
     <function name="notify_startup_complete" c:identifier="gdk_notify_startup_complete" version="2.2">
       <doc xml:space="preserve">Indicates to the GUI environment that the application has finished
 loading. If the applications opens windows, this function is
-normally called after opening the application&#x2019;s initial set of
+normally called after opening the application’s initial set of
 windows.
 
 GTK+ will call this function automatically after opening the first
@@ -22907,7 +22907,7 @@ signal on the @embedder and the #GdkWindow::to-embedder and
     <function name="pango_context_get" c:identifier="gdk_pango_context_get">
       <doc xml:space="preserve">Creates a #PangoContext for the default GDK screen.
 
-The context must be freed when you&#x2019;re finished with it.
+The context must be freed when you’re finished with it.
 
 When using GTK+, normally you should use gtk_widget_get_pango_context()
 instead of this function, to get the appropriate context for
@@ -22917,7 +22917,7 @@ The newly created context will have the default font options (see
 #cairo_font_options_t) for the default screen; if these options
 change it will not be updated. Using gtk_widget_get_pango_context()
 is more convenient if you want to keep a context around and track
-changes to the screen&#x2019;s font rendering settings.</doc>
+changes to the screen’s font rendering settings.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">a new #PangoContext for the default display</doc>
         <type name="Pango.Context" c:type="PangoContext*"/>
@@ -22926,7 +22926,7 @@ changes to the screen&#x2019;s font rendering settings.</doc>
     <function name="pango_context_get_for_display" c:identifier="gdk_pango_context_get_for_display" version="3.22">
       <doc xml:space="preserve">Creates a #PangoContext for @display.
 
-The context must be freed when you&#x2019;re finished with it.
+The context must be freed when you’re finished with it.
 
 When using GTK+, normally you should use gtk_widget_get_pango_context()
 instead of this function, to get the appropriate context for
@@ -22951,7 +22951,7 @@ changes to the font rendering settings.</doc>
     <function name="pango_context_get_for_screen" c:identifier="gdk_pango_context_get_for_screen" version="2.2">
       <doc xml:space="preserve">Creates a #PangoContext for @screen.
 
-The context must be freed when you&#x2019;re finished with it.
+The context must be freed when you’re finished with it.
 
 When using GTK+, normally you should use gtk_widget_get_pango_context()
 instead of this function, to get the appropriate context for
@@ -22961,7 +22961,7 @@ The newly created context will have the default font options
 (see #cairo_font_options_t) for the screen; if these options
 change it will not be updated. Using gtk_widget_get_pango_context()
 is more convenient if you want to keep a context around and track
-changes to the screen&#x2019;s font rendering settings.</doc>
+changes to the screen’s font rendering settings.</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">a new #PangoContext for @screen</doc>
         <type name="Pango.Context" c:type="PangoContext*"/>
@@ -22981,7 +22981,7 @@ GDK.
 
 Creating a #PangoLayout object is the first step in rendering text,
 and requires getting a handle to a #PangoContext. For GTK+ programs,
-you&#x2019;ll usually want to use gtk_widget_get_pango_context(), or
+you’ll usually want to use gtk_widget_get_pango_context(), or
 gtk_widget_create_pango_layout(), rather than using the lowlevel
 gdk_pango_context_get_for_screen(). Once you have a #PangoLayout, you
 can set the text and attributes of it with Pango functions like
@@ -23068,7 +23068,7 @@ g_object_unref (context);
       <doc xml:space="preserve">Obtains a clip region which contains the areas where the given ranges
 of text would be drawn. @x_origin and @y_origin are the top left point
 to center the layout. @index_ranges should contain
-ranges of bytes in the layout&#x2019;s text.
+ranges of bytes in the layout’s text.
 
 Note that the regions returned correspond to logical extents of the text
 ranges, not ink extents. So the drawn layout may in fact touch areas out of
@@ -23105,7 +23105,7 @@ of text, such as when text is selected.</doc>
       <doc xml:space="preserve">Obtains a clip region which contains the areas where the given
 ranges of text would be drawn. @x_origin and @y_origin are the top left
 position of the layout. @index_ranges
-should contain ranges of bytes in the layout&#x2019;s text. The clip
+should contain ranges of bytes in the layout’s text. The clip
 region will include space to the left or right of the line (to the
 layout bounding box) if you have indexes above or below the indexes
 contained inside the line. This is to draw the selection all the way
@@ -23154,7 +23154,7 @@ use by calls to gdk_display_open().
 Any arguments used by GDK are removed from the array and @argc and @argv are
 updated accordingly.
 
-You shouldn&#x2019;t call this function explicitly if you are using
+You shouldn’t call this function explicitly if you are using
 gtk_init(), gtk_init_check(), gdk_init(), or gdk_init_check().</doc>
       <return-value transfer-ownership="none">
         <type name="none" c:type="void"/>
@@ -23226,14 +23226,14 @@ obscured/offscreen regions to be placed in the pixbuf. The contents of
 portions of the pixbuf corresponding to the offscreen region are
 undefined.
 
-If the window you&#x2019;re obtaining data from is partially obscured by
+If the window you’re obtaining data from is partially obscured by
 other windows, then the contents of the pixbuf areas corresponding
 to the obscured regions are undefined.
 
-If the window is not mapped (typically because it&#x2019;s iconified/minimized
+If the window is not mapped (typically because it’s iconified/minimized
 or not on the current workspace), then %NULL will be returned.
 
-If memory can&#x2019;t be allocated for the return value, %NULL will be returned
+If memory can’t be allocated for the return value, %NULL will be returned
 instead.
 
 In short, there are several ways this function can fail, and if it fails
@@ -23337,7 +23337,7 @@ are emitted when the grab ends unvoluntarily.</doc>
         <parameter name="time_" transfer-ownership="none">
           <doc xml:space="preserve">the timestamp of the event which led to this pointer grab. This usually
         comes from a #GdkEventButton struct, though %GDK_CURRENT_TIME can be used if
-        the time isn&#x2019;t known.</doc>
+        the time isn’t known.</doc>
           <type name="guint32" c:type="guint32"/>
         </parameter>
       </parameters>
@@ -23381,16 +23381,16 @@ public API and should not be used in application code.</doc>
     </function>
     <docsection name="properties">
       <doc xml:space="preserve">Each window under X can have any number of associated
-&#x201C;properties&#x201D; attached to it.
+“properties” attached to it.
 Properties are arbitrary chunks of data identified by
-&#x201C;atom&#x201D;s. (An &#x201C;atom&#x201D;
+“atom”s. (An “atom”
 is a numeric index into a string table on the X server. They are used
 to transfer strings efficiently between clients without
 having to transfer the entire string.) A property
 has an associated type, which is also identified
 using an atom.
 
-A property has an associated &#x201C;format&#x201D;,
+A property has an associated “format”,
 an integer describing how many bits are in each unit
 of data inside the property. It must be 8, 16, or 32.
 When data is transferred between the server and client,
@@ -23552,7 +23552,7 @@ gdk_property_get() is provided.</doc>
     </function>
     <function name="query_depths" c:identifier="gdk_query_depths" deprecated="1" deprecated-version="3.22">
       <doc xml:space="preserve">This function returns the available bit depths for the default
-screen. It&#x2019;s equivalent to listing the visuals
+screen. It’s equivalent to listing the visuals
 (gdk_list_visuals()) and then looking at the depth field in each
 visual, removing duplicates.
 
@@ -23578,7 +23578,7 @@ The array returned by this function should not be freed.</doc>
     </function>
     <function name="query_visual_types" c:identifier="gdk_query_visual_types" deprecated="1" deprecated-version="3.22">
       <doc xml:space="preserve">This function returns the available visual types for the default
-screen. It&#x2019;s equivalent to listing the visuals
+screen. It’s equivalent to listing the visuals
 (gdk_list_visuals()) and then looking at the type field in each
 visual, removing duplicates.
 
@@ -23604,7 +23604,7 @@ The array returned by this function should not be freed.</doc>
     </function>
     <docsection name="regions">
       <doc xml:space="preserve">GDK provides the #GdkPoint and #GdkRectangle data types for representing pixels
-and sets of pixels on the screen. Together with Cairo&#x2019;s #cairo_region_t data
+and sets of pixels on the screen. Together with Cairo’s #cairo_region_t data
 type, they make up the central types for representing graphical data.
 
 A #GdkPoint represents an x and y coordinate of a point.
@@ -23618,7 +23618,7 @@ gdk_rectangle_union().
     </docsection>
     <docsection name="rgba_colors">
       <doc xml:space="preserve">#GdkRGBA is a convenient way to pass rgba colors around.
-It&#x2019;s based on cairo&#x2019;s way to deal with colors and mirrors its behavior.
+It’s based on cairo’s way to deal with colors and mirrors its behavior.
 All values are in the range from 0.0 to 1.0 inclusive. So the color
 (0.0, 0.0, 0.0, 0.0) represents transparent black and
 (1.0, 1.0, 1.0, 1.0) is opaque white. Other values will be clamped
@@ -23859,17 +23859,17 @@ API instead.</doc>
       </parameters>
     </function>
     <docsection name="selections">
-      <doc xml:space="preserve">GDK&#x2019;s selection functions, based on the [X selection mechanism](
+      <doc xml:space="preserve">GDK’s selection functions, based on the [X selection mechanism](
 https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html),
 provide a way to transfer arbitrary chunks of
-data between programs. A &#x201C;selection&#x201D; is a essentially
+data between programs. A “selection” is a essentially
 a named clipboard, identified by a string interned as a #GdkAtom. By
 claiming ownership of a selection, an application indicates that it will
 be responsible for supplying its contents. The most common selections are
 `PRIMARY` and `CLIPBOARD`.
 
 The contents of a selection can be represented in a number of formats,
-called &#x201C;targets&#x201D;. Each target is identified by an atom.
+called “targets”. Each target is identified by an atom.
 A list of all possible targets supported by the selection owner can be
 retrieved by requesting the special target `TARGETS`. When
 a selection is retrieved, the data is accompanied by a type (an atom), and
@@ -24171,7 +24171,7 @@ accesses to the same #GHashTable from multiple threads.
 
 GTK+, however, is not thread safe. You should only use GTK+ and GDK
 from the thread gtk_init() and gtk_main() were called on.
-This is usually referred to as the &#x201C;main thread&#x201D;.
+This is usually referred to as the “main thread”.
 
 Signals on GTK+ and GDK types, as well as non-signal callbacks, are
 emitted in the main thread.
@@ -24336,7 +24336,7 @@ Note that timeout functions may be delayed, due to the processing of other
 event sources. Thus they should not be relied on for precise timing.
 After each call to the timeout function, the time of the next
 timeout is recalculated based on the current time and the given interval
-(it does not try to &#x201C;catch up&#x201D; time lost in delays).
+(it does not try to “catch up” time lost in delays).
 
 This variant of g_timeout_add_full() can be thought of a MT-safe version
 for GTK+ widgets for the following use case:
@@ -24424,7 +24424,7 @@ For details, see gdk_threads_add_timeout_full().</doc>
     <function name="threads_add_timeout_seconds_full" c:identifier="gdk_threads_add_timeout_seconds_full" shadows="threads_add_timeout_seconds" version="2.14">
       <doc xml:space="preserve">A variant of gdk_threads_add_timeout_full() with second-granularity.
 See g_timeout_add_seconds_full() for a discussion of why it is
-a good idea to use this function if you don&#x2019;t need finer granularity.</doc>
+a good idea to use this function if you don’t need finer granularity.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the ID (greater than 0) of the event source.</doc>
         <type name="guint" c:type="guint"/>
@@ -24502,7 +24502,7 @@ lock that when held, holds the GTK+ lock as well. When GTK+ unlocks
 the GTK+ lock when entering a recursive main loop, the application
 must temporarily release its lock as well.
 
-Most threaded GTK+ apps won&#x2019;t need to use this method.
+Most threaded GTK+ apps won’t need to use this method.
 
 This method must be called before gdk_threads_init(), and cannot
 be called multiple times.</doc>
@@ -24563,15 +24563,15 @@ the way the bits are translated into an RGB value for display, and
 the way the bits are stored in memory. For example, a piece of display
 hardware might support 24-bit color, 16-bit color, or 8-bit color;
 meaning 24/16/8-bit pixel sizes. For a given pixel size, pixels can
-be in different formats; for example the &#x201C;red&#x201D; element of an RGB pixel
+be in different formats; for example the “red” element of an RGB pixel
 may be in the top 8 bits of the pixel, or may be in the lower 4 bits.
 
 There are several standard visuals. The visual returned by
-gdk_screen_get_system_visual() is the system&#x2019;s default visual, and
+gdk_screen_get_system_visual() is the system’s default visual, and
 the visual returned by gdk_screen_get_rgba_visual() should be used for
 creating windows with an alpha channel.
 
-A number of functions are provided for determining the &#x201C;best&#x201D; available
+A number of functions are provided for determining the “best” available
 visual. For the purposes of making this determination, higher bit depths
 are considered better, and for visuals of the same bit depth,
 %GDK_VISUAL_PSEUDO_COLOR is preferred at 8bpp, otherwise, the visual
@@ -24582,9 +24582,9 @@ types are ranked in the order of(highest to lowest)
     </docsection>
     <docsection name="windows">
       <doc xml:space="preserve">A #GdkWindow is a (usually) rectangular region on the screen.
-It&#x2019;s a low-level object, used to implement high-level objects such as
+It’s a low-level object, used to implement high-level objects such as
 #GtkWidget and #GtkWindow on the GTK+ level. A #GtkWindow is a toplevel
-window, the thing a user might think of as a &#x201C;window&#x201D; with a titlebar
+window, the thing a user might think of as a “window” with a titlebar
 and so on; a #GtkWindow may contain many #GdkWindows. For example,
 each #GtkButton has a #GdkWindow associated with it.
 
@@ -24593,7 +24593,7 @@ each #GtkButton has a #GdkWindow associated with it.
 Normally, the windowing system takes care of rendering the contents
 of a child window onto its parent window. This mechanism can be
 intercepted by calling gdk_window_set_composited() on the child
-window. For a &#x201C;composited&#x201D; window it is the
+window. For a “composited” window it is the
 responsibility of the application to render the window contents at
 the right spot.
 

--- a/Gdk-4.0.gir
+++ b/Gdk-4.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -2800,7 +2800,7 @@ This function consumes @error.</doc>
       <member name="device_switch" value="8" c:identifier="GDK_CROSSING_DEVICE_SWITCH" glib:nick="device-switch" glib:name="GDK_CROSSING_DEVICE_SWITCH">
         <doc xml:space="preserve">crossing because of a device switch (i.e.
   a mouse taking control of the pointer after a touch device), this event
-  is synthetic as the pointer didn&#x2019;t leave the surface.</doc>
+  is synthetic as the pointer didn’t leave the surface.</doc>
       </member>
     </enumeration>
     <class name="Cursor" c:symbol-prefix="cursor" c:type="GdkCursor" parent="GObject.Object" glib:type-name="GdkCursor" glib:get-type="gdk_cursor_get_type" glib:type-struct="CursorClass">
@@ -2942,11 +2942,11 @@ platforms can be found in the CSS specification:
             <type name="Texture" c:type="GdkTexture*"/>
           </parameter>
           <parameter name="hotspot_x" transfer-ownership="none">
-            <doc xml:space="preserve">the horizontal offset of the &#x201C;hotspot&#x201D; of the cursor</doc>
+            <doc xml:space="preserve">the horizontal offset of the “hotspot” of the cursor</doc>
             <type name="gint" c:type="int"/>
           </parameter>
           <parameter name="hotspot_y" transfer-ownership="none">
-            <doc xml:space="preserve">the vertical offset of the &#x201C;hotspot&#x201D; of the cursor</doc>
+            <doc xml:space="preserve">the vertical offset of the “hotspot” of the cursor</doc>
             <type name="gint" c:type="int"/>
           </parameter>
           <parameter name="fallback" transfer-ownership="none" nullable="1" allow-none="1">
@@ -4189,7 +4189,7 @@ On modern displays, this value is always %TRUE.</doc>
 alpha channel.
 
 Even if a %TRUE is returned, it is possible that the
-surface&#x2019;s alpha channel won&#x2019;t be honored when displaying the
+surface’s alpha channel won’t be honored when displaying the
 surface on the screen: in particular, for X an appropriate
 windowing manager and compositing manager must be running to
 provide appropriate display. Use [method@Gdk.Display.is_composited]
@@ -6940,7 +6940,7 @@ timescale as g_get_monotonic_time(), however, it is not the same
 as g_get_monotonic_time(). The frame time does not advance during
 the time a frame is being painted, and outside of a frame, an attempt
 is made so that all calls to [method@Gdk.FrameClock.get_frame_time] that
-are called at a &#x201C;similar&#x201D; time get the same value. This means that
+are called at a “similar” time get the same value. This means that
 if different animations are timed by looking at the difference in
 time between an initial value from [method@Gdk.FrameClock.get_frame_time]
 and the value inside the [signal@Gdk.FrameClock::update] signal of the clock,
@@ -7026,10 +7026,10 @@ each frame drawn.</doc>
       <method name="get_frame_time" c:identifier="gdk_frame_clock_get_frame_time">
         <doc xml:space="preserve">Gets the time that should currently be used for animations.
 
-Inside the processing of a frame, it&#x2019;s the time used to compute the
+Inside the processing of a frame, it’s the time used to compute the
 animation position of everything in a frame. Outside of a frame, it's
-the time of the conceptual &#x201C;previous frame,&#x201D; which may be either
-the actual previous frame time, or if that&#x2019;s too old, an updated
+the time of the conceptual “previous frame,” which may be either
+the actual previous frame time, or if that’s too old, an updated
 time.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">a timestamp in microseconds, in the timescale of
@@ -7303,13 +7303,13 @@ The frame is complete.</doc>
       </member>
     </enumeration>
     <record name="FrameTimings" c:type="GdkFrameTimings" opaque="1" glib:type-name="GdkFrameTimings" glib:get-type="gdk_frame_timings_get_type" c:symbol-prefix="frame_timings">
-      <doc xml:space="preserve">Holds timing information for a single frame of the application&#x2019;s displays.
+      <doc xml:space="preserve">Holds timing information for a single frame of the application’s displays.
 
 To retrieve `GdkFrameTimings` objects, use [method@Gdk.FrameClock.get_timings]
 or [method@Gdk.FrameClock.get_current_timings]. The information in
 `GdkFrameTimings` is useful for precise synchronization of video with
 the event or audio streams, and for measuring quality metrics for the
-application&#x2019;s display, such as latency and jitter.</doc>
+application’s display, such as latency and jitter.</doc>
       <method name="get_complete" c:identifier="gdk_frame_timings_get_complete">
         <doc xml:space="preserve">Returns whether @timings are complete.
 
@@ -7414,8 +7414,8 @@ This is the time at which the frame became visible to the user.</doc>
         <doc xml:space="preserve">Gets the natural interval between presentation times for
 the display that this frame was displayed on.
 
-Frame presentation usually happens during the &#x201C;vertical
-blanking interval&#x201D;.</doc>
+Frame presentation usually happens during the “vertical
+blanking interval”.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the refresh interval of the display, in microseconds,
   or 0 if the refresh interval is not available.
@@ -16102,9 +16102,9 @@ Note that we ignore Caps Lock for matching.</doc>
       </field>
       <field name="level" writable="1">
         <doc xml:space="preserve">indicates which symbol on the key will be used, in a vertical direction.
-  So on a standard US keyboard, the key with the number &#x201C;1&#x201D; on it also has the
+  So on a standard US keyboard, the key with the number “1” on it also has the
   exclamation point ("!") character on it. The level indicates whether to use
-  the &#x201C;1&#x201D; or the &#x201C;!&#x201D; symbol. The letter keys are considered to have a lowercase
+  the “1” or the “!” symbol. The letter keys are considered to have a lowercase
   letter at level 0, and an uppercase letter at level 1, though only the
   uppercase letter is printed.</doc>
         <type name="gint" c:type="int"/>
@@ -16790,7 +16790,7 @@ The format is opaque.</doc>
       <constructor name="new" c:identifier="gdk_memory_texture_new">
         <doc xml:space="preserve">Creates a new texture for a blob of image data.
 
-The `GBytes` must contain @stride &#xD7; @height pixels
+The `GBytes` must contain @stride × @height pixels
 in the given format.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A newly-created `GdkTexture`</doc>
@@ -17343,8 +17343,8 @@ This can be used to identify a monitor in the UI.</doc>
         <doc xml:space="preserve">Retrieves the size and position of the monitor within the
 display coordinate space.
 
-The returned geometry is in  &#x201D;application pixels&#x201D;, not in
-&#x201D;device pixels&#x201D; (see [method@Gdk.Monitor.get_scale]).</doc>
+The returned geometry is in  ”application pixels”, not in
+”device pixels” (see [method@Gdk.Monitor.get_scale]).</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -17425,7 +17425,7 @@ is returned as 60000.</doc>
 to device pixels.
 
 This can be used if you want to create pixel based data for a
-particular monitor, but most of the time you&#x2019;re drawing to a surface
+particular monitor, but most of the time you’re drawing to a surface
 where it is better to use [method@Gdk.Surface.get_scale] instead.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the scale</doc>
@@ -17446,7 +17446,7 @@ On traditional systems this is 1, but on very high density outputs
 it can be a higher value (often 2).
 
 This can be used if you want to create pixel based data for a
-particular monitor, but most of the time you&#x2019;re drawing to a surface
+particular monitor, but most of the time you’re drawing to a surface
 where it is better to use [method@Gdk.Surface.get_scale_factor] instead.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the scale factor</doc>
@@ -18755,10 +18755,10 @@ surrounding the window, would there be any.</doc>
       <doc xml:space="preserve">An event related to the proximity of a tool to a device.</doc>
     </class>
     <record name="RGBA" c:type="GdkRGBA" glib:type-name="GdkRGBA" glib:get-type="gdk_rgba_get_type" c:symbol-prefix="rgba">
-      <doc xml:space="preserve">Represents a color, in a way that is compatible with cairo&#x2019;s notion of color.
+      <doc xml:space="preserve">Represents a color, in a way that is compatible with cairo’s notion of color.
 
-`GdkRGBA` is a convenient way to pass colors around. It&#x2019;s based on
-cairo&#x2019;s way to deal with colors and mirrors its behavior. All values
+`GdkRGBA` is a convenient way to pass colors around. It’s based on
+cairo’s way to deal with colors and mirrors its behavior. All values
 are in the range from 0.0 to 1.0 inclusive. So the color
 (0.0, 0.0, 0.0, 0.0) represents transparent black and
 (1.0, 1.0, 1.0, 1.0) is opaque white. Other values will
@@ -18875,22 +18875,22 @@ from previous contents.</doc>
 The string can be either one of:
 
 - A standard name (Taken from the CSS specification).
-- A hexadecimal value in the form &#x201C;\#rgb&#x201D;, &#x201C;\#rrggbb&#x201D;,
-  &#x201C;\#rrrgggbbb&#x201D; or &#x201D;\#rrrrggggbbbb&#x201D;
-- A hexadecimal value in the form &#x201C;\#rgba&#x201D;, &#x201C;\#rrggbbaa&#x201D;,
-  or &#x201D;\#rrrrggggbbbbaaaa&#x201D;
-- A RGB color in the form &#x201C;rgb(r,g,b)&#x201D; (In this case the color
+- A hexadecimal value in the form “\#rgb”, “\#rrggbb”,
+  “\#rrrgggbbb” or ”\#rrrrggggbbbb”
+- A hexadecimal value in the form “\#rgba”, “\#rrggbbaa”,
+  or ”\#rrrrggggbbbbaaaa”
+- A RGB color in the form “rgb(r,g,b)” (In this case the color
   will have full opacity)
-- A RGBA color in the form &#x201C;rgba(r,g,b,a)&#x201D;
-- A HSL color in the form &#x201C;hsl(h,s,l)&#x201D;
-- A HSLA color in the form &#x201C;hsla(h,s,l,a)&#x201D;
+- A RGBA color in the form “rgba(r,g,b,a)”
+- A HSL color in the form “hsl(h,s,l)”
+- A HSLA color in the form “hsla(h,s,l,a)”
 
-Where &#x201C;r&#x201D;, &#x201C;g&#x201D;, &#x201C;b&#x201D; and &#x201C;a&#x201D; are respectively the red, green,
-blue and alpha color values. In the last two cases, &#x201C;r&#x201D;, &#x201C;g&#x201D;,
-and &#x201C;b&#x201D; are either integers in the range 0 to 255 or percentage
+Where “r”, “g”, “b” and “a” are respectively the red, green,
+blue and alpha color values. In the last two cases, “r”, “g”,
+and “b” are either integers in the range 0 to 255 or percentage
 values in the range 0% to 100%, and a is a floating point value
-in the range 0 to 1. The range for &#x201C;h&#x201D; is 0 to 360, and
-&#x201C;s&#x201D;, &#x201C;l&#x201D; can be either numbers in the range 0 to 100 or
+in the range 0 to 1. The range for “h” is 0 to 360, and
+“s”, “l” can be either numbers in the range 0 to 100 or
 percentages.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">%TRUE if the parsing succeeded</doc>
@@ -18926,17 +18926,17 @@ percentages.</doc>
       </method>
       <method name="to_string" c:identifier="gdk_rgba_to_string">
         <doc xml:space="preserve">Returns a textual specification of @rgba in the form
-`rgb(r,g,b)` or `rgba(r,g,b,a)`, where &#x201C;r&#x201D;, &#x201C;g&#x201D;, &#x201C;b&#x201D; and
-&#x201C;a&#x201D; represent the red, green, blue and alpha values
-respectively. &#x201C;r&#x201D;, &#x201C;g&#x201D;, and &#x201C;b&#x201D; are represented as integers
-in the range 0 to 255, and &#x201C;a&#x201D; is represented as a floating
+`rgb(r,g,b)` or `rgba(r,g,b,a)`, where “r”, “g”, “b” and
+“a” represent the red, green, blue and alpha values
+respectively. “r”, “g”, and “b” are represented as integers
+in the range 0 to 255, and “a” is represented as a floating
 point value in the range 0 to 1.
 
 These string forms are string forms that are supported by
 the CSS3 colors module, and can be parsed by [method@Gdk.RGBA.parse].
 
 Note that this string representation may lose some precision,
-since &#x201C;r&#x201D;, &#x201C;g&#x201D; and &#x201C;b&#x201D; are represented as 8-bit integers. If
+since “r”, “g” and “b” are represented as 8-bit integers. If
 this is a concern, you should use a different representation.</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">A newly allocated text string</doc>
@@ -18953,7 +18953,7 @@ this is a concern, you should use a different representation.</doc>
     <record name="Rectangle" c:type="GdkRectangle" glib:type-name="GdkRectangle" glib:get-type="gdk_rectangle_get_type" c:symbol-prefix="rectangle">
       <doc xml:space="preserve">Represents a rectangle.
 
-`GdkRectangle` is identical to `cairo_rectangle_t`. Together with Cairo&#x2019;s
+`GdkRectangle` is identical to `cairo_rectangle_t`. Together with Cairo’s
 `cairo_region_t` data type, these are the central types for representing
 sets of pixels.
 
@@ -19024,7 +19024,7 @@ volumes in 2D and 3D.</doc>
         <doc xml:space="preserve">Calculates the intersection of two rectangles.
 
 It is allowed for @dest to be the same as either @src1 or @src2.
-If the rectangles do not intersect, @dest&#x2019;s width and height is set
+If the rectangles do not intersect, @dest’s width and height is set
 to 0 and its x and y values are undefined. If you are only interested
 in whether the rectangles intersect, but not in the intersecting area
 itself, pass %NULL for @dest.</doc>
@@ -19440,7 +19440,7 @@ of physical pixels on an output device are laid out.</doc>
     <class name="Surface" c:symbol-prefix="surface" c:type="GdkSurface" parent="GObject.Object" abstract="1" glib:type-name="GdkSurface" glib:get-type="gdk_surface_get_type" glib:type-struct="SurfaceClass">
       <doc xml:space="preserve">Represents a rectangular region on the screen.
 
-It&#x2019;s a low-level object, used to implement high-level objects
+It’s a low-level object, used to implement high-level objects
 such as [GtkWindow](../gtk4/class.Window.html).
 
 The surfaces you see in practice are either [iface@Gdk.Toplevel] or
@@ -19542,7 +19542,7 @@ Initially the surface contents are all 0 (transparent if contents
 have transparency, black otherwise.)
 
 This function always returns a valid pointer, but it will return a
-pointer to a &#x201C;nil&#x201D; surface if @other is already in an error state
+pointer to a “nil” surface if @other is already in an error state
 or any other error occurs.</doc>
         <doc-deprecated xml:space="preserve">Create a suitable cairo image surface yourself</doc-deprecated>
         <return-value transfer-ownership="full">
@@ -19590,7 +19590,7 @@ or any other error occurs.</doc>
 decrements @surface's reference count.
 
 The window system resources for all children of @surface are also
-destroyed, but the children&#x2019;s reference counts are not decremented.
+destroyed, but the children’s reference counts are not decremented.
 
 Note that a surface will not be destroyed automatically when its
 reference count reaches zero. You must call this function yourself
@@ -19711,8 +19711,8 @@ reparented to a new toplevel surface.</doc>
       <method name="get_height" c:identifier="gdk_surface_get_height" glib:get-property="height">
         <doc xml:space="preserve">Returns the height of the given @surface.
 
-Surface size is reported in &#x201D;application pixels&#x201D;, not
-&#x201D;device pixels&#x201D; (see [method@Gdk.Surface.get_scale_factor]).</doc>
+Surface size is reported in ”application pixels”, not
+”device pixels” (see [method@Gdk.Surface.get_scale_factor]).</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">The height of @surface</doc>
           <type name="gint" c:type="int"/>
@@ -19789,8 +19789,8 @@ The scale factor may change during the lifetime of the surface.</doc>
       <method name="get_width" c:identifier="gdk_surface_get_width" glib:get-property="width">
         <doc xml:space="preserve">Returns the width of the given @surface.
 
-Surface size is reported in &#x201D;application pixels&#x201D;, not
-&#x201D;device pixels&#x201D; (see [method@Gdk.Surface.get_scale_factor]).</doc>
+Surface size is reported in ”application pixels”, not
+”device pixels” (see [method@Gdk.Surface.get_scale_factor]).</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">The width of @surface</doc>
           <type name="gint" c:type="int"/>
@@ -19807,7 +19807,7 @@ Surface size is reported in &#x201D;application pixels&#x201D;, not
 
 For toplevel surfaces, withdraws them, so they will no longer be
 known to the window manager; for all surfaces, unmaps them, so
-they won&#x2019;t be displayed. Normally done automatically as
+they won’t be displayed. Normally done automatically as
 part of [gtk_widget_hide()](../gtk4/method.Widget.hide.html).</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -19922,7 +19922,7 @@ to an unset bit in the mask will be passed on the surface below
 An input region is typically used with RGBA surfaces. The alpha
 channel of the surface defines which pixels are invisible and
 allows for nicely antialiased borders, and the input region
-controls where the surface is &#x201C;clickable&#x201D;.
+controls where the surface is “clickable”.
 
 Use [method@Gdk.Display.supports_input_shapes] to find out if
 a particular backend supports input regions.</doc>
@@ -20066,8 +20066,8 @@ compared to [property@Gdk.Surface:scale].</doc>
         <doc xml:space="preserve">Emitted when the size of @surface is changed, or when relayout should
 be performed.
 
-Surface size is reported in &#x201D;application pixels&#x201D;, not
-&#x201D;device pixels&#x201D; (see gdk_surface_get_scale_factor()).</doc>
+Surface size is reported in ”application pixels”, not
+”device pixels” (see gdk_surface_get_scale_factor()).</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -20832,7 +20832,7 @@ You might use this function to implement draggable titlebars.</doc>
       <method name="begin_resize" c:identifier="gdk_toplevel_begin_resize">
         <doc xml:space="preserve">Begins an interactive resize operation.
 
-You might use this function to implement a &#x201C;window resize grip.&#x201D;</doc>
+You might use this function to implement a “window resize grip.”</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -21192,7 +21192,7 @@ allows the window manager to do things like center @surface
 on @parent and keep @surface above @parent.
 
 See [gtk_window_set_transient_for()](../gtk4/method.Window.set_transient_for.html)
-if you&#x2019;re using [GtkWindow](../gtk4/class.Window.html).</doc>
+if you’re using [GtkWindow](../gtk4/class.Window.html).</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -21394,8 +21394,8 @@ etc).</doc>
 Used together with [method@Gdk.Toplevel.present] to describe
 how a toplevel surface should be placed and behave on-screen.
 
-The size is in &#x201D;application pixels&#x201D;, not
-&#x201D;device pixels&#x201D; (see [method@Gdk.Surface.get_scale]).</doc>
+The size is in ”application pixels”, not
+”device pixels” (see [method@Gdk.Surface.get_scale]).</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">newly created instance of `GdkToplevelLayout`</doc>
           <type name="ToplevelLayout" c:type="GdkToplevelLayout*"/>
@@ -22512,7 +22512,7 @@ Examples of keyvals are `GDK_KEY_a`, `GDK_KEY_Enter`, `GDK_KEY_F1`, etc.</doc>
 
 The names are the same as those in the
 `gdk/gdkkeysyms.h` header file
-but without the leading &#x201C;GDK_KEY_&#x201D;.</doc>
+but without the leading “GDK_KEY_”.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">the corresponding key value, or `GDK_KEY_VoidSymbol`
   if the key name is not a valid key</doc>
@@ -22584,7 +22584,7 @@ aliases for their normal counterpart, such as
 
 The names are the same as those in the
 `gdk/gdkkeysyms.h` header file
-but without the leading &#x201C;GDK_KEY_&#x201D;.</doc>
+but without the leading “GDK_KEY_”.</doc>
       <return-value transfer-ownership="none" nullable="1">
         <doc xml:space="preserve">a string containing the name
   of the key</doc>
@@ -22672,7 +22672,7 @@ the first frame).</doc>
 of text would be drawn.
 
 @x_origin and @y_origin are the top left point to center the layout.
-@index_ranges should contain ranges of bytes in the layout&#x2019;s text.
+@index_ranges should contain ranges of bytes in the layout’s text.
 
 Note that the regions returned correspond to logical extents of the text
 ranges, not ink extents. So the drawn layout may in fact touch areas out of
@@ -22710,7 +22710,7 @@ of text, such as when text is selected.</doc>
 ranges of text would be drawn.
 
 @x_origin and @y_origin are the top left position of the layout.
-@index_ranges should contain ranges of bytes in the layout&#x2019;s text.
+@index_ranges should contain ranges of bytes in the layout’s text.
 The clip region will include space to the left or right of the line
 (to the layout bounding box) if you have indexes above or below the
 indexes contained inside the line. This is to draw the selection all

--- a/GdkMacos-4.0.gir
+++ b/GdkMacos-4.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -114,10 +114,10 @@ and/or use gtk-doc annotations.  -->
         </parameters>
       </function>
       <function name="get_workarea" c:identifier="gdk_macos_monitor_get_workarea">
-        <doc xml:space="preserve">Retrieves the size and position of the &#x201C;work area&#x201D; on a monitor
+        <doc xml:space="preserve">Retrieves the size and position of the “work area” on a monitor
 within the display coordinate space.
 
-The returned geometry is in &#x201D;application pixels&#x201D;, not in &#x201D;device pixels&#x201D;
+The returned geometry is in ”application pixels”, not in ”device pixels”
 (see [method@Gdk.Monitor.get_scale_factor]).</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>

--- a/GdkPixbuf-2.0.gir
+++ b/GdkPixbuf-2.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->

--- a/GdkPixdata-2.0.gir
+++ b/GdkPixdata-2.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->

--- a/GdkWayland-4.0.gir
+++ b/GdkWayland-4.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->

--- a/GdkWin32-4.0.gir
+++ b/GdkWin32-4.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -763,10 +763,10 @@ if a filter wants a GDK event queued, it should do that itself.</doc>
     </enumeration>
     <class name="Win32Monitor" c:symbol-prefix="win32_monitor" c:type="GdkWin32Monitor" parent="Gdk.Monitor" glib:type-name="GdkWin32Monitor" glib:get-type="gdk_win32_monitor_get_type" glib:type-struct="Win32MonitorClass">
       <function name="get_workarea" c:identifier="gdk_win32_monitor_get_workarea">
-        <doc xml:space="preserve">Retrieves the size and position of the &#x201C;work area&#x201D; on a monitor
+        <doc xml:space="preserve">Retrieves the size and position of the “work area” on a monitor
 within the display coordinate space.
 
-The returned geometry is in &#x201D;application pixels&#x201D;, not in &#x201D;device pixels&#x201D;
+The returned geometry is in ”application pixels”, not in ”device pixels”
 (see [method@Gdk.Monitor.get_scale_factor]).</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>

--- a/GdkX11-3.0.gir
+++ b/GdkX11-3.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -366,7 +366,7 @@ Will XSync() if necessary and will always block until
 the error is known to have occurred or not occurred,
 so the error code can be returned.
 
-If you don&#x2019;t need to use the return value,
+If you don’t need to use the return value,
 gdk_x11_display_error_trap_pop_ignored() would be more efficient.
 
 See gdk_error_trap_pop() for the all-displays-at-once
@@ -716,7 +716,7 @@ directly includes an is_modifier field.</doc>
       </method>
       <method name="key_is_modifier" c:identifier="gdk_x11_keymap_key_is_modifier" version="3.6">
         <doc xml:space="preserve">Determines whether a particular key code represents a key that
-is a modifier. That is, it&#x2019;s a key that normally just affects
+is a modifier. That is, it’s a key that normally just affects
 the keyboard state and the behavior of other keys rather than
 producing a direct effect itself. This is only needed for code
 processing raw X events, since #GdkEventKey directly includes
@@ -849,7 +849,7 @@ and should not be freed.</doc>
         <doc xml:space="preserve">Looks up the #GdkVisual for a particular screen and X Visual ID.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the #GdkVisual (owned by the screen
-  object), or %NULL if the visual ID wasn&#x2019;t found.</doc>
+  object), or %NULL if the visual ID wasn’t found.</doc>
           <type name="X11Visual" c:type="GdkVisual*"/>
         </return-value>
         <parameters>
@@ -869,7 +869,7 @@ whether the window manager supports a certain hint from the
 [Extended Window Manager Hints](http://www.freedesktop.org/Standards/wm-spec) specification.
 
 When using this function, keep in mind that the window manager
-can change over time; so you shouldn&#x2019;t use this function in
+can change over time; so you shouldn’t use this function in
 a way that impacts persistent application state. A common bug
 is that your application can start up before the window manager
 does when the user logs in, and before the window manager starts
@@ -926,7 +926,7 @@ was already known to GDK, a new reference to the existing
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a #GdkWindow wrapper for the native
   window, or %NULL if the window has been destroyed. The wrapper
-  will be newly created, if one doesn&#x2019;t exist already.</doc>
+  will be newly created, if one doesn’t exist already.</doc>
           <type name="Gdk.Window" c:type="GdkWindow*"/>
         </return-value>
         <parameters>
@@ -975,7 +975,7 @@ was already known to GDK, a new reference to the existing
       <method name="get_xid" c:identifier="gdk_x11_window_get_xid">
         <doc xml:space="preserve">Returns the X resource (window) belonging to a #GdkWindow.</doc>
         <return-value transfer-ownership="none">
-          <doc xml:space="preserve">the ID of @drawable&#x2019;s X resource.</doc>
+          <doc xml:space="preserve">the ID of @drawable’s X resource.</doc>
           <type name="xlib.Window" c:type="Window"/>
         </return-value>
         <parameters>
@@ -1484,7 +1484,7 @@ is converted to %None.</doc>
       <doc xml:space="preserve">Returns the #GdkDevice that wraps the given device ID.</doc>
       <return-value transfer-ownership="none" nullable="1">
         <doc xml:space="preserve">The #GdkDevice wrapping the device ID,
-         or %NULL if the given ID doesn&#x2019;t currently represent a device.</doc>
+         or %NULL if the given ID doesn’t currently represent a device.</doc>
         <type name="X11DeviceCore" c:type="GdkDevice*"/>
       </return-value>
       <parameters>
@@ -1577,11 +1577,11 @@ available. Otherwise behaves like a transparent pattern.</doc>
       </parameters>
     </function>
     <function name="x11_get_xatom_by_name" c:identifier="gdk_x11_get_xatom_by_name">
-      <doc xml:space="preserve">Returns the X atom for GDK&#x2019;s default display corresponding to @atom_name.
+      <doc xml:space="preserve">Returns the X atom for GDK’s default display corresponding to @atom_name.
 This function caches the result, so if called repeatedly it is much
 faster than XInternAtom(), which is a round trip to the server each time.</doc>
       <return-value transfer-ownership="none">
-        <doc xml:space="preserve">a X atom for GDK&#x2019;s default display.</doc>
+        <doc xml:space="preserve">a X atom for GDK’s default display.</doc>
         <type name="xlib.Atom" c:type="Atom"/>
       </return-value>
       <parameters>
@@ -1611,19 +1611,19 @@ faster than XInternAtom(), which is a round trip to the server each time.</doc>
       </parameters>
     </function>
     <function name="x11_get_xatom_name" c:identifier="gdk_x11_get_xatom_name">
-      <doc xml:space="preserve">Returns the name of an X atom for GDK&#x2019;s default display. This
+      <doc xml:space="preserve">Returns the name of an X atom for GDK’s default display. This
 function is meant mainly for debugging, so for convenience, unlike
 XAtomName() and gdk_atom_name(), the result
-doesn&#x2019;t need to be freed. Also, this function will never return %NULL,
+doesn’t need to be freed. Also, this function will never return %NULL,
 even if @xatom is invalid.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">name of the X atom; this string is owned by GTK+,
-  so it shouldn&#x2019;t be modifed or freed.</doc>
+  so it shouldn’t be modifed or freed.</doc>
         <type name="utf8" c:type="const gchar*"/>
       </return-value>
       <parameters>
         <parameter name="xatom" transfer-ownership="none">
-          <doc xml:space="preserve">an X atom for GDK&#x2019;s default display</doc>
+          <doc xml:space="preserve">an X atom for GDK’s default display</doc>
           <type name="xlib.Atom" c:type="Atom"/>
         </parameter>
       </parameters>
@@ -1631,11 +1631,11 @@ even if @xatom is invalid.</doc>
     <function name="x11_get_xatom_name_for_display" c:identifier="gdk_x11_get_xatom_name_for_display" version="2.2">
       <doc xml:space="preserve">Returns the name of an X atom for its display. This
 function is meant mainly for debugging, so for convenience, unlike
-XAtomName() and gdk_atom_name(), the result doesn&#x2019;t need to
+XAtomName() and gdk_atom_name(), the result doesn’t need to
 be freed.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">name of the X atom; this string is owned by GDK,
-  so it shouldn&#x2019;t be modifed or freed.</doc>
+  so it shouldn’t be modifed or freed.</doc>
         <type name="utf8" c:type="const gchar*"/>
       </return-value>
       <parameters>
@@ -1703,8 +1703,8 @@ when filtering XInput extension events on the root window.</doc>
       </parameters>
     </function>
     <function name="x11_set_sm_client_id" c:identifier="gdk_x11_set_sm_client_id" version="2.24">
-      <doc xml:space="preserve">Sets the `SM_CLIENT_ID` property on the application&#x2019;s leader window so that
-the window manager can save the application&#x2019;s state using the X11R6 ICCCM
+      <doc xml:space="preserve">Sets the `SM_CLIENT_ID` property on the application’s leader window so that
+the window manager can save the application’s state using the X11R6 ICCCM
 session management protocol.
 
 See the X Session Management Library documentation for more information on

--- a/GdkX11-4.0.gir
+++ b/GdkX11-4.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -235,7 +235,7 @@ Will XSync() if necessary and will always block until
 the error is known to have occurred or not occurred,
 so the error code can be returned.
 
-If you don&#x2019;t need to use the return value,
+If you don’t need to use the return value,
 gdk_x11_display_error_trap_pop_ignored() would be more efficient.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">X error code or 0 on success</doc>
@@ -355,7 +355,7 @@ This function returns `NULL` if GDK is using GLX.</doc>
       <method name="get_primary_monitor" c:identifier="gdk_x11_display_get_primary_monitor" deprecated="1" deprecated-version="4.18">
         <doc xml:space="preserve">Gets the primary monitor for the display.
 
-The primary monitor is considered the monitor where the &#x201C;main desktop&#x201D;
+The primary monitor is considered the monitor where the “main desktop”
 lives. While normal application surfaces typically allow the window
 manager to place the surfaces, specialized desktop applications
 such as panels should place themselves on the primary monitor.
@@ -752,10 +752,10 @@ XFreeEventData() will be called afterwards.</doc>
         </parameters>
       </method>
       <method name="get_workarea" c:identifier="gdk_x11_monitor_get_workarea" deprecated="1" deprecated-version="4.18">
-        <doc xml:space="preserve">Retrieves the size and position of the &#x201C;work area&#x201D; on a monitor
+        <doc xml:space="preserve">Retrieves the size and position of the “work area” on a monitor
 within the display coordinate space.
 
-The returned geometry is in &#x201D;application pixels&#x201D;, not in &#x201D;device pixels&#x201D;
+The returned geometry is in ”application pixels”, not in ”device pixels”
 (see [method@Gdk.Monitor.get_scale_factor]).</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -873,7 +873,7 @@ whether the window manager supports a certain hint from the
 [Extended Window Manager Hints](https://specifications.freedesktop.org/wm/latest/) specification.
 
 When using this function, keep in mind that the window manager
-can change over time; so you shouldn&#x2019;t use this function in
+can change over time; so you shouldn’t use this function in
 a way that impacts persistent application state. A common bug
 is that your application can start up before the window manager
 does when the user logs in, and before the window manager starts
@@ -951,7 +951,7 @@ a window manager change.</doc>
       <method name="get_xid" c:identifier="gdk_x11_surface_get_xid" deprecated="1" deprecated-version="4.18">
         <doc xml:space="preserve">Returns the X resource (surface) belonging to a `GdkSurface`.</doc>
         <return-value transfer-ownership="none">
-          <doc xml:space="preserve">the ID of @drawable&#x2019;s X resource.</doc>
+          <doc xml:space="preserve">the ID of @drawable’s X resource.</doc>
           <type name="xlib.Window" c:type="gulong"/>
         </return-value>
         <parameters>
@@ -1330,7 +1330,7 @@ to convert the argument back to an XID.</doc>
       <return-value transfer-ownership="none" nullable="1">
         <doc xml:space="preserve">The
   `GdkDevice` wrapping the device ID, or %NULL if the given ID
-  doesn&#x2019;t currently represent a device.</doc>
+  doesn’t currently represent a device.</doc>
         <type name="X11DeviceXI2" c:type="GdkDevice*"/>
       </return-value>
       <parameters>
@@ -1408,11 +1408,11 @@ faster than XInternAtom(), which is a round trip to the server each time.</doc>
     <function name="x11_get_xatom_name_for_display" c:identifier="gdk_x11_get_xatom_name_for_display" deprecated="1" deprecated-version="4.18">
       <doc xml:space="preserve">Returns the name of an X atom for its display. This
 function is meant mainly for debugging, so for convenience, unlike
-XAtomName() and the result doesn&#x2019;t need to
+XAtomName() and the result doesn’t need to
 be freed.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">name of the X atom; this string is owned by GDK,
-  so it shouldn&#x2019;t be modified or freed.</doc>
+  so it shouldn’t be modified or freed.</doc>
         <type name="utf8" c:type="const char*"/>
       </return-value>
       <parameters>
@@ -1440,8 +1440,8 @@ be freed.</doc>
       </parameters>
     </function>
     <function name="x11_set_sm_client_id" c:identifier="gdk_x11_set_sm_client_id" deprecated="1" deprecated-version="4.18">
-      <doc xml:space="preserve">Sets the `SM_CLIENT_ID` property on the application&#x2019;s leader window so that
-the window manager can save the application&#x2019;s state using the X11R6 ICCCM
+      <doc xml:space="preserve">Sets the `SM_CLIENT_ID` property on the application’s leader window so that
+the window manager can save the application’s state using the X11R6 ICCCM
 session management protocol.
 
 See the X Session Management Library documentation for more information on

--- a/GioUnix-2.0.gir
+++ b/GioUnix-2.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -190,7 +190,7 @@ Should be called only once; subsequent calls are ignored.</doc>
       </function>
       <method name="get_action_name" c:identifier="g_desktop_app_info_get_action_name" version="2.38">
         <doc xml:space="preserve">Gets the user-visible display name of the
-[&#x2018;additional application actions&#x2019;](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s11.html)
+[‘additional application actions’](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s11.html)
 specified by @action_name.
 
 This corresponds to the `Name` key within the keyfile group for the
@@ -601,22 +601,22 @@ activation) then @stdin_fd, @stdout_fd and @stderr_fd are ignored.</doc>
             <type name="gpointer" c:type="gpointer"/>
           </parameter>
           <parameter name="stdin_fd" transfer-ownership="none">
-            <doc xml:space="preserve">file descriptor to use for child&#x2019;s stdin, or `-1`</doc>
+            <doc xml:space="preserve">file descriptor to use for child’s stdin, or `-1`</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="stdout_fd" transfer-ownership="none">
-            <doc xml:space="preserve">file descriptor to use for child&#x2019;s stdout, or `-1`</doc>
+            <doc xml:space="preserve">file descriptor to use for child’s stdout, or `-1`</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
           <parameter name="stderr_fd" transfer-ownership="none">
-            <doc xml:space="preserve">file descriptor to use for child&#x2019;s stderr, or `-1`</doc>
+            <doc xml:space="preserve">file descriptor to use for child’s stderr, or `-1`</doc>
             <type name="gint" c:type="gint"/>
           </parameter>
         </parameters>
       </method>
       <method name="list_actions" c:identifier="g_desktop_app_info_list_actions" version="2.38">
         <doc xml:space="preserve">Returns the list of
-[&#x2018;additional application actions&#x2019;](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s11.html)
+[‘additional application actions’](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s11.html)
 supported on the desktop file, as per the desktop file specification.
 
 As per the specification, this is the list of actions that are
@@ -1428,9 +1428,9 @@ The result is a translated string.</doc>
 
 This is the Boolean OR of
 [func@GioUnix.is_system_fs_type], [func@GioUnix.is_system_device_path] and
-[func@GioUnix.is_mount_path_system_internal] on @mount_entry&#x2019;s properties.
+[func@GioUnix.is_mount_path_system_internal] on @mount_entry’s properties.
 
-The definition of what a &#x2018;system&#x2019; mount entry is may change over time as new
+The definition of what a ‘system’ mount entry is may change over time as new
 file system types and device paths are ignored.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">true if the Unix mount is for a system path; false otherwise</doc>
@@ -1480,7 +1480,7 @@ If more mounts have the same mount path, the last matching mount
 is returned.
 
 This will return `NULL` if looking up the mount entry fails, if
-@file_path doesn&#x2019;t exist or there is an I/O error.</doc>
+@file_path doesn’t exist or there is an I/O error.</doc>
         <return-value transfer-ownership="full" nullable="1">
           <doc xml:space="preserve">a [struct@GioUnix.MountEntry]</doc>
           <type name="MountEntry" c:type="GUnixMountEntry*"/>
@@ -1540,7 +1540,7 @@ rate at which events would be reported under some uncommon
 circumstances.  Since @mount_monitor is a singleton, it also meant
 that calling this function would have side effects for other users of
 the monitor.</doc>
-        <doc-deprecated xml:space="preserve">This function does nothing. Don&#x2019;t call it.</doc-deprecated>
+        <doc-deprecated xml:space="preserve">This function does nothing. Don’t call it.</doc-deprecated>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -1964,7 +1964,7 @@ for programs to read, and system administrators at a shell; rather than
 something that should, for example, appear in a GUI. For example, the Linux
 `/proc` filesystem.
 
-The list of device paths considered &#x2018;system&#x2019; ones may change over time.</doc>
+The list of device paths considered ‘system’ ones may change over time.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">true if @device_path is considered an implementation detail of
    the OS; false otherwise</doc>
@@ -1986,7 +1986,7 @@ for programs to read, and system administrators at a shell; rather than
 something that should, for example, appear in a GUI. For example, the Linux
 `/proc` filesystem.
 
-The list of file system types considered &#x2018;system&#x2019; ones may change over time.</doc>
+The list of file system types considered ‘system’ ones may change over time.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">true if @fs_type is considered an implementation detail of the OS;
    false otherwise</doc>
@@ -2176,7 +2176,7 @@ If more mounts have the same mount path, the last matching mount
 is returned.
 
 This will return `NULL` if looking up the mount entry fails, if
-@file_path doesn&#x2019;t exist or there is an I/O error.</doc>
+@file_path doesn’t exist or there is an I/O error.</doc>
       <return-value transfer-ownership="full" nullable="1">
         <doc xml:space="preserve">a [struct@GioUnix.MountEntry]</doc>
         <type name="MountEntry" c:type="GUnixMountEntry*"/>
@@ -2203,7 +2203,7 @@ If more mounts have the same mount path, the last matching mount
 is returned.
 
 This will return `NULL` if looking up the mount entry fails, if
-@file_path doesn&#x2019;t exist or there is an I/O error.</doc>
+@file_path doesn’t exist or there is an I/O error.</doc>
       <doc-deprecated xml:space="preserve">Use [func@GioUnix.MountEntry.for] instead.</doc-deprecated>
       <return-value transfer-ownership="full" nullable="1">
         <doc xml:space="preserve">a [struct@GioUnix.MountEntry]</doc>
@@ -2406,9 +2406,9 @@ The result is a translated string.</doc>
 
 This is the Boolean OR of
 [func@GioUnix.is_system_fs_type], [func@GioUnix.is_system_device_path] and
-[func@GioUnix.is_mount_path_system_internal] on @mount_entry&#x2019;s properties.
+[func@GioUnix.is_mount_path_system_internal] on @mount_entry’s properties.
 
-The definition of what a &#x2018;system&#x2019; mount entry is may change over time as new
+The definition of what a ‘system’ mount entry is may change over time as new
 file system types and device paths are ignored.</doc>
       <doc-deprecated xml:space="preserve">Use [method@GioUnix.MountEntry.is_system_internal] instead.</doc-deprecated>
       <return-value transfer-ownership="none">

--- a/GioWin32-2.0.gir
+++ b/GioWin32-2.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->

--- a/Graphene-1.0.gir
+++ b/Graphene-1.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -1608,11 +1608,11 @@ associated with the #graphene_euler_t; for instance, if the order
 used to initialize @e is %GRAPHENE_EULER_ORDER_XYZ:
 
  * the first rotation moves the body around the X axis with
-   an angle &#x3C6;
+   an angle φ
  * the second rotation moves the body around the Y axis with
-   an angle of &#x3D1;
+   an angle of ϑ
  * the third rotation moves the body around the Z axis with
-   an angle of &#x3C8;
+   an angle of ψ
 
 The rotation sign convention is right-handed, to preserve compatibility
 between Euler-based, quaternion-based, and angle-axis-based rotations.</doc>
@@ -2229,9 +2229,9 @@ transformation matrix.
 The arguments map to the following matrix layout:
 
 |[&lt;!-- language="plain" --&gt;
-  &#x239B; xx  yx &#x239E;   &#x239B;  a   b  0 &#x239E;
-  &#x239C; xy  yy &#x239F; = &#x239C;  c   d  0 &#x239F;
-  &#x239D; x0  y0 &#x23A0;   &#x239D; tx  ty  1 &#x23A0;
+  ⎛ xx  yx ⎞   ⎛  a   b  0 ⎞
+  ⎜ xy  yy ⎟ = ⎜  c   d  0 ⎟
+  ⎝ x0  y0 ⎠   ⎝ tx  ty  1 ⎠
 ]|
 
 This function can be used to convert between an affine matrix type
@@ -2692,7 +2692,7 @@ a 2D affine transformation matrix.</doc>
         <doc xml:space="preserve">Multiplies two #graphene_matrix_t.
 
 Matrix multiplication is not commutative in general; the order of the factors matters.
-The product of this multiplication is (@a &#xD7; @b)</doc>
+The product of this multiplication is (@a × @b)</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
         </return-value>
@@ -3057,9 +3057,9 @@ matrix, if the given matrix is compatible.
 The returned values have the following layout:
 
 |[&lt;!-- language="plain" --&gt;
-  &#x239B; xx  yx &#x239E;   &#x239B;  a   b  0 &#x239E;
-  &#x239C; xy  yy &#x239F; = &#x239C;  c   d  0 &#x239F;
-  &#x239D; x0  y0 &#x23A0;   &#x239D; tx  ty  1 &#x23A0;
+  ⎛ xx  yx ⎞   ⎛  a   b  0 ⎞
+  ⎜ xy  yy ⎟ = ⎜  c   d  0 ⎟
+  ⎝ x0  y0 ⎠   ⎝ tx  ty  1 ⎠
 ]|
 
 This function can be used to convert between a #graphene_matrix_t
@@ -5968,8 +5968,8 @@ calling `ceil` on the bottom-right coordinates.
 
 If you want to be sure that the rounded rectangle
 completely covers the area that was covered by the
-original rectangle &#x2014; i.e. you want to cover the area
-including all its corners &#x2014; this function will make sure
+original rectangle — i.e. you want to cover the area
+including all its corners — this function will make sure
 that the size is recomputed taking into account the ceiling
 of the coordinates of the bottom-right corner.
 If the difference between the original coordinates and the
@@ -8667,25 +8667,25 @@ three angles. It also optionally can describe the order of the rotations.
 states that, in three-dimensional space, any displacement of a rigid body
 such that a point on the rigid body remains fixed, is equivalent to a single
 rotation about some axis that runs through the fixed point. The angles on
-each axis can be placed in a vector of three components&#x2014;&#x3B1;, &#x3B2;, and &#x3B3;&#x2014;called
+each axis can be placed in a vector of three components—α, β, and γ—called
 the *Euler angle vector*. Each rotation described by these components results
 in a rotation matrix:
 
 |[
-  rot(&#x3B1;) = A
-  rot(&#x3B2;) = B
-  rot(&#x3B3;) = G
+  rot(α) = A
+  rot(β) = B
+  rot(γ) = G
 ]|
 
 The resulting rotation matrix expressed by the Euler angle vector is
 given by the product of each rotation matrix:
 
 |[
-  G &#xD7; B &#xD7; A = R
+  G × B × A = R
 ]|
 
 In order to specify the meaning of an Euler angle vector, we need to
-assign each axis of rotation to the corresponding &#x3B1;, &#x3B2;, and &#x3B3; components,
+assign each axis of rotation to the corresponding α, β, and γ components,
 for instance X, Y, and Z.
 
 Additionally, we need to specify whether the rotations move the axes
@@ -8705,7 +8705,7 @@ by the right-hand rule, which means all rotations are counterclockwise.
 
 Rotations described Euler angles are typically immediately understandable,
 compared to rotations expressed using quaternions, but they are susceptible
-of ["Gimbal lock"](http://en.wikipedia.org/wiki/Gimbal_lock) &#x2014; the loss of
+of ["Gimbal lock"](http://en.wikipedia.org/wiki/Gimbal_lock) — the loss of
 one degree of freedom caused by two axis on the same plane. You typically
 should use #graphene_euler_t to expose rotation angles in your API, or to
 store them, but use #graphene_quaternion_t to apply rotations to modelview
@@ -8807,10 +8807,10 @@ The matrix is treated as row-major, i.e. it has four vectors (x, y, z, and
 w) representing rows, and elements of each vector are a column:
 
 |[&lt;!-- language="plain" --&gt;
-  &#x23A1; m.x &#x23A4;    &#x239B; x.x  x.y  x.z  x.w &#x239E;
-  &#x239C; m.y &#x239F; -\ &#x239C; y.x  y.y  y.z  y.w &#x239F;
-  &#x239C; m.z &#x239F; -/ &#x239C; z.x  z.y  z.z  z.w &#x239F;
-  &#x23A3; m.w &#x23A6;    &#x239D; w.x  w.y  w.z  w.w &#x23A0;
+  ⎡ m.x ⎤    ⎛ x.x  x.y  x.z  x.w ⎞
+  ⎜ m.y ⎟ -\ ⎜ y.x  y.y  y.z  y.w ⎟
+  ⎜ m.z ⎟ -/ ⎜ z.x  z.y  z.z  z.w ⎟
+  ⎣ m.w ⎦    ⎝ w.x  w.y  w.z  w.w ⎠
 ]|
 
 It is possible to easily convert a #graphene_matrix_t to and from an array
@@ -8827,7 +8827,7 @@ matrices; in other words, given a matrix `A` and a vector `b`, the result
 of a multiplication is going to be:
 
 |[
-  res = b &#xD7; A
+  res = b × A
 ]|
 
 Multiplying two matrices, on the other hand, will use right-multiplication;
@@ -8835,17 +8835,17 @@ given two matrices `A` and `B`, the result of the multiplication is going
 to be
 
 |[
-  res = A &#xD7; B
+  res = A × B
 ]|
 
 as the implementation will multiply each row vector of matrix `A` with the
 matrix `B` to obtain the new row vectors of the result matrix:
 
 |[
-  res = &#x23A1; A.x &#xD7; B &#x23A4;
-        &#x239C; A.y &#xD7; B &#x239F;
-        &#x239C; A.z &#xD7; B &#x239F;
-        &#x23A3; A.w &#xD7; B &#x23A6;
+  res = ⎡ A.x × B ⎤
+        ⎜ A.y × B ⎟
+        ⎜ A.z × B ⎟
+        ⎣ A.w × B ⎦
 ]|
 
 For more information, see the documentation for #graphene_simd4x4f_t,

--- a/Gsk-4.0.gir
+++ b/Gsk-4.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -3029,7 +3029,7 @@ structure is meant to help in this endeavor.
 
 Conceptually, a path consists of zero or more contours (continuous, connected
 curves), each of which may or may not be closed. Contours are typically
-constructed from B&#xE9;zier segments.
+constructed from Bézier segments.
 
 &lt;picture&gt;
   &lt;source srcset="path-dark.png" media="(prefers-color-scheme: dark)"&gt;
@@ -3474,15 +3474,15 @@ A high-level summary of the syntax:
 
 - `M x y` Move to `(x, y)`
 - `L x y` Add a line from the current point to `(x, y)`
-- `Q x1 y1 x2 y2` Add a quadratic B&#xE9;zier from the current point to `(x2, y2)`, with control point `(x1, y1)`
-- `C x1 y1 x2 y2 x3 y3` Add a cubic B&#xE9;zier from the current point to `(x3, y3)`, with control points `(x1, y1)` and `(x2, y2)`
+- `Q x1 y1 x2 y2` Add a quadratic Bézier from the current point to `(x2, y2)`, with control point `(x1, y1)`
+- `C x1 y1 x2 y2 x3 y3` Add a cubic Bézier from the current point to `(x3, y3)`, with control points `(x1, y1)` and `(x2, y2)`
 - `Z` Close the contour by drawing a line back to the start point
 - `H x` Add a horizontal line from the current point to the given x value
 - `V y` Add a vertical line from the current point to the given y value
-- `T x2 y2` Add a quadratic B&#xE9;zier, using the reflection of the previous segments' control point as control point
-- `S x2 y2 x3 y3` Add a cubic B&#xE9;zier, using the reflection of the previous segments' second control point as first control point
+- `T x2 y2` Add a quadratic Bézier, using the reflection of the previous segments' control point as control point
+- `S x2 y2 x3 y3` Add a cubic Bézier, using the reflection of the previous segments' second control point as first control point
 - `A rx ry r l s x y` Add an elliptical arc from the current point to `(x, y)` with radii rx and ry. See the SVG documentation for how the other parameters influence the arc.
-- `O x1 y1 x2 y2 w` Add a rational quadratic B&#xE9;zier from the current point to `(x2, y2)` with control point `(x1, y1)` and weight `w`.
+- `O x1 y1 x2 y2 w` Add a rational quadratic Bézier from the current point to `(x2, y2)` with control point `(x1, y1)` and weight `w`.
 
 All the commands have lowercase variants that interpret coordinates
 relative to the current point.
@@ -3537,7 +3537,7 @@ back with a line to the starting point.
 
 This is similar to how paths are drawn in Cairo.
 
-Note that `GskPathBuilder` will reduce the degree of added B&#xE9;zier
+Note that `GskPathBuilder` will reduce the degree of added Bézier
 curves as much as possible, to simplify rendering.</doc>
       <constructor name="new" c:identifier="gsk_path_builder_new" version="4.14">
         <doc xml:space="preserve">Create a new `GskPathBuilder` object.
@@ -3776,10 +3776,10 @@ from the current point to @x2, @y2 with the given @weight and @x1, @y1 as the
 control point.
 
 The weight determines how strongly the curve is pulled towards the control point.
-A conic with weight 1 is identical to a quadratic B&#xE9;zier curve with the same points.
+A conic with weight 1 is identical to a quadratic Bézier curve with the same points.
 
 Conic curves can be used to draw ellipses and circles. They are also known as
-rational quadratic B&#xE9;zier curves.
+rational quadratic Bézier curves.
 
 After this, @x2, @y2 will be the new current point.
 
@@ -3818,7 +3818,7 @@ After this, @x2, @y2 will be the new current point.
         </parameters>
       </method>
       <method name="cubic_to" c:identifier="gsk_path_builder_cubic_to" version="4.14">
-        <doc xml:space="preserve">Adds a [cubic B&#xE9;zier curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve)
+        <doc xml:space="preserve">Adds a [cubic Bézier curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve)
 from the current point to @x3, @y3 with @x1, @y1 and @x2, @y2 as the control
 points.
 
@@ -3988,7 +3988,7 @@ The second call will start a new contour.</doc>
         </parameters>
       </method>
       <method name="quad_to" c:identifier="gsk_path_builder_quad_to" version="4.14">
-        <doc xml:space="preserve">Adds a [quadratic B&#xE9;zier curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve)
+        <doc xml:space="preserve">Adds a [quadratic Bézier curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve)
 from the current point to @x2, @y2 with @x1, @y1 as the control point.
 
 After this, @x2, @y2 will be the new current point.
@@ -4112,7 +4112,7 @@ This is the relative version of [method@Gsk.PathBuilder.conic_to].</doc>
         </parameters>
       </method>
       <method name="rel_cubic_to" c:identifier="gsk_path_builder_rel_cubic_to" version="4.14">
-        <doc xml:space="preserve">Adds a [cubic B&#xE9;zier curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve)
+        <doc xml:space="preserve">Adds a [cubic Bézier curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve)
 from the current point to @x3, @y3 with @x1, @y1 and @x2, @y2 as the control
 points.
 
@@ -4236,7 +4236,7 @@ This is the relative version of [method@Gsk.PathBuilder.move_to].</doc>
         </parameters>
       </method>
       <method name="rel_quad_to" c:identifier="gsk_path_builder_rel_quad_to" version="4.14">
-        <doc xml:space="preserve">Adds a [quadratic B&#xE9;zier curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve)
+        <doc xml:space="preserve">Adds a [quadratic Bézier curve](https://en.wikipedia.org/wiki/B%C3%A9zier_curve)
 from the current point to @x2, @y2 with @x1, @y1 the control point.
 
 All coordinates are given relative to the current point.
@@ -4683,17 +4683,17 @@ More values may be added in the future.</doc>
   end point of a straight line.</doc>
       </member>
       <member name="quad" value="3" c:identifier="GSK_PATH_QUAD" glib:nick="quad" glib:name="GSK_PATH_QUAD">
-        <doc xml:space="preserve">A curve-to operation describing a quadratic B&#xE9;zier curve
+        <doc xml:space="preserve">A curve-to operation describing a quadratic Bézier curve
   with 3 points describing the start point, the control point and the end
   point of the curve.</doc>
       </member>
       <member name="cubic" value="4" c:identifier="GSK_PATH_CUBIC" glib:nick="cubic" glib:name="GSK_PATH_CUBIC">
-        <doc xml:space="preserve">A curve-to operation describing a cubic B&#xE9;zier curve with 4
+        <doc xml:space="preserve">A curve-to operation describing a cubic Bézier curve with 4
   points describing the start point, the two control points and the end point
   of the curve.</doc>
       </member>
       <member name="conic" value="5" c:identifier="GSK_PATH_CONIC" glib:nick="conic" glib:name="GSK_PATH_CONIC">
-        <doc xml:space="preserve">A rational quadratic B&#xE9;zier curve with 3 points describing
+        <doc xml:space="preserve">A rational quadratic Bézier curve with 3 points describing
   the start point, control point and end point of the curve. A weight for the
   curve will be passed, too.</doc>
       </member>
@@ -4813,7 +4813,7 @@ infinite radius). In this case, the @center is not modified.
 Circles with a radius of zero have `INFINITY` as curvature
 
 Note that certain points on a path may not have a single curvature,
-such as sharp turns. At such points, there are two curvatures &#x2014; the
+such as sharp turns. At such points, there are two curvatures — the
 (limit of) the curvature of the path going into the point, and the
 (limit of) the curvature of the path coming out of it. The @direction
 argument lets you choose which one to get.
@@ -4916,7 +4916,7 @@ can e.g. be used in
 
 Note that certain points on a path may not have a single
 tangent, such as sharp turns. At such points, there are
-two tangents &#x2014; the direction of the path going into the
+two tangents — the direction of the path going into the
 point, and the direction coming out of it. The @direction
 argument lets you choose which one to get.
 
@@ -8568,15 +8568,15 @@ A high-level summary of the syntax:
 
 - `M x y` Move to `(x, y)`
 - `L x y` Add a line from the current point to `(x, y)`
-- `Q x1 y1 x2 y2` Add a quadratic B&#xE9;zier from the current point to `(x2, y2)`, with control point `(x1, y1)`
-- `C x1 y1 x2 y2 x3 y3` Add a cubic B&#xE9;zier from the current point to `(x3, y3)`, with control points `(x1, y1)` and `(x2, y2)`
+- `Q x1 y1 x2 y2` Add a quadratic Bézier from the current point to `(x2, y2)`, with control point `(x1, y1)`
+- `C x1 y1 x2 y2 x3 y3` Add a cubic Bézier from the current point to `(x3, y3)`, with control points `(x1, y1)` and `(x2, y2)`
 - `Z` Close the contour by drawing a line back to the start point
 - `H x` Add a horizontal line from the current point to the given x value
 - `V y` Add a vertical line from the current point to the given y value
-- `T x2 y2` Add a quadratic B&#xE9;zier, using the reflection of the previous segments' control point as control point
-- `S x2 y2 x3 y3` Add a cubic B&#xE9;zier, using the reflection of the previous segments' second control point as first control point
+- `T x2 y2` Add a quadratic Bézier, using the reflection of the previous segments' control point as control point
+- `S x2 y2 x3 y3` Add a cubic Bézier, using the reflection of the previous segments' second control point as first control point
 - `A rx ry r l s x y` Add an elliptical arc from the current point to `(x, y)` with radii rx and ry. See the SVG documentation for how the other parameters influence the arc.
-- `O x1 y1 x2 y2 w` Add a rational quadratic B&#xE9;zier from the current point to `(x2, y2)` with control point `(x1, y1)` and weight `w`.
+- `O x1 y1 x2 y2 w` Add a rational quadratic Bézier from the current point to `(x2, y2)` with control point `(x1, y1)` and weight `w`.
 
 All the commands have lowercase variants that interpret coordinates
 relative to the current point.

--- a/HarfBuzz-0.0.gir
+++ b/HarfBuzz-0.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -2986,7 +2986,7 @@ A human-readable, plain text format.
 The serialized codepoints will look something like:
 
 |[&lt;!-- language="plain" --&gt;
-&#xA0;&lt;U+0651=0|U+0628=1&gt;
+ &lt;U+0651=0|U+0628=1&gt;
 ]|
 
 - Glyphs are separated with `|`
@@ -5137,16 +5137,16 @@ The format is Python-esque.  Here is how it all works:
 &lt;/thead&gt;
 &lt;tbody&gt;
 &lt;row&gt;&lt;entry&gt;Setting value:&lt;/entry&gt;&lt;/row&gt;
-&lt;row&gt;&lt;entry&gt;kern&lt;/entry&gt;      &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;&#x221E;&lt;/entry&gt;   &lt;entry&gt;Turn feature on&lt;/entry&gt;&lt;/row&gt;
-&lt;row&gt;&lt;entry&gt;+kern&lt;/entry&gt;     &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;&#x221E;&lt;/entry&gt;   &lt;entry&gt;Turn feature on&lt;/entry&gt;&lt;/row&gt;
-&lt;row&gt;&lt;entry&gt;-kern&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;&#x221E;&lt;/entry&gt;   &lt;entry&gt;Turn feature off&lt;/entry&gt;&lt;/row&gt;
-&lt;row&gt;&lt;entry&gt;kern=0&lt;/entry&gt;    &lt;entry&gt;0&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;&#x221E;&lt;/entry&gt;   &lt;entry&gt;Turn feature off&lt;/entry&gt;&lt;/row&gt;
-&lt;row&gt;&lt;entry&gt;kern=1&lt;/entry&gt;    &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;&#x221E;&lt;/entry&gt;   &lt;entry&gt;Turn feature on&lt;/entry&gt;&lt;/row&gt;
-&lt;row&gt;&lt;entry&gt;aalt=2&lt;/entry&gt;    &lt;entry&gt;2&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;&#x221E;&lt;/entry&gt;   &lt;entry&gt;Choose 2nd alternate&lt;/entry&gt;&lt;/row&gt;
+&lt;row&gt;&lt;entry&gt;kern&lt;/entry&gt;      &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;∞&lt;/entry&gt;   &lt;entry&gt;Turn feature on&lt;/entry&gt;&lt;/row&gt;
+&lt;row&gt;&lt;entry&gt;+kern&lt;/entry&gt;     &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;∞&lt;/entry&gt;   &lt;entry&gt;Turn feature on&lt;/entry&gt;&lt;/row&gt;
+&lt;row&gt;&lt;entry&gt;-kern&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;∞&lt;/entry&gt;   &lt;entry&gt;Turn feature off&lt;/entry&gt;&lt;/row&gt;
+&lt;row&gt;&lt;entry&gt;kern=0&lt;/entry&gt;    &lt;entry&gt;0&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;∞&lt;/entry&gt;   &lt;entry&gt;Turn feature off&lt;/entry&gt;&lt;/row&gt;
+&lt;row&gt;&lt;entry&gt;kern=1&lt;/entry&gt;    &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;∞&lt;/entry&gt;   &lt;entry&gt;Turn feature on&lt;/entry&gt;&lt;/row&gt;
+&lt;row&gt;&lt;entry&gt;aalt=2&lt;/entry&gt;    &lt;entry&gt;2&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;∞&lt;/entry&gt;   &lt;entry&gt;Choose 2nd alternate&lt;/entry&gt;&lt;/row&gt;
 &lt;row&gt;&lt;entry&gt;Setting index:&lt;/entry&gt;&lt;/row&gt;
-&lt;row&gt;&lt;entry&gt;kern[]&lt;/entry&gt;    &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;&#x221E;&lt;/entry&gt;   &lt;entry&gt;Turn feature on&lt;/entry&gt;&lt;/row&gt;
-&lt;row&gt;&lt;entry&gt;kern[:]&lt;/entry&gt;   &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;&#x221E;&lt;/entry&gt;   &lt;entry&gt;Turn feature on&lt;/entry&gt;&lt;/row&gt;
-&lt;row&gt;&lt;entry&gt;kern[5:]&lt;/entry&gt;  &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;5&lt;/entry&gt;      &lt;entry&gt;&#x221E;&lt;/entry&gt;   &lt;entry&gt;Turn feature on, partial&lt;/entry&gt;&lt;/row&gt;
+&lt;row&gt;&lt;entry&gt;kern[]&lt;/entry&gt;    &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;∞&lt;/entry&gt;   &lt;entry&gt;Turn feature on&lt;/entry&gt;&lt;/row&gt;
+&lt;row&gt;&lt;entry&gt;kern[:]&lt;/entry&gt;   &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;∞&lt;/entry&gt;   &lt;entry&gt;Turn feature on&lt;/entry&gt;&lt;/row&gt;
+&lt;row&gt;&lt;entry&gt;kern[5:]&lt;/entry&gt;  &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;5&lt;/entry&gt;      &lt;entry&gt;∞&lt;/entry&gt;   &lt;entry&gt;Turn feature on, partial&lt;/entry&gt;&lt;/row&gt;
 &lt;row&gt;&lt;entry&gt;kern[:5]&lt;/entry&gt;  &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;0&lt;/entry&gt;      &lt;entry&gt;5&lt;/entry&gt;   &lt;entry&gt;Turn feature on, partial&lt;/entry&gt;&lt;/row&gt;
 &lt;row&gt;&lt;entry&gt;kern[3:5]&lt;/entry&gt; &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;3&lt;/entry&gt;      &lt;entry&gt;5&lt;/entry&gt;   &lt;entry&gt;Turn feature on, range&lt;/entry&gt;&lt;/row&gt;
 &lt;row&gt;&lt;entry&gt;kern[3]&lt;/entry&gt;   &lt;entry&gt;1&lt;/entry&gt;     &lt;entry&gt;3&lt;/entry&gt;      &lt;entry&gt;3+1&lt;/entry&gt; &lt;entry&gt;Turn feature on, single char&lt;/entry&gt;&lt;/row&gt;
@@ -10317,18 +10317,18 @@ begin at the offset provided.</doc>
           <type name="guint" c:type="unsigned int"/>
         </parameter>
         <parameter name="label_id" direction="out" caller-allocates="0" transfer-ownership="full" nullable="1">
-          <doc xml:space="preserve">The &#x2018;name&#x2019; table name ID that specifies a string
+          <doc xml:space="preserve">The ‘name’ table name ID that specifies a string
            for a user-interface label for this feature.</doc>
           <type name="ot_name_id_t" c:type="hb_ot_name_id_t*"/>
         </parameter>
         <parameter name="tooltip_id" direction="out" caller-allocates="0" transfer-ownership="full" nullable="1">
-          <doc xml:space="preserve">The &#x2018;name&#x2019; table name ID that specifies a string
+          <doc xml:space="preserve">The ‘name’ table name ID that specifies a string
              that an application can use for tooltip text for this
              feature.</doc>
           <type name="ot_name_id_t" c:type="hb_ot_name_id_t*"/>
         </parameter>
         <parameter name="sample_id" direction="out" caller-allocates="0" transfer-ownership="full" nullable="1">
-          <doc xml:space="preserve">The &#x2018;name&#x2019; table name ID that specifies sample text
+          <doc xml:space="preserve">The ‘name’ table name ID that specifies sample text
             that illustrates the effect of this feature.</doc>
           <type name="ot_name_id_t" c:type="hb_ot_name_id_t*"/>
         </parameter>
@@ -10337,7 +10337,7 @@ begin at the offset provided.</doc>
           <type name="guint" c:type="unsigned int*"/>
         </parameter>
         <parameter name="first_param_id" direction="out" caller-allocates="0" transfer-ownership="full" nullable="1">
-          <doc xml:space="preserve">The first &#x2018;name&#x2019; table name ID used to specify
+          <doc xml:space="preserve">The first ‘name’ table name ID used to specify
                  strings for user-interface labels for the feature
                  parameters. (Must be zero if numParameters is zero.)</doc>
           <type name="ot_name_id_t" c:type="hb_ot_name_id_t*"/>
@@ -10758,7 +10758,7 @@ https://docs.microsoft.com/en-us/typography/opentype/spec/features_pt#tag-size).
           <type name="guint" c:type="unsigned int*"/>
         </parameter>
         <parameter name="subfamily_name_id" direction="out" caller-allocates="0" transfer-ownership="full">
-          <doc xml:space="preserve">The &#x2018;name&#x2019; table name ID of the face within the font subfamily</doc>
+          <doc xml:space="preserve">The ‘name’ table name ID of the face within the font subfamily</doc>
           <type name="ot_name_id_t" c:type="hb_ot_name_id_t*"/>
         </parameter>
         <parameter name="range_start" direction="out" caller-allocates="0" transfer-ownership="full">
@@ -11884,7 +11884,7 @@ See also #hb_ot_math_get_glyph_kerning, which handles selecting the
 appropriate kern value for a given correction height.
 
 &lt;note&gt;For a glyph with @n defined kern values (where @n &gt; 0), there are only
-@n&#x2212;1 defined correction heights, as each correction height defines a boundary
+@n−1 defined correction heights, as each correction height defines a boundary
 past which the next kern value should be selected. Therefore, only the
 #hb_ot_math_kern_entry_t.kern_value of the uppermost #hb_ot_math_kern_entry_t
 actually comes from the font; its corresponding
@@ -15239,7 +15239,7 @@ gradient tiling.  See hb_paint_sweep_gradient_tiles().</doc>
       </parameters>
     </callback>
     <function name="paint_sweep_gradient_tiles" c:identifier="hb_paint_sweep_gradient_tiles" version="14.2.0">
-      <doc xml:space="preserve">Iterates the full 0..2&#x3C0; sweep produced by a color-stop list,
+      <doc xml:space="preserve">Iterates the full 0..2π sweep produced by a color-stop list,
 invoking @emit_patch once per (start, end) angular segment.
 Handles #HB_PAINT_EXTEND_PAD, #HB_PAINT_EXTEND_REPEAT, and
 #HB_PAINT_EXTEND_REFLECT.  Stops must be pre-sorted by
@@ -15919,7 +15919,7 @@ See also the Script (sc) property of the Unicode Character Database.</doc>
       </member>
     </bitfield>
     <function name="script_to_iso15924_tag" c:identifier="hb_script_to_iso15924_tag" version="0.9.2">
-      <doc xml:space="preserve">Converts an #hb_script_t to a corresponding ISO&#xA0;15924 script tag.</doc>
+      <doc xml:space="preserve">Converts an #hb_script_t to a corresponding ISO 15924 script tag.</doc>
       <return-value transfer-ownership="none">
         <doc xml:space="preserve">An #hb_tag_t representing an ISO 15924 script tag.</doc>
         <type name="tag_t" c:type="hb_tag_t"/>
@@ -17005,7 +17005,7 @@ Typical right-leaning Italic fonts have a positive slant ratio (typically around
       <member name="b_style_tag_width" value="2003072104" c:identifier="HB_STYLE_TAG_WIDTH">
         <doc xml:space="preserve">Used to vary width of text from narrower to wider.
 Non-zero. Values can be interpreted as a percentage of whatever the font
-designer considers &#x201C;normal width&#x201D; for that font design.</doc>
+designer considers “normal width” for that font design.</doc>
       </member>
       <member name="b_style_tag_weight" value="2003265652" c:identifier="HB_STYLE_TAG_WEIGHT">
         <doc xml:space="preserve">Used to vary stroke thicknesses or other design details

--- a/Pango-1.0.gir
+++ b/Pango-1.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -4007,10 +4007,10 @@ The following words are understood as color values:
 "With-Color", "Without-Color".
 
 VARIATIONS is a comma-separated list of font variations
-of the form @&#x200D;axis1=value,axis2=value,...
+of the form @‍axis1=value,axis2=value,...
 
 FEATURES is a comma-separated list of font features of the form
-\#&#x200D;feature1=value,feature2=value,...
+\#‍feature1=value,feature2=value,...
 The =value part can be ommitted if the value is 1.
 
 Any one of the options may be absent. If FAMILY-LIST is absent, then
@@ -4021,7 +4021,7 @@ size in the resulting font description will be set to 0.
 
 A typical example:
 
-    Cantarell Italic Light 15 @&#x200D;wght=200 #&#x200D;tnum=1</doc>
+    Cantarell Italic Light 15 @‍wght=200 #‍tnum=1</doc>
         <return-value transfer-ownership="full">
           <doc xml:space="preserve">a new `PangoFontDescription`.</doc>
           <type name="FontDescription" c:type="PangoFontDescription*"/>
@@ -7567,7 +7567,7 @@ The following example shows text with both a strong and a weak cursor.
 
 The strong cursor has a little arrow pointing to the right, the weak
 cursor to the left. Typing a 'c' in this situation will insert the
-character after the 'b', and typing another Hebrew character, like '&#x5D2;',
+character after the 'b', and typing another Hebrew character, like 'ג',
 will insert it at the end.</doc>
         <return-value transfer-ownership="none">
           <type name="none" c:type="void"/>
@@ -9840,10 +9840,10 @@ Note that output numbers will always be non-negative.</doc>
 
 For a simple shear matrix in the form:
 
-    1 &#x3BB;
+    1 λ
     0 1
 
-this is simply &#x3BB;.</doc>
+this is simply λ.</doc>
         <return-value transfer-ownership="none">
           <doc xml:space="preserve">the slant ratio of @matrix</doc>
           <type name="gdouble" c:type="double"/>
@@ -13624,10 +13624,10 @@ The following words are understood as color values:
 "With-Color", "Without-Color".
 
 VARIATIONS is a comma-separated list of font variations
-of the form @&#x200D;axis1=value,axis2=value,...
+of the form @‍axis1=value,axis2=value,...
 
 FEATURES is a comma-separated list of font features of the form
-\#&#x200D;feature1=value,feature2=value,...
+\#‍feature1=value,feature2=value,...
 The =value part can be ommitted if the value is 1.
 
 Any one of the options may be absent. If FAMILY-LIST is absent, then
@@ -13638,7 +13638,7 @@ size in the resulting font description will be set to 0.
 
 A typical example:
 
-    Cantarell Italic Light 15 @&#x200D;wght=200 #&#x200D;tnum=1</doc>
+    Cantarell Italic Light 15 @‍wght=200 #‍tnum=1</doc>
       <return-value transfer-ownership="full">
         <doc xml:space="preserve">a new `PangoFontDescription`.</doc>
         <type name="FontDescription" c:type="PangoFontDescription*"/>

--- a/PangoCairo-1.0.gir
+++ b/PangoCairo-1.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->

--- a/PangoFT2-1.0.gir
+++ b/PangoFT2-1.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->

--- a/PangoFc-1.0.gir
+++ b/PangoFc-1.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->

--- a/PangoOT-1.0.gir
+++ b/PangoOT-1.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->
@@ -902,7 +902,7 @@ example, as a switch expression, as it dereferences pointers.</doc>
     <enumeration name="TableType" c:type="PangoOTTableType">
       <doc xml:space="preserve">The PangoOTTableType enumeration values are used to
 identify the various OpenType tables in the
-pango_ot_info_&#x2026; functions.</doc>
+pango_ot_info_… functions.</doc>
       <member name="gsub" value="0" c:identifier="PANGO_OT_TABLE_GSUB">
         <doc xml:space="preserve">The GSUB table.</doc>
       </member>

--- a/PangoXft-1.0.gir
+++ b/PangoXft-1.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- This file was automatically generated from C sources - DO NOT EDIT!
 To affect the contents of this file, edit the original C definitions,
 and/or use gtk-doc annotations.  -->

--- a/Vulkan-1.0.gir
+++ b/Vulkan-1.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" version="1.2">
   <namespace name="Vulkan" version="1.0" c:identifier-prefixes="VK" c:symbol-prefixes="vk">
     <record name="Bool32" c:type="VkBool32"/>

--- a/cairo-1.0.gir
+++ b/cairo-1.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0" version="1.2">
   <include name="GObject" version="2.0"/>
   <package name="cairo-gobject"/>

--- a/fix.sh
+++ b/fix.sh
@@ -2,85 +2,85 @@
 set -x -e
 
 # Remove Int32 alias because it misses c:type, it not like anyone actually cares about it.
-xmlstarlet ed -L \
-	-d '///_:alias[@name="Int32"]' \
+xmlstarlet edit --inplace \
+	--delete '///_:alias[@name="Int32"]' \
 	freetype2-2.0.gir
 
 # gir uses error domain to find quark function corresponding to given error enum,
 # but in this case it happens to be named differently, i.e., as g_option_error_quark.
-xmlstarlet ed -L \
-	-u '//*[@glib:error-domain="g-option-context-error-quark"]/@glib:error-domain' -v g-option-error-quark \
+xmlstarlet edit --inplace \
+	--update '//*[@glib:error-domain="g-option-context-error-quark"]/@glib:error-domain' -v g-option-error-quark \
 	GLib-2.0.gir
 
 # GtkEntry icon signals incorrect assume GdkEventButton when other variants may be passed
-xmlstarlet ed -L \
-	-u '//_:class[@name="Entry"]/glib:signal[@name="icon-press"]//_:parameter[@name="event"]/_:type[@name="Gdk.EventButton"]/@name' -v "Gdk.Event" \
-	-u '//_:class[@name="Entry"]/glib:signal[@name="icon-release"]//_:parameter[@name="event"]/_:type[@name="Gdk.EventButton"]/@name' -v "Gdk.Event" \
+xmlstarlet edit --inplace \
+	--update '//_:class[@name="Entry"]/glib:signal[@name="icon-press"]//_:parameter[@name="event"]/_:type[@name="Gdk.EventButton"]/@name' -v "Gdk.Event" \
+	--update '//_:class[@name="Entry"]/glib:signal[@name="icon-release"]//_:parameter[@name="event"]/_:type[@name="Gdk.EventButton"]/@name' -v "Gdk.Event" \
 	Gtk-3.0.gir
 
 # GtkIconSize usage
-xmlstarlet ed -L \
-	-u '//_:type[@c:type="GtkIconSize"]/@name' -v "IconSize" \
-	-u '//_:type[@c:type="GtkIconSize*"]/@name' -v "IconSize" \
+xmlstarlet edit --inplace \
+	--update '//_:type[@c:type="GtkIconSize"]/@name' -v "IconSize" \
+	--update '//_:type[@c:type="GtkIconSize*"]/@name' -v "IconSize" \
 	Gtk-3.0.gir
 
 # incorrect GIR due to gobject-introspection GitLab issue #189
-xmlstarlet ed -L \
-	-u '//_:class[@name="IconTheme"]/_:method//_:parameter[@name="icon_names"]/_:array/@c:type' -v "const gchar**" \
-	-u '//_:class[@name="IconTheme"]/_:method[@name="get_search_path"]//_:parameter[@name="path"]/_:array/@c:type' -v "gchar***" \
-	-u '//_:class[@name="IconTheme"]/_:method[@name="set_search_path"]//_:parameter[@name="path"]/_:array/@c:type' -v "const gchar**" \
+xmlstarlet edit --inplace \
+	--update '//_:class[@name="IconTheme"]/_:method//_:parameter[@name="icon_names"]/_:array/@c:type' -v "const gchar**" \
+	--update '//_:class[@name="IconTheme"]/_:method[@name="get_search_path"]//_:parameter[@name="path"]/_:array/@c:type' -v "gchar***" \
+	--update '//_:class[@name="IconTheme"]/_:method[@name="set_search_path"]//_:parameter[@name="path"]/_:array/@c:type' -v "const gchar**" \
 	Gtk-3.0.gir
 
 # incorrect GIR due to gobject-introspection GitLab issue #189
-xmlstarlet ed -L \
-	-u '//_:record[@name="KeyFile"]/_:method[@name="set_boolean_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "gboolean*" \
-	-u '//_:record[@name="KeyFile"]/_:method[@name="set_double_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "gdouble*" \
-	-u '//_:record[@name="KeyFile"]/_:method[@name="set_integer_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "gint*" \
-	-u '//_:record[@name="KeyFile"]/_:method[@name="set_locale_string_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "const gchar* const*" \
-	-u '//_:record[@name="KeyFile"]/_:method[@name="set_string_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "const gchar* const*" \
+xmlstarlet edit --inplace \
+	--update '//_:record[@name="KeyFile"]/_:method[@name="set_boolean_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "gboolean*" \
+	--update '//_:record[@name="KeyFile"]/_:method[@name="set_double_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "gdouble*" \
+	--update '//_:record[@name="KeyFile"]/_:method[@name="set_integer_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "gint*" \
+	--update '//_:record[@name="KeyFile"]/_:method[@name="set_locale_string_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "const gchar* const*" \
+	--update '//_:record[@name="KeyFile"]/_:method[@name="set_string_list"]//_:parameter[@name="list"]/_:array/@c:type' -v "const gchar* const*" \
 	GLib-2.0.gir
 
 # incorrect GIR due to gobject-introspection GitLab issue #189
-xmlstarlet ed -L \
-	-u '//_:class[@name="Object"]/_:method[@name="getv"]//_:parameter[@name="names"]/_:array/@c:type' -v "const gchar**" \
-	-u '//_:class[@name="Object"]/_:method[@name="getv"]//_:parameter[@name="values"]/_:array/@c:type' -v "GValue*" \
-	-u '//_:class[@name="Object"]/_:method[@name="setv"]//_:parameter[@name="names"]/_:array/@c:type' -v "const gchar**" \
-	-u '//_:class[@name="Object"]/_:method[@name="setv"]//_:parameter[@name="values"]/_:array/@c:type' -v "const GValue*" \
-	-u '//_:class[@name="Object"]/_:constructor[@name="new_with_properties"]//_:parameter[@name="names"]/_:array/@c:type' -v "const char**" \
-	-u '//_:class[@name="Object"]/_:constructor[@name="new_with_properties"]//_:parameter[@name="values"]/_:array/@c:type' -v "const GValue*" \
+xmlstarlet edit --inplace \
+	--update '//_:class[@name="Object"]/_:method[@name="getv"]//_:parameter[@name="names"]/_:array/@c:type' -v "const gchar**" \
+	--update '//_:class[@name="Object"]/_:method[@name="getv"]//_:parameter[@name="values"]/_:array/@c:type' -v "GValue*" \
+	--update '//_:class[@name="Object"]/_:method[@name="setv"]//_:parameter[@name="names"]/_:array/@c:type' -v "const gchar**" \
+	--update '//_:class[@name="Object"]/_:method[@name="setv"]//_:parameter[@name="values"]/_:array/@c:type' -v "const GValue*" \
+	--update '//_:class[@name="Object"]/_:constructor[@name="new_with_properties"]//_:parameter[@name="names"]/_:array/@c:type' -v "const char**" \
+	--update '//_:class[@name="Object"]/_:constructor[@name="new_with_properties"]//_:parameter[@name="values"]/_:array/@c:type' -v "const GValue*" \
 	GObject-2.0.gir
 
 # add missing attributes to resolve type struct for TypePlugin
-xmlstarlet ed -L \
-	-i '//_:interface[@name="TypePlugin" and not(@glib:type-struct)]' -t 'attr' -n 'glib:type-struct' -v 'TypePluginClass' \
-	-i '//_:record[@name="TypePluginClass" and not(@glib:is-gtype-struct-for)]' -t 'attr' -n 'glib:is-gtype-struct-for' -v 'TypePlugin' \
+xmlstarlet edit --inplace \
+	--insert '//_:interface[@name="TypePlugin" and not(@glib:type-struct)]' -t 'attr' -n 'glib:type-struct' -v 'TypePluginClass' \
+	--insert '//_:record[@name="TypePluginClass" and not(@glib:is-gtype-struct-for)]' -t 'attr' -n 'glib:is-gtype-struct-for' -v 'TypePlugin' \
 	GObject-2.0.gir
 
 # fix wrong "full" transfer ownership
-xmlstarlet ed -L \
-	-u '//_:method[@c:identifier="gdk_frame_clock_get_current_timings"]/_:return-value/@transfer-ownership' -v "none" \
-	-u '//_:method[@c:identifier="gdk_frame_clock_get_timings"]/_:return-value/@transfer-ownership' -v "none" \
+xmlstarlet edit --inplace \
+	--update '//_:method[@c:identifier="gdk_frame_clock_get_current_timings"]/_:return-value/@transfer-ownership' -v "none" \
+	--update '//_:method[@c:identifier="gdk_frame_clock_get_timings"]/_:return-value/@transfer-ownership' -v "none" \
 	Gdk-3.0.gir
 
 # replace gmodule with gpointer
-xmlstarlet ed -L \
-	-u '//_:record[@name="PixbufModule"]/_:field[@name="module"]/_:type/@name' -v "gpointer" \
-	-u '//_:record[@name="PixbufModule"]/_:field[@name="module"]/_:type/@c:type' -v "gpointer" \
+xmlstarlet edit --inplace \
+	--update '//_:record[@name="PixbufModule"]/_:field[@name="module"]/_:type/@name' -v "gpointer" \
+	--update '//_:record[@name="PixbufModule"]/_:field[@name="module"]/_:type/@c:type' -v "gpointer" \
 	GdkPixbuf-2.0.gir
 
 # replace "gint" response_id parameters with "ResponseType"
-xmlstarlet ed -L \
-	-u '//_:parameter[@name="response_id"]/_:type[@name="gint"]/@c:type' -v "GtkResponseType" \
-	-u '//_:parameter[@name="response_id"]/_:type[@name="gint"]/@name' -v "ResponseType" \
+xmlstarlet edit --inplace \
+	--update '//_:parameter[@name="response_id"]/_:type[@name="gint"]/@c:type' -v "GtkResponseType" \
+	--update '//_:parameter[@name="response_id"]/_:type[@name="gint"]/@name' -v "ResponseType" \
 	Gtk-3.0.gir Gtk-4.0.gir
 
 # fix wrong "full" transfer ownership
-xmlstarlet ed -L \
-	-u '//_:constructor[@c:identifier="gtk_shortcut_label_new"]/_:return-value/@transfer-ownership' -v "none" \
+xmlstarlet edit --inplace \
+	--update '//_:constructor[@c:identifier="gtk_shortcut_label_new"]/_:return-value/@transfer-ownership' -v "none" \
 	Gtk-3.0.gir
 
 # add out annotation for functions returning GValue
-xmlstarlet ed -L \
+xmlstarlet edit --inplace \
 	-a '//_:method[@c:identifier="gtk_style_context_get_style_property"]//_:parameter[@name="value" and not(@direction)]' -type attr -n "direction" -v "out" \
 	-a '//_:method[@c:identifier="gtk_style_context_get_style_property"]//_:parameter[@name="value" and not(@caller-allocates)]' -type attr -n "caller-allocates" -v "1" \
 	-a '//_:method[@c:identifier="gtk_cell_area_cell_get_property"]//_:parameter[@name="value" and not(@direction)]' -type attr -n "direction" -v "out" \
@@ -92,110 +92,110 @@ xmlstarlet ed -L \
 	Gtk-3.0.gir
 
 # remove freetype and graphite methods; GitHub issue #2557
-xmlstarlet ed -L \
-	-d '///_:function[@c:identifier="hb_graphite2_face_get_gr_face"]' \
-	-d '///_:function[@c:identifier="hb_graphite2_font_get_gr_font"]' \
-	-d '///_:function[@c:identifier="hb_ft_face_create"]' \
-	-d '///_:function[@c:identifier="hb_ft_face_create_cached"]' \
-	-d '///_:function[@c:identifier="hb_ft_face_create_referenced"]' \
-	-d '///_:function[@c:identifier="hb_ft_font_create"]' \
-	-d '///_:function[@c:identifier="hb_ft_font_create_cached"]' \
-	-d '///_:function[@c:identifier="hb_ft_font_create_referenced"]' \
-	-d '///_:function[@c:identifier="hb_ft_font_get_face"]' \
-	-d '///_:function[@c:identifier="hb_ft_font_lock_face"]' \
+xmlstarlet edit --inplace \
+	--delete '///_:function[@c:identifier="hb_graphite2_face_get_gr_face"]' \
+	--delete '///_:function[@c:identifier="hb_graphite2_font_get_gr_font"]' \
+	--delete '///_:function[@c:identifier="hb_ft_face_create"]' \
+	--delete '///_:function[@c:identifier="hb_ft_face_create_cached"]' \
+	--delete '///_:function[@c:identifier="hb_ft_face_create_referenced"]' \
+	--delete '///_:function[@c:identifier="hb_ft_font_create"]' \
+	--delete '///_:function[@c:identifier="hb_ft_font_create_cached"]' \
+	--delete '///_:function[@c:identifier="hb_ft_font_create_referenced"]' \
+	--delete '///_:function[@c:identifier="hb_ft_font_get_face"]' \
+	--delete '///_:function[@c:identifier="hb_ft_font_lock_face"]' \
 	HarfBuzz-0.0.gir
 
 # fix harfbuzz types on Pango
-xmlstarlet ed -L \
-	-i '///_:type[not(@name) and @c:type="hb_font_t*"]' -t 'attr' -n 'name' -v "gconstpointer" \
-	-u '//_:type[@c:type="hb_font_t*"]/@c:type' -v "gconstpointer" \
-	-i '///_:array[not(@name) and @c:type="hb_feature_t*"]' -t 'attr' -n 'name' -v "gconstpointer" \
+xmlstarlet edit --inplace \
+	--insert '///_:type[not(@name) and @c:type="hb_font_t*"]' -t 'attr' -n 'name' -v "gconstpointer" \
+	--update '//_:type[@c:type="hb_font_t*"]/@c:type' -v "gconstpointer" \
+	--insert '///_:array[not(@name) and @c:type="hb_feature_t*"]' -t 'attr' -n 'name' -v "gconstpointer" \
 	-r '///_:array[@c:type="hb_feature_t*"]' -v "type" \
-	-d '//_:type[@c:type="hb_feature_t*"]/*' \
-	-d '//_:type[@c:type="hb_feature_t*"]/@length' \
-	-d '//_:type[@c:type="hb_feature_t*"]/@zero-terminated' \
-	-u '//_:type[@c:type="hb_feature_t*"]/@c:type' -v "gconstpointer" \
+	--delete '//_:type[@c:type="hb_feature_t*"]/*' \
+	--delete '//_:type[@c:type="hb_feature_t*"]/@length' \
+	--delete '//_:type[@c:type="hb_feature_t*"]/@zero-terminated' \
+	--update '//_:type[@c:type="hb_feature_t*"]/@c:type' -v "gconstpointer" \
 	Pango-1.0.gir
 
 # Fix unsupported bitfield (https://github.com/gtk-rs/gir/issues/465) on pango
-xmlstarlet ed -L \
-	-d '//_:record[@c:type="PangoGlyphVisAttr"]/_:field/@bits' \
-	-d '//_:record[@c:type="PangoGlyphVisAttr"]/_:field[@name="is_color"]' \
+xmlstarlet edit --inplace \
+	--delete '//_:record[@c:type="PangoGlyphVisAttr"]/_:field/@bits' \
+	--delete '//_:record[@c:type="PangoGlyphVisAttr"]/_:field[@name="is_color"]' \
 	Pango-1.0.gir
 
 #  Remove unstable method from focal release
-xmlstarlet ed -L \
-	-d '///_:method[@c:identifier="atk_plug_set_child"]' \
+xmlstarlet edit --inplace \
+	--delete '///_:method[@c:identifier="atk_plug_set_child"]' \
 	Atk-1.0.gir
 
 # fix non-existant c-types
-xmlstarlet ed -L \
-	-u '//_:class[@name="WaylandDevice"]/_:method[@name="get_wl_keyboard"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
-	-u '//_:class[@name="WaylandDevice"]/_:method[@name="get_wl_pointer"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
-	-u '//_:class[@name="WaylandDevice"]/_:method[@name="get_wl_seat"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
-	-u '//_:class[@name="WaylandDisplay"]/_:method[@name="get_wl_compositor"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
-	-u '//_:class[@name="WaylandDisplay"]/_:method[@name="get_wl_display"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
-	-u '//_:class[@name="WaylandMonitor"]/_:method[@name="get_wl_output"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
-	-u '//_:class[@name="WaylandSeat"]/_:method[@name="get_wl_seat"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
-	-u '//_:class[@name="WaylandSurface"]/_:method[@name="get_wl_surface"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
-	-u '//_:class[@name="WaylandDevice"]/_:method[@name="get_xkb_keymap"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
-	-u '//_:class[@name="WaylandDevice"]/_:method[@name="get_xkb_keymap"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
- 	-u '//_:class[@name="WaylandToplevel"]/_:method[@name="get_xdg_toplevel"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
+xmlstarlet edit --inplace \
+	--update '//_:class[@name="WaylandDevice"]/_:method[@name="get_wl_keyboard"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
+	--update '//_:class[@name="WaylandDevice"]/_:method[@name="get_wl_pointer"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
+	--update '//_:class[@name="WaylandDevice"]/_:method[@name="get_wl_seat"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
+	--update '//_:class[@name="WaylandDisplay"]/_:method[@name="get_wl_compositor"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
+	--update '//_:class[@name="WaylandDisplay"]/_:method[@name="get_wl_display"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
+	--update '//_:class[@name="WaylandMonitor"]/_:method[@name="get_wl_output"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
+	--update '//_:class[@name="WaylandSeat"]/_:method[@name="get_wl_seat"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
+	--update '//_:class[@name="WaylandSurface"]/_:method[@name="get_wl_surface"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
+	--update '//_:class[@name="WaylandDevice"]/_:method[@name="get_xkb_keymap"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
+	--update '//_:class[@name="WaylandDevice"]/_:method[@name="get_xkb_keymap"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
+ 	--update '//_:class[@name="WaylandToplevel"]/_:method[@name="get_xdg_toplevel"]//_:type[@name="gpointer"]/@c:type' -v "gpointer" \
 	GdkWayland-4.0.gir
 
 # avoid always depending on x11 crate
-xmlstarlet ed -L \
-	-u '//_:class[@name="X11Display"]/_:method[@name="get_xcursor"]//_:type[@name="xlib.Cursor"]/@c:type' -v "gulong" \
-	-u '//_:class[@name="X11Display"]/_:method[@name="get_xdisplay"]//_:type[@name="xlib.Display"]/@c:type' -v "gpointer" \
-	-u '//_:class[@name="X11Display"]/_:method[@name="get_xrootwindow"]//_:type[@name="xlib.Window"]/@c:type' -v "gulong" \
-	-u '//_:class[@name="X11Display"]/_:method[@name="get_xscreen"]//_:type[@name="xlib.Screen"]/@c:type' -v "gpointer" \
-	-u '//_:class[@name="X11Monitor"]/_:method[@name="get_output"]//_:type[@name="xlib.XID"]/@c:type' -v "gulong" \
-	-u '//_:class[@name="X11Screen"]/_:method[@name="get_monitor_output"]//_:type[@name="xlib.XID"]/@c:type' -v "gulong" \
-	-u '//_:class[@name="X11Screen"]/_:method[@name="get_xscreen"]//_:type[@name="xlib.Screen"]/@c:type' -v "gpointer" \
-	-u '//_:class[@name="X11Surface"]/_:method[@name="get_xid"]//_:type[@name="xlib.Window"]/@c:type' -v "gulong" \
-	-u '//_:class[@name="X11Surface"]/_:function[@name="lookup_for_display"]//_:type[@name="xlib.Window"]/@c:type' -v "gulong" \
-	-u '//_:class[@name="get_xid"]/_:method[@name="lookup_for_display"]//_:type[@name="xlib.Window"]/@c:type' -v "gulong" \
-	-u '//_:function[@name="x11_get_xatom_by_name_for_display"]//_:type[@name="xlib.Atom"]/@c:type' -v "gulong" \
-	-u '//_:function[@name="x11_get_xatom_name_for_display"]//_:type[@name="xlib.Atom"]/@c:type' -v "gulong" \
-	-u '//_:function[@name="x11_lookup_xdisplay"]//_:type[@name="xlib.Display"]/@c:type' -v "gpointer" \
+xmlstarlet edit --inplace \
+	--update '//_:class[@name="X11Display"]/_:method[@name="get_xcursor"]//_:type[@name="xlib.Cursor"]/@c:type' -v "gulong" \
+	--update '//_:class[@name="X11Display"]/_:method[@name="get_xdisplay"]//_:type[@name="xlib.Display"]/@c:type' -v "gpointer" \
+	--update '//_:class[@name="X11Display"]/_:method[@name="get_xrootwindow"]//_:type[@name="xlib.Window"]/@c:type' -v "gulong" \
+	--update '//_:class[@name="X11Display"]/_:method[@name="get_xscreen"]//_:type[@name="xlib.Screen"]/@c:type' -v "gpointer" \
+	--update '//_:class[@name="X11Monitor"]/_:method[@name="get_output"]//_:type[@name="xlib.XID"]/@c:type' -v "gulong" \
+	--update '//_:class[@name="X11Screen"]/_:method[@name="get_monitor_output"]//_:type[@name="xlib.XID"]/@c:type' -v "gulong" \
+	--update '//_:class[@name="X11Screen"]/_:method[@name="get_xscreen"]//_:type[@name="xlib.Screen"]/@c:type' -v "gpointer" \
+	--update '//_:class[@name="X11Surface"]/_:method[@name="get_xid"]//_:type[@name="xlib.Window"]/@c:type' -v "gulong" \
+	--update '//_:class[@name="X11Surface"]/_:function[@name="lookup_for_display"]//_:type[@name="xlib.Window"]/@c:type' -v "gulong" \
+	--update '//_:class[@name="get_xid"]/_:method[@name="lookup_for_display"]//_:type[@name="xlib.Window"]/@c:type' -v "gulong" \
+	--update '//_:function[@name="x11_get_xatom_by_name_for_display"]//_:type[@name="xlib.Atom"]/@c:type' -v "gulong" \
+	--update '//_:function[@name="x11_get_xatom_name_for_display"]//_:type[@name="xlib.Atom"]/@c:type' -v "gulong" \
+	--update '//_:function[@name="x11_lookup_xdisplay"]//_:type[@name="xlib.Display"]/@c:type' -v "gpointer" \
 	GdkX11-4.0.gir
 
-xmlstarlet ed -L \
-	-u '//_:callback[@name="Win32MessageFilterFunc"]//_:type[@name="win32.MSG"]/@c:type' -v "gpointer" \
-	-u '//_:class[@name="Win32HCursor"]//_:type[@name="win32.HCURSOR"]/@c:type' -v "gssize" \
-	-u '//_:class[@name="Win32Surface"]//_:type[@name="win32.HGDIOBJ"]/@c:type' -v "gssize" \
-	-u '//_:class[@name="Win32Surface"]//_:type[@name="win32.HWND"]/@c:type' -v "gssize" \
+xmlstarlet edit --inplace \
+	--update '//_:callback[@name="Win32MessageFilterFunc"]//_:type[@name="win32.MSG"]/@c:type' -v "gpointer" \
+	--update '//_:class[@name="Win32HCursor"]//_:type[@name="win32.HCURSOR"]/@c:type' -v "gssize" \
+	--update '//_:class[@name="Win32Surface"]//_:type[@name="win32.HGDIOBJ"]/@c:type' -v "gssize" \
+	--update '//_:class[@name="Win32Surface"]//_:type[@name="win32.HWND"]/@c:type' -v "gssize" \
     -u '//_:function[@name="win32_handle_table_lookup"]//_:type[@name="win32.HWND"]/@c:type' -v 'gssize' \
     -u '//_:function[@name="win32_set_modal_dialog_libgtk_only"]//_:type[@name="win32.HWND"]/@c:type' -v 'gssize' \
     -u '//_:function[@name="win32_icon_to_pixbuf_libgtk_only"]//_:type[@name="win32.HICON"]/@c:type' -v 'gssize' \
     -u '//_:function[@name="win32_pixbuf_to_hicon_libgtk_only"]//_:type[@name="win32.HICON"]/@c:type' -v 'gssize' \
-	-i '//_:type[@c:type="ID3D12Fence*" and not(@name)]' -t 'attr' -n 'name' -v "gpointer" \
-	-u '//_:type[@c:type="ID3D12Fence*"]/@c:type' -v "gpointer" \
-	-i '//_:type[@c:type="ID3D12Resource*" and not(@name)]' -t 'attr' -n 'name' -v "gpointer" \
-	-u '//_:type[@c:type="ID3D12Resource*"]/@c:type' -v "gpointer" \
+	--insert '//_:type[@c:type="ID3D12Fence*" and not(@name)]' -t 'attr' -n 'name' -v "gpointer" \
+	--update '//_:type[@c:type="ID3D12Fence*"]/@c:type' -v "gpointer" \
+	--insert '//_:type[@c:type="ID3D12Resource*" and not(@name)]' -t 'attr' -n 'name' -v "gpointer" \
+	--update '//_:type[@c:type="ID3D12Resource*"]/@c:type' -v "gpointer" \
 	GdkWin32-4.0.gir
 
 # Fix invalid type for GtkImage and GtkStackSwitcher "icon-size" property
-xmlstarlet ed -L \
-	-u '//_:class[@name="Image"]/_:property[@name="icon-size"]/_:type/@c:type' -v "GtkIconSize" \
-	-u '//_:class[@name="Image"]/_:property[@name="icon-size"]/_:type/@name' -v "IconSize" \
-	-u '//_:class[@name="StackSwitcher"]/_:property[@name="icon-size"]/_:type/@c:type' -v "GtkIconSize" \
-	-u '//_:class[@name="StackSwitcher"]/_:property[@name="icon-size"]/_:type/@name' -v "IconSize" \
+xmlstarlet edit --inplace \
+	--update '//_:class[@name="Image"]/_:property[@name="icon-size"]/_:type/@c:type' -v "GtkIconSize" \
+	--update '//_:class[@name="Image"]/_:property[@name="icon-size"]/_:type/@name' -v "IconSize" \
+	--update '//_:class[@name="StackSwitcher"]/_:property[@name="icon-size"]/_:type/@c:type' -v "GtkIconSize" \
+	--update '//_:class[@name="StackSwitcher"]/_:property[@name="icon-size"]/_:type/@name' -v "IconSize" \
 	Gtk-3.0.gir
 
 # Fix GLibUnix type names to use GLibUnix prefix instead of GLib
-xmlstarlet ed -L \
-	-u '//_:type[@name="GLib.UnixPipe"]/@name' -v "GLibUnix.Pipe" \
-	-u '//_:type[@name="GLib.UnixPipeEnd"]/@name' -v "GLibUnix.PipeEnd" \
+xmlstarlet edit --inplace \
+	--update '//_:type[@name="GLib.UnixPipe"]/@name' -v "GLibUnix.Pipe" \
+	--update '//_:type[@name="GLib.UnixPipeEnd"]/@name' -v "GLibUnix.PipeEnd" \
 	GLibUnix-2.0.gir
 
 # Fix GLibWin32 type name to remove GLib prefix
-xmlstarlet ed -L \
-	-u '//_:type[@name="GLib.Win32OSType"]/@name' -v "OSType" \
+xmlstarlet edit --inplace \
+	--update '//_:type[@name="GLib.Win32OSType"]/@name' -v "OSType" \
 	GLibWin32-2.0.gir
 
 # Fix GioWin32 NetworkMonitor types to use gpointer
-xmlstarlet ed -L \
-	-i '//_:record[@name="NetworkMonitor"]/_:field[@name="parent_instance"]/_:type[@c:type="GNetworkMonitorBase" and not(@name)]' -t 'attr' -n 'name' -v "gpointer" \
-	-i '//_:record[@name="NetworkMonitorClass"]/_:field[@name="parent_class"]/_:type[@c:type="GNetworkMonitorBaseClass" and not(@name)]' -t 'attr' -n 'name' -v "gpointer" \
+xmlstarlet edit --inplace \
+	--insert '//_:record[@name="NetworkMonitor"]/_:field[@name="parent_instance"]/_:type[@c:type="GNetworkMonitorBase" and not(@name)]' -t 'attr' -n 'name' -v "gpointer" \
+	--insert '//_:record[@name="NetworkMonitorClass"]/_:field[@name="parent_class"]/_:type[@c:type="GNetworkMonitorBaseClass" and not(@name)]' -t 'attr' -n 'name' -v "gpointer" \
 	GioWin32-2.0.gir

--- a/fontconfig-2.0.gir
+++ b/fontconfig-2.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" version="1.2">
   <namespace name="fontconfig" version="2.0" c:identifier-prefixes="Fc" c:symbol-prefixes="fc">
     <record name="Pattern" c:type="FcPattern"/>

--- a/freetype2-2.0.gir
+++ b/freetype2-2.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" version="1.2">
   <namespace name="freetype2" version="2.0" c:identifier-prefixes="FT" c:symbol-prefixes="FT">
     <record name="Bitmap" c:type="FT_Bitmap"/>

--- a/libxml2-2.0.gir
+++ b/libxml2-2.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" version="1.2">
   <package name="libxml-2.0"/>
   <namespace name="libxml2" version="2.0" c:identifier-prefixes="xml" c:symbol-prefixes="xml">

--- a/reformat.sh
+++ b/reformat.sh
@@ -3,9 +3,9 @@ set -x -e
 
 # `///` used as `//` not works in Windows in this case
 for file in *.gir; do
-	xmlstarlet ed -L \
-		-d '//_:doc/@line' \
-		-d '//_:doc/@filename' \
-		-d '///_:source-position' \
+	xmlstarlet edit --inplace \
+		--delete '//_:doc/@line' \
+		--delete '//_:doc/@filename' \
+		--delete '///_:source-position' \
 		"$file"
 done

--- a/reformat.sh
+++ b/reformat.sh
@@ -3,9 +3,13 @@ set -x -e
 
 # `///` used as `//` not works in Windows in this case
 for file in *.gir; do
-	xmlstarlet edit --inplace \
+    # TODO Revert once all files have been regenerated with
+    # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/558.
+	xmlstarlet format --encode utf-8 "$file" \
+	| xmlstarlet edit \
 		--delete '//_:doc/@line' \
 		--delete '//_:doc/@filename' \
 		--delete '///_:source-position' \
-		"$file"
+		> "$file".tmp
+	/usr/bin/mv "$file".tmp "$file"
 done

--- a/win32-1.0.gir
+++ b/win32-1.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" version="1.2">
   <namespace name="win32" version="1.0" c:identifier-prefixes="" c:symbol-prefixes="Win32">
     <alias name="HWND" c:type="HWND">

--- a/xfixes-4.0.gir
+++ b/xfixes-4.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" version="1.2">
   <namespace name="xfixes" version="4.0" c:identifier-prefixes="X" c:symbol-prefixes="X">
     <record name="XserverRegion" c:type="XserverRegion"/>

--- a/xft-2.0.gir
+++ b/xft-2.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" version="1.2">
   <include name="xlib" version="2.0"/>
   <namespace name="xft" version="2.0" c:identifier-prefixes="Xft" c:symbol-prefixes="Xft">

--- a/xlib-2.0.gir
+++ b/xlib-2.0.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" version="1.2">
   <namespace name="xlib" version="2.0" c:identifier-prefixes="" c:symbol-prefixes="X">
     <alias name="Atom" c:type="Atom">

--- a/xrandr-1.3.gir
+++ b/xrandr-1.3.gir
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <repository xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" version="1.2">
   <namespace name="xrandr" version="1.3" c:identifier-prefixes="XRR" c:symbol-prefixes="XRR">
     <record name="ScreenSize" c:type="XRRScreenSize"/>


### PR DESCRIPTION
I noticed that the files originally come with utf-8 contents but xmlstarlet is mangling unicode symbols when the xml declaration does not contain `encoding=utf-8`. This is addressed at [gobject-introspection!558](https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/558) but it might take some time before all introspection files are regenerated.

Calling the `xmlstarlet format --encode` on a gir file (a freshly generated one) should only add the `encoding` attribute to the xml declaration.

This might be due to something else, but I also noticed that in the few cases where the unicode was mangled that I checked our docs were missing the respective paragraphs, e.g. compare [GTK docs](https://docs.gtk.org/gtk4/method.AboutDialog.set_translator_credits.html) with [gtk4-rs'](https://gtk-rs.org/gtk4-rs/git/docs/gtk4/struct.AboutDialog.html#method.set_translator_credits).